### PR TITLE
Configurable signatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ $ npm install -g @mux/cli
 $ mux COMMAND
 running command...
 $ mux (-v|--version|version)
-@mux/cli/0.3.2 darwin-x64 node-v10.15.3
+@mux/cli/0.4.0 linux-x64 node-v10.20.1
 $ mux --help [COMMAND]
 USAGE
   $ mux COMMAND
@@ -53,7 +53,7 @@ OPTIONS
   -p, --private  add a private playback policy to the created asset
 ```
 
-_See code: [src/commands/assets/create.ts](https://github.com/muxinc/cli/blob/v0.3.2/src/commands/assets/create.ts)_
+_See code: [src/commands/assets/create.ts](https://github.com/muxinc/cli/blob/v0.4.0/src/commands/assets/create.ts)_
 
 ## `mux assets:upload PATH`
 
@@ -72,7 +72,7 @@ OPTIONS
   -p, --private                add a private playback policy to the created asset
 ```
 
-_See code: [src/commands/assets/upload.ts](https://github.com/muxinc/cli/blob/v0.3.2/src/commands/assets/upload.ts)_
+_See code: [src/commands/assets/upload.ts](https://github.com/muxinc/cli/blob/v0.4.0/src/commands/assets/upload.ts)_
 
 ## `mux help [COMMAND]`
 
@@ -103,7 +103,7 @@ ARGUMENTS
   ENVFILE  path to a Mux access token .env file
 ```
 
-_See code: [src/commands/init.ts](https://github.com/muxinc/cli/blob/v0.3.2/src/commands/init.ts)_
+_See code: [src/commands/init.ts](https://github.com/muxinc/cli/blob/v0.4.0/src/commands/init.ts)_
 
 ## `mux sign PLAYBACK-ID`
 
@@ -117,5 +117,5 @@ ARGUMENTS
   PLAYBACK-ID  Playback ID to create a signed URL token for.
 ```
 
-_See code: [src/commands/sign.ts](https://github.com/muxinc/cli/blob/v0.3.2/src/commands/sign.ts)_
+_See code: [src/commands/sign.ts](https://github.com/muxinc/cli/blob/v0.4.0/src/commands/sign.ts)_
 <!-- commandsstop -->

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mux/cli",
   "description": "Your friendly neighborhood Mux CLI tool!",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "author": "Matthew McClure @mmcc",
   "bin": {
     "mux": "./bin/run"

--- a/src/commands/sign.ts
+++ b/src/commands/sign.ts
@@ -21,13 +21,19 @@ export default class Sign extends MuxBase {
       description: 'How long the signature is valid for. If no unit is specified, milliseconds is assumed.',
       default: '7d',
     }),
+    type: flags.string({
+      char: 't',
+      description: 'What type of token this signature is for.',
+      default: 'video',
+      options: ['video', 'thumbnail', 'gif'],
+    })
   };
 
   async run() {
     const { args, flags } = this.parse(Sign);
     const playbackId = args['playback-id'];
 
-    const options = { expiration: flags.expiresIn }
+    const options = { expiration: flags.expiresIn, type: flags.type }
     const key = this.JWT.sign(playbackId, options);
     const url = `https://stream.mux.com/${playbackId}.m3u8?token=${key}`;
 

--- a/src/commands/sign.ts
+++ b/src/commands/sign.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk';
 import * as clipboard from 'clipboardy';
+import { flags } from '@oclif/command';
 
 import MuxBase from '../base';
 
@@ -14,11 +15,20 @@ export default class Sign extends MuxBase {
     },
   ];
 
+  static flags = {
+    expiresIn: flags.string({
+      char: 'e',
+      description: 'How long the signature is valid for. If no unit is specified, milliseconds is assumed.',
+      default: '7d',
+    }),
+  };
+
   async run() {
-    const { args } = this.parse(Sign);
+    const { args, flags } = this.parse(Sign);
     const playbackId = args['playback-id'];
 
-    const key = this.JWT.sign(playbackId);
+    const options = { expiration: flags.expiresIn }
+    const key = this.JWT.sign(playbackId, options);
     const url = `https://stream.mux.com/${playbackId}.m3u8?token=${key}`;
 
     this.log(


### PR DESCRIPTION
We were only putting in defaults before when creating signatures. This change allows developers to specify the type of a signature and the expiration.