### PR TITLE
feat: read MUX_BASE_URL from env-file and persist to config

### DIFF
--- a/src/commands/login.test.ts
+++ b/src/commands/login.test.ts
@@ -111,6 +111,22 @@ MUX_TOKEN_SECRET = test_secret_456`,
     expect(result.MUX_TOKEN_SECRET).toBe('test_secret_456');
   });
 
+  it('should parse MUX_BASE_URL', async () => {
+    const envPath = join(testDir, '.env');
+    await Bun.write(
+      envPath,
+      `MUX_TOKEN_ID=test_id_123
+MUX_TOKEN_SECRET=test_secret_456
+MUX_BASE_URL=https://api.staging.mux.com`,
+    );
+
+    const result = await parseEnvFile(envPath);
+
+    expect(result.MUX_TOKEN_ID).toBe('test_id_123');
+    expect(result.MUX_TOKEN_SECRET).toBe('test_secret_456');
+    expect(result.MUX_BASE_URL).toBe('https://api.staging.mux.com');
+  });
+
   it('should ignore other environment variables', async () => {
     const envPath = join(testDir, '.env');
     await Bun.write(

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -4,7 +4,7 @@ import { Command } from '@cliffy/command';
 import { listEnvironments, setEnvironment } from '../lib/config.ts';
 import {
   DEFAULT_BASE_URL,
-  getMuxUrl,
+  getMuxBaseUrl,
   validateCredentials,
 } from '../lib/mux.ts';
 import { inputPrompt, secretPrompt } from '../lib/prompt.ts';
@@ -104,7 +104,7 @@ export const loginCommand = new Command()
 
       tokenId = envVars.MUX_TOKEN_ID;
       tokenSecret = envVars.MUX_TOKEN_SECRET;
-      baseUrl = getMuxUrl({
+      baseUrl = getMuxBaseUrl({
         environment: { baseUrl: envVars.MUX_BASE_URL },
       });
     } else {
@@ -124,7 +124,7 @@ export const loginCommand = new Command()
         throw new Error('Token Secret is required');
       }
 
-      baseUrl = getMuxUrl(null);
+      baseUrl = getMuxBaseUrl(null);
     }
 
     console.log('Validating credentials...');

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -4,7 +4,7 @@ import { Command } from '@cliffy/command';
 import { listEnvironments, setEnvironment } from '../lib/config.ts';
 import {
   DEFAULT_BASE_URL,
-  resolveBaseUrl,
+  getMuxUrl,
   validateCredentials,
 } from '../lib/mux.ts';
 import { inputPrompt, secretPrompt } from '../lib/prompt.ts';
@@ -104,7 +104,7 @@ export const loginCommand = new Command()
 
       tokenId = envVars.MUX_TOKEN_ID;
       tokenSecret = envVars.MUX_TOKEN_SECRET;
-      baseUrl = resolveBaseUrl({
+      baseUrl = getMuxUrl({
         environment: { baseUrl: envVars.MUX_BASE_URL },
       });
     } else {
@@ -124,7 +124,7 @@ export const loginCommand = new Command()
         throw new Error('Token Secret is required');
       }
 
-      baseUrl = resolveBaseUrl(null);
+      baseUrl = getMuxUrl(null);
     }
 
     console.log('Validating credentials...');

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -83,6 +83,8 @@ export const loginCommand = new Command()
       );
     }
 
+    // Resolve base URL: env-file > MUX_BASE_URL env var > default
+    // Only persist to config if nonstandard
     let baseUrl: string | undefined;
 
     if (options.envFile) {
@@ -100,10 +102,7 @@ export const loginCommand = new Command()
 
       tokenId = envVars.MUX_TOKEN_ID;
       tokenSecret = envVars.MUX_TOKEN_SECRET;
-
-      if (envVars.MUX_BASE_URL && envVars.MUX_BASE_URL !== DEFAULT_BASE_URL) {
-        baseUrl = envVars.MUX_BASE_URL;
-      }
+      baseUrl = envVars.MUX_BASE_URL || process.env.MUX_BASE_URL;
     } else {
       // Interactive prompts
       console.log('Enter your Mux API credentials.');
@@ -120,14 +119,17 @@ export const loginCommand = new Command()
       if (!tokenSecret.trim()) {
         throw new Error('Token Secret is required');
       }
+
+      baseUrl = process.env.MUX_BASE_URL;
     }
 
-    // Validate credentials
+    // Validate credentials against the resolved base URL (never fall through to config)
+    const validationUrl = baseUrl || DEFAULT_BASE_URL;
     console.log('Validating credentials...');
     const validation = await validateCredentials(
       tokenId.trim(),
       tokenSecret.trim(),
-      baseUrl || DEFAULT_BASE_URL,
+      validationUrl,
     );
 
     if (!validation.valid) {
@@ -141,7 +143,7 @@ export const loginCommand = new Command()
       tokenId: tokenId.trim(),
       tokenSecret: tokenSecret.trim(),
       environmentId: validation.environmentId,
-      ...(baseUrl && { baseUrl }),
+      ...(baseUrl && baseUrl !== DEFAULT_BASE_URL && { baseUrl }),
     });
 
     console.log(

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -127,7 +127,7 @@ export const loginCommand = new Command()
     const validation = await validateCredentials(
       tokenId.trim(),
       tokenSecret.trim(),
-      baseUrl,
+      baseUrl || DEFAULT_BASE_URL,
     );
 
     if (!validation.valid) {

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -2,13 +2,14 @@ import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { Command } from '@cliffy/command';
 import { listEnvironments, setEnvironment } from '../lib/config.ts';
-import { validateCredentials } from '../lib/mux.ts';
+import { DEFAULT_BASE_URL, validateCredentials } from '../lib/mux.ts';
 import { inputPrompt, secretPrompt } from '../lib/prompt.ts';
 import { getConfigPath } from '../lib/xdg.ts';
 
 export interface EnvVars {
   MUX_TOKEN_ID?: string;
   MUX_TOKEN_SECRET?: string;
+  MUX_BASE_URL?: string;
 }
 
 /**
@@ -48,6 +49,8 @@ export async function parseEnvFile(filePath: string): Promise<EnvVars> {
         envVars.MUX_TOKEN_ID = value;
       } else if (key === 'MUX_TOKEN_SECRET') {
         envVars.MUX_TOKEN_SECRET = value;
+      } else if (key === 'MUX_BASE_URL') {
+        envVars.MUX_BASE_URL = value;
       }
     }
   }
@@ -80,6 +83,8 @@ export const loginCommand = new Command()
       );
     }
 
+    let baseUrl: string | undefined;
+
     if (options.envFile) {
       // Read from .env file
       console.log(`Reading credentials from ${options.envFile}...`);
@@ -95,6 +100,10 @@ export const loginCommand = new Command()
 
       tokenId = envVars.MUX_TOKEN_ID;
       tokenSecret = envVars.MUX_TOKEN_SECRET;
+
+      if (envVars.MUX_BASE_URL && envVars.MUX_BASE_URL !== DEFAULT_BASE_URL) {
+        baseUrl = envVars.MUX_BASE_URL;
+      }
     } else {
       // Interactive prompts
       console.log('Enter your Mux API credentials.');
@@ -118,6 +127,7 @@ export const loginCommand = new Command()
     const validation = await validateCredentials(
       tokenId.trim(),
       tokenSecret.trim(),
+      baseUrl,
     );
 
     if (!validation.valid) {
@@ -131,6 +141,7 @@ export const loginCommand = new Command()
       tokenId: tokenId.trim(),
       tokenSecret: tokenSecret.trim(),
       environmentId: validation.environmentId,
+      ...(baseUrl && { baseUrl }),
     });
 
     console.log(

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -2,7 +2,11 @@ import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { Command } from '@cliffy/command';
 import { listEnvironments, setEnvironment } from '../lib/config.ts';
-import { DEFAULT_BASE_URL, resolveBaseUrl, validateCredentials } from '../lib/mux.ts';
+import {
+  DEFAULT_BASE_URL,
+  resolveBaseUrl,
+  validateCredentials,
+} from '../lib/mux.ts';
 import { inputPrompt, secretPrompt } from '../lib/prompt.ts';
 import { getConfigPath } from '../lib/xdg.ts';
 
@@ -100,7 +104,9 @@ export const loginCommand = new Command()
 
       tokenId = envVars.MUX_TOKEN_ID;
       tokenSecret = envVars.MUX_TOKEN_SECRET;
-      baseUrl = resolveBaseUrl({ environment: { baseUrl: envVars.MUX_BASE_URL } });
+      baseUrl = resolveBaseUrl({
+        environment: { baseUrl: envVars.MUX_BASE_URL },
+      });
     } else {
       // Interactive prompts
       console.log('Enter your Mux API credentials.');

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -2,7 +2,7 @@ import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { Command } from '@cliffy/command';
 import { listEnvironments, setEnvironment } from '../lib/config.ts';
-import { DEFAULT_BASE_URL, validateCredentials } from '../lib/mux.ts';
+import { DEFAULT_BASE_URL, resolveBaseUrl, validateCredentials } from '../lib/mux.ts';
 import { inputPrompt, secretPrompt } from '../lib/prompt.ts';
 import { getConfigPath } from '../lib/xdg.ts';
 
@@ -83,9 +83,7 @@ export const loginCommand = new Command()
       );
     }
 
-    // Resolve base URL: env-file > MUX_BASE_URL env var > default
-    // Only persist to config if nonstandard
-    let baseUrl: string | undefined;
+    let baseUrl: string;
 
     if (options.envFile) {
       // Read from .env file
@@ -102,7 +100,7 @@ export const loginCommand = new Command()
 
       tokenId = envVars.MUX_TOKEN_ID;
       tokenSecret = envVars.MUX_TOKEN_SECRET;
-      baseUrl = envVars.MUX_BASE_URL || process.env.MUX_BASE_URL;
+      baseUrl = resolveBaseUrl({ environment: { baseUrl: envVars.MUX_BASE_URL } });
     } else {
       // Interactive prompts
       console.log('Enter your Mux API credentials.');
@@ -120,11 +118,10 @@ export const loginCommand = new Command()
         throw new Error('Token Secret is required');
       }
 
-      baseUrl = process.env.MUX_BASE_URL;
+      baseUrl = resolveBaseUrl(null);
     }
 
-    // Validate credentials against the resolved base URL (never fall through to config)
-    const validationUrl = baseUrl || DEFAULT_BASE_URL;
+    const validationUrl = baseUrl;
     console.log('Validating credentials...');
     const validation = await validateCredentials(
       tokenId.trim(),
@@ -143,7 +140,7 @@ export const loginCommand = new Command()
       tokenId: tokenId.trim(),
       tokenSecret: tokenSecret.trim(),
       environmentId: validation.environmentId,
-      ...(baseUrl && baseUrl !== DEFAULT_BASE_URL && { baseUrl }),
+      ...(baseUrl !== DEFAULT_BASE_URL && { baseUrl }),
     });
 
     console.log(

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -121,12 +121,11 @@ export const loginCommand = new Command()
       baseUrl = resolveBaseUrl(null);
     }
 
-    const validationUrl = baseUrl;
     console.log('Validating credentials...');
     const validation = await validateCredentials(
       tokenId.trim(),
       tokenSecret.trim(),
-      validationUrl,
+      baseUrl,
     );
 
     if (!validation.valid) {

--- a/src/commands/webhooks/listen.ts
+++ b/src/commands/webhooks/listen.ts
@@ -3,7 +3,7 @@ import { Command } from '@cliffy/command';
 import { getCurrentEnvironment, updateEnvironment } from '@/lib/config.ts';
 import { checkFetchPermissionError } from '@/lib/errors.ts';
 import { appendEvent, type StoredEvent } from '@/lib/events-store.ts';
-import { getAuthHeaders, getMuxBaseUrl } from '@/lib/mux.ts';
+import { getAuthHeaders, resolveBaseUrl } from '@/lib/mux.ts';
 import { parseSSEStream } from '@/lib/sse.ts';
 import { buildSignedHeaders, getSigningSecret } from '@/lib/webhook-signing.ts';
 
@@ -61,7 +61,7 @@ export const listenCommand = new Command()
     }
 
     const authHeaders = await getAuthHeaders();
-    const baseUrl = await getMuxBaseUrl();
+    const baseUrl = resolveBaseUrl(env);
     const url = `${baseUrl}/system/v1/webhook-events/stream`;
 
     let signingSecret: string | undefined;

--- a/src/commands/webhooks/listen.ts
+++ b/src/commands/webhooks/listen.ts
@@ -3,7 +3,7 @@ import { Command } from '@cliffy/command';
 import { getCurrentEnvironment, updateEnvironment } from '@/lib/config.ts';
 import { checkFetchPermissionError } from '@/lib/errors.ts';
 import { appendEvent, type StoredEvent } from '@/lib/events-store.ts';
-import { getAuthHeaders, resolveBaseUrl } from '@/lib/mux.ts';
+import { getAuthHeaders, getMuxUrl } from '@/lib/mux.ts';
 import { parseSSEStream } from '@/lib/sse.ts';
 import { buildSignedHeaders, getSigningSecret } from '@/lib/webhook-signing.ts';
 
@@ -61,7 +61,7 @@ export const listenCommand = new Command()
     }
 
     const authHeaders = await getAuthHeaders();
-    const baseUrl = resolveBaseUrl(env);
+    const baseUrl = getMuxUrl(env);
     const url = `${baseUrl}/system/v1/webhook-events/stream`;
 
     let signingSecret: string | undefined;

--- a/src/commands/webhooks/listen.ts
+++ b/src/commands/webhooks/listen.ts
@@ -61,7 +61,7 @@ export const listenCommand = new Command()
     }
 
     const authHeaders = await getAuthHeaders();
-    const baseUrl = getMuxBaseUrl();
+    const baseUrl = await getMuxBaseUrl();
     const url = `${baseUrl}/system/v1/webhook-events/stream`;
 
     let signingSecret: string | undefined;

--- a/src/commands/webhooks/listen.ts
+++ b/src/commands/webhooks/listen.ts
@@ -3,7 +3,7 @@ import { Command } from '@cliffy/command';
 import { getCurrentEnvironment, updateEnvironment } from '@/lib/config.ts';
 import { checkFetchPermissionError } from '@/lib/errors.ts';
 import { appendEvent, type StoredEvent } from '@/lib/events-store.ts';
-import { getAuthHeaders, getMuxUrl } from '@/lib/mux.ts';
+import { getAuthHeaders, getMuxBaseUrl } from '@/lib/mux.ts';
 import { parseSSEStream } from '@/lib/sse.ts';
 import { buildSignedHeaders, getSigningSecret } from '@/lib/webhook-signing.ts';
 
@@ -61,7 +61,7 @@ export const listenCommand = new Command()
     }
 
     const authHeaders = await getAuthHeaders();
-    const baseUrl = getMuxUrl(env);
+    const baseUrl = getMuxBaseUrl(env);
     const url = `${baseUrl}/system/v1/webhook-events/stream`;
 
     let signingSecret: string | undefined;

--- a/src/commands/whoami.ts
+++ b/src/commands/whoami.ts
@@ -12,7 +12,7 @@ export const whoamiCommand = new Command()
   .action(async (options: WhoAmIOptions) => {
     try {
       const headers = await getAuthHeaders();
-      const baseUrl = getMuxBaseUrl();
+      const baseUrl = await getMuxBaseUrl();
       const response = await fetch(`${baseUrl}/system/v1/whoami`, { headers });
 
       if (!response.ok) {

--- a/src/commands/whoami.ts
+++ b/src/commands/whoami.ts
@@ -1,6 +1,6 @@
 import { Command } from '@cliffy/command';
 import { handleCommandError } from '@/lib/errors.ts';
-import { DEFAULT_BASE_URL, getAuthHeaders, getMuxBaseUrl } from '../lib/mux.ts';
+import { DEFAULT_BASE_URL, getAuthContext } from '../lib/mux.ts';
 
 interface WhoAmIOptions {
   json?: boolean;
@@ -11,8 +11,7 @@ export const whoamiCommand = new Command()
   .option('--json', 'Output JSON instead of pretty format')
   .action(async (options: WhoAmIOptions) => {
     try {
-      const headers = await getAuthHeaders();
-      const baseUrl = await getMuxBaseUrl();
+      const { headers, baseUrl } = await getAuthContext();
       const response = await fetch(`${baseUrl}/system/v1/whoami`, { headers });
 
       if (!response.ok) {

--- a/src/commands/whoami.ts
+++ b/src/commands/whoami.ts
@@ -1,6 +1,6 @@
 import { Command } from '@cliffy/command';
 import { handleCommandError } from '@/lib/errors.ts';
-import { getAuthHeaders, getMuxBaseUrl } from '../lib/mux.ts';
+import { DEFAULT_BASE_URL, getAuthHeaders, getMuxBaseUrl } from '../lib/mux.ts';
 
 interface WhoAmIOptions {
   json?: boolean;
@@ -38,6 +38,9 @@ export const whoamiCommand = new Command()
       console.log(
         `Permissions:   ${(data.permissions as string[]).join(', ')}`,
       );
+      if (baseUrl !== DEFAULT_BASE_URL) {
+        console.log(`API endpoint:  ${baseUrl}`);
+      }
     } catch (error) {
       await handleCommandError(error, 'whoami', 'get', options);
     }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -7,6 +7,7 @@ export interface Environment {
   tokenId: string;
   tokenSecret: string;
   environmentId?: string;
+  baseUrl?: string;
   signingKeyId?: string;
   signingPrivateKey?: string;
   forwardUrl?: string;

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,5 +1,5 @@
 import { AuthenticationError, NotFoundError } from '@mux/mux-node';
-import { getAuthHeaders, getMuxBaseUrl } from './mux.ts';
+import { getAuthContext } from './mux.ts';
 
 /**
  * Format a permission error message for display.
@@ -47,8 +47,7 @@ async function fetchTokenInfo(): Promise<{
   tokenName?: string;
 } | null> {
   try {
-    const headers = await getAuthHeaders();
-    const baseUrl = await getMuxBaseUrl();
+    const { headers, baseUrl } = await getAuthContext();
     const response = await fetch(`${baseUrl}/system/v1/whoami`, { headers });
 
     if (!response.ok) return null;

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -48,7 +48,7 @@ async function fetchTokenInfo(): Promise<{
 } | null> {
   try {
     const headers = await getAuthHeaders();
-    const baseUrl = getMuxBaseUrl();
+    const baseUrl = await getMuxBaseUrl();
     const response = await fetch(`${baseUrl}/system/v1/whoami`, { headers });
 
     if (!response.ok) return null;

--- a/src/lib/mux.test.ts
+++ b/src/lib/mux.test.ts
@@ -2,10 +2,11 @@ import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { getCurrentEnvironment } from './config.ts';
 import { setEnvironment } from './config.ts';
-import { DEFAULT_BASE_URL, getMuxBaseUrl } from './mux.ts';
+import { DEFAULT_BASE_URL, getMuxUrl } from './mux.ts';
 
-describe('getMuxBaseUrl', () => {
+describe('getMuxUrl', () => {
   let testConfigDir: string;
   let originalXdgConfigHome: string | undefined;
   let originalMuxBaseUrl: string | undefined;
@@ -33,7 +34,8 @@ describe('getMuxBaseUrl', () => {
   });
 
   it('should return default when no env var or config', async () => {
-    expect(await getMuxBaseUrl()).toBe(DEFAULT_BASE_URL);
+    const env = await getCurrentEnvironment();
+    expect(getMuxUrl(env)).toBe(DEFAULT_BASE_URL);
   });
 
   it('should prefer MUX_BASE_URL env var over everything', async () => {
@@ -44,7 +46,8 @@ describe('getMuxBaseUrl', () => {
       baseUrl: 'https://config.example.com',
     });
 
-    expect(await getMuxBaseUrl()).toBe('https://env-var.example.com');
+    const env = await getCurrentEnvironment();
+    expect(getMuxUrl(env)).toBe('https://env-var.example.com');
   });
 
   it('should use config baseUrl when no env var is set', async () => {
@@ -54,7 +57,8 @@ describe('getMuxBaseUrl', () => {
       baseUrl: 'https://api.staging.mux.com',
     });
 
-    expect(await getMuxBaseUrl()).toBe('https://api.staging.mux.com');
+    const env = await getCurrentEnvironment();
+    expect(getMuxUrl(env)).toBe('https://api.staging.mux.com');
   });
 
   it('should fall back to default when config has no baseUrl', async () => {
@@ -63,6 +67,7 @@ describe('getMuxBaseUrl', () => {
       tokenSecret: 'secret',
     });
 
-    expect(await getMuxBaseUrl()).toBe(DEFAULT_BASE_URL);
+    const env = await getCurrentEnvironment();
+    expect(getMuxUrl(env)).toBe(DEFAULT_BASE_URL);
   });
 });

--- a/src/lib/mux.test.ts
+++ b/src/lib/mux.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { setEnvironment } from './config.ts';
+import { DEFAULT_BASE_URL, getMuxBaseUrl } from './mux.ts';
+
+describe('getMuxBaseUrl', () => {
+  let testConfigDir: string;
+  let originalXdgConfigHome: string | undefined;
+  let originalMuxBaseUrl: string | undefined;
+
+  beforeEach(async () => {
+    testConfigDir = await mkdtemp(join(tmpdir(), 'mux-cli-test-'));
+    originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
+    originalMuxBaseUrl = process.env.MUX_BASE_URL;
+    process.env.XDG_CONFIG_HOME = testConfigDir;
+    delete process.env.MUX_BASE_URL;
+  });
+
+  afterEach(async () => {
+    if (originalXdgConfigHome === undefined) {
+      delete process.env.XDG_CONFIG_HOME;
+    } else {
+      process.env.XDG_CONFIG_HOME = originalXdgConfigHome;
+    }
+    if (originalMuxBaseUrl === undefined) {
+      delete process.env.MUX_BASE_URL;
+    } else {
+      process.env.MUX_BASE_URL = originalMuxBaseUrl;
+    }
+    await rm(testConfigDir, { recursive: true, force: true });
+  });
+
+  it('should return default when no env var or config', async () => {
+    expect(await getMuxBaseUrl()).toBe(DEFAULT_BASE_URL);
+  });
+
+  it('should prefer MUX_BASE_URL env var over everything', async () => {
+    process.env.MUX_BASE_URL = 'https://env-var.example.com';
+    await setEnvironment('default', {
+      tokenId: 'id',
+      tokenSecret: 'secret',
+      baseUrl: 'https://config.example.com',
+    });
+
+    expect(await getMuxBaseUrl()).toBe('https://env-var.example.com');
+  });
+
+  it('should use config baseUrl when no env var is set', async () => {
+    await setEnvironment('default', {
+      tokenId: 'id',
+      tokenSecret: 'secret',
+      baseUrl: 'https://api.staging.mux.com',
+    });
+
+    expect(await getMuxBaseUrl()).toBe('https://api.staging.mux.com');
+  });
+
+  it('should fall back to default when config has no baseUrl', async () => {
+    await setEnvironment('default', {
+      tokenId: 'id',
+      tokenSecret: 'secret',
+    });
+
+    expect(await getMuxBaseUrl()).toBe(DEFAULT_BASE_URL);
+  });
+});

--- a/src/lib/mux.test.ts
+++ b/src/lib/mux.test.ts
@@ -4,9 +4,9 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { getCurrentEnvironment } from './config.ts';
 import { setEnvironment } from './config.ts';
-import { DEFAULT_BASE_URL, getMuxUrl } from './mux.ts';
+import { DEFAULT_BASE_URL, getMuxBaseUrl } from './mux.ts';
 
-describe('getMuxUrl', () => {
+describe('getMuxBaseUrl', () => {
   let testConfigDir: string;
   let originalXdgConfigHome: string | undefined;
   let originalMuxBaseUrl: string | undefined;
@@ -35,7 +35,7 @@ describe('getMuxUrl', () => {
 
   it('should return default when no env var or config', async () => {
     const env = await getCurrentEnvironment();
-    expect(getMuxUrl(env)).toBe(DEFAULT_BASE_URL);
+    expect(getMuxBaseUrl(env)).toBe(DEFAULT_BASE_URL);
   });
 
   it('should prefer MUX_BASE_URL env var over everything', async () => {
@@ -47,7 +47,7 @@ describe('getMuxUrl', () => {
     });
 
     const env = await getCurrentEnvironment();
-    expect(getMuxUrl(env)).toBe('https://env-var.example.com');
+    expect(getMuxBaseUrl(env)).toBe('https://env-var.example.com');
   });
 
   it('should use config baseUrl when no env var is set', async () => {
@@ -58,7 +58,7 @@ describe('getMuxUrl', () => {
     });
 
     const env = await getCurrentEnvironment();
-    expect(getMuxUrl(env)).toBe('https://api.staging.mux.com');
+    expect(getMuxBaseUrl(env)).toBe('https://api.staging.mux.com');
   });
 
   it('should fall back to default when config has no baseUrl', async () => {
@@ -68,6 +68,6 @@ describe('getMuxUrl', () => {
     });
 
     const env = await getCurrentEnvironment();
-    expect(getMuxUrl(env)).toBe(DEFAULT_BASE_URL);
+    expect(getMuxBaseUrl(env)).toBe(DEFAULT_BASE_URL);
   });
 });

--- a/src/lib/mux.ts
+++ b/src/lib/mux.ts
@@ -15,7 +15,7 @@ function getUserAgent(): string {
  * Resolve the Mux API base URL.
  * Priority: MUX_BASE_URL env var > config baseUrl > default
  */
-export function getMuxUrl(
+export function getMuxBaseUrl(
   env?: { environment: { baseUrl?: string } } | null,
 ): string {
   return (
@@ -43,7 +43,7 @@ export async function getAuthContext(): Promise<{
       Authorization: `Basic ${credentials}`,
       'User-Agent': getUserAgent(),
     },
-    baseUrl: getMuxUrl(env),
+    baseUrl: getMuxBaseUrl(env),
   };
 }
 
@@ -64,7 +64,7 @@ export async function createAuthenticatedMuxClient(): Promise<Mux> {
     throw new Error("Not logged in. Please run 'mux login' to authenticate.");
   }
 
-  const baseURL = getMuxUrl(env);
+  const baseURL = getMuxBaseUrl(env);
 
   return new Mux({
     tokenId: env.environment.tokenId,
@@ -84,7 +84,8 @@ export async function validateCredentials(
   overrideBaseUrl?: string,
 ): Promise<{ valid: boolean; environmentId?: string; error?: string }> {
   try {
-    const baseUrl = overrideBaseUrl || getMuxUrl(await getCurrentEnvironment());
+    const baseUrl =
+      overrideBaseUrl || getMuxBaseUrl(await getCurrentEnvironment());
     const credentials = btoa(`${tokenId}:${tokenSecret}`);
     const response = await fetch(`${baseUrl}/system/v1/whoami`, {
       headers: {

--- a/src/lib/mux.ts
+++ b/src/lib/mux.ts
@@ -14,22 +14,13 @@ function getUserAgent(): string {
 /**
  * Resolve the Mux API base URL.
  * Priority: MUX_BASE_URL env var > config baseUrl > default
- * Pass a pre-fetched environment to avoid redundant config reads.
  */
-export function resolveBaseUrl(
+export function getMuxUrl(
   env?: { environment: { baseUrl?: string } } | null,
 ): string {
   return (
     process.env.MUX_BASE_URL || env?.environment.baseUrl || DEFAULT_BASE_URL
   );
-}
-
-/**
- * Get the Mux API base URL (reads config if needed).
- */
-export async function getMuxBaseUrl(): Promise<string> {
-  const env = await getCurrentEnvironment();
-  return resolveBaseUrl(env);
 }
 
 /**
@@ -52,7 +43,7 @@ export async function getAuthContext(): Promise<{
       Authorization: `Basic ${credentials}`,
       'User-Agent': getUserAgent(),
     },
-    baseUrl: resolveBaseUrl(env),
+    baseUrl: getMuxUrl(env),
   };
 }
 
@@ -73,7 +64,7 @@ export async function createAuthenticatedMuxClient(): Promise<Mux> {
     throw new Error("Not logged in. Please run 'mux login' to authenticate.");
   }
 
-  const baseURL = resolveBaseUrl(env);
+  const baseURL = getMuxUrl(env);
 
   return new Mux({
     tokenId: env.environment.tokenId,
@@ -93,7 +84,7 @@ export async function validateCredentials(
   overrideBaseUrl?: string,
 ): Promise<{ valid: boolean; environmentId?: string; error?: string }> {
   try {
-    const baseUrl = overrideBaseUrl || (await getMuxBaseUrl());
+    const baseUrl = overrideBaseUrl || getMuxUrl(await getCurrentEnvironment());
     const credentials = btoa(`${tokenId}:${tokenSecret}`);
     const response = await fetch(`${baseUrl}/system/v1/whoami`, {
       headers: {

--- a/src/lib/mux.ts
+++ b/src/lib/mux.ts
@@ -33,9 +33,12 @@ export async function getMuxBaseUrl(): Promise<string> {
 }
 
 /**
- * Get auth headers for raw fetch requests to Mux API
+ * Get auth headers and base URL in a single config read.
  */
-export async function getAuthHeaders(): Promise<Record<string, string>> {
+export async function getAuthContext(): Promise<{
+  headers: Record<string, string>;
+  baseUrl: string;
+}> {
   const env = await getCurrentEnvironment();
   if (!env) {
     throw new Error("Not logged in. Please run 'mux login' to authenticate.");
@@ -45,9 +48,19 @@ export async function getAuthHeaders(): Promise<Record<string, string>> {
     `${env.environment.tokenId}:${env.environment.tokenSecret}`,
   );
   return {
-    Authorization: `Basic ${credentials}`,
-    'User-Agent': getUserAgent(),
+    headers: {
+      Authorization: `Basic ${credentials}`,
+      'User-Agent': getUserAgent(),
+    },
+    baseUrl: resolveBaseUrl(env),
   };
+}
+
+/**
+ * Get auth headers for raw fetch requests to Mux API
+ */
+export async function getAuthHeaders(): Promise<Record<string, string>> {
+  return (await getAuthContext()).headers;
 }
 
 /**

--- a/src/lib/mux.ts
+++ b/src/lib/mux.ts
@@ -56,9 +56,12 @@ export async function createAuthenticatedMuxClient(): Promise<Mux> {
     throw new Error("Not logged in. Please run 'mux login' to authenticate.");
   }
 
+  const baseURL = await getMuxBaseUrl();
+
   return new Mux({
     tokenId: env.environment.tokenId,
     tokenSecret: env.environment.tokenSecret,
+    ...(baseURL !== DEFAULT_BASE_URL && { baseURL }),
     defaultHeaders: { 'User-Agent': getUserAgent() },
   });
 }

--- a/src/lib/mux.ts
+++ b/src/lib/mux.ts
@@ -12,20 +12,20 @@ function getUserAgent(): string {
 }
 
 /**
- * Get the Mux API base URL.
+ * Resolve the Mux API base URL.
  * Priority: MUX_BASE_URL env var > config baseUrl > default
+ * Pass a pre-fetched environment to avoid redundant config reads.
+ */
+export function resolveBaseUrl(env?: { environment: { baseUrl?: string } } | null): string {
+  return process.env.MUX_BASE_URL || env?.environment.baseUrl || DEFAULT_BASE_URL;
+}
+
+/**
+ * Get the Mux API base URL (reads config if needed).
  */
 export async function getMuxBaseUrl(): Promise<string> {
-  if (process.env.MUX_BASE_URL) {
-    return process.env.MUX_BASE_URL;
-  }
-
   const env = await getCurrentEnvironment();
-  if (env?.environment.baseUrl) {
-    return env.environment.baseUrl;
-  }
-
-  return DEFAULT_BASE_URL;
+  return resolveBaseUrl(env);
 }
 
 /**
@@ -56,8 +56,7 @@ export async function createAuthenticatedMuxClient(): Promise<Mux> {
     throw new Error("Not logged in. Please run 'mux login' to authenticate.");
   }
 
-  const baseURL =
-    process.env.MUX_BASE_URL || env.environment.baseUrl || DEFAULT_BASE_URL;
+  const baseURL = resolveBaseUrl(env);
 
   return new Mux({
     tokenId: env.environment.tokenId,

--- a/src/lib/mux.ts
+++ b/src/lib/mux.ts
@@ -56,7 +56,8 @@ export async function createAuthenticatedMuxClient(): Promise<Mux> {
     throw new Error("Not logged in. Please run 'mux login' to authenticate.");
   }
 
-  const baseURL = await getMuxBaseUrl();
+  const baseURL =
+    process.env.MUX_BASE_URL || env.environment.baseUrl || DEFAULT_BASE_URL;
 
   return new Mux({
     tokenId: env.environment.tokenId,

--- a/src/lib/mux.ts
+++ b/src/lib/mux.ts
@@ -16,8 +16,12 @@ function getUserAgent(): string {
  * Priority: MUX_BASE_URL env var > config baseUrl > default
  * Pass a pre-fetched environment to avoid redundant config reads.
  */
-export function resolveBaseUrl(env?: { environment: { baseUrl?: string } } | null): string {
-  return process.env.MUX_BASE_URL || env?.environment.baseUrl || DEFAULT_BASE_URL;
+export function resolveBaseUrl(
+  env?: { environment: { baseUrl?: string } } | null,
+): string {
+  return (
+    process.env.MUX_BASE_URL || env?.environment.baseUrl || DEFAULT_BASE_URL
+  );
 }
 
 /**

--- a/src/lib/mux.ts
+++ b/src/lib/mux.ts
@@ -3,7 +3,7 @@ import pkg from '../../package.json';
 import { getCurrentEnvironment } from './config.ts';
 import { isAgentMode } from './context.ts';
 
-const DEFAULT_BASE_URL = 'https://api.mux.com';
+export const DEFAULT_BASE_URL = 'https://api.mux.com';
 
 function getUserAgent(): string {
   return isAgentMode()
@@ -12,10 +12,20 @@ function getUserAgent(): string {
 }
 
 /**
- * Get the Mux API base URL, respecting MUX_BASE_URL env var
+ * Get the Mux API base URL.
+ * Priority: MUX_BASE_URL env var > config baseUrl > default
  */
-export function getMuxBaseUrl(): string {
-  return process.env.MUX_BASE_URL || DEFAULT_BASE_URL;
+export async function getMuxBaseUrl(): Promise<string> {
+  if (process.env.MUX_BASE_URL) {
+    return process.env.MUX_BASE_URL;
+  }
+
+  const env = await getCurrentEnvironment();
+  if (env?.environment.baseUrl) {
+    return env.environment.baseUrl;
+  }
+
+  return DEFAULT_BASE_URL;
 }
 
 /**
@@ -60,9 +70,10 @@ export async function createAuthenticatedMuxClient(): Promise<Mux> {
 export async function validateCredentials(
   tokenId: string,
   tokenSecret: string,
+  overrideBaseUrl?: string,
 ): Promise<{ valid: boolean; environmentId?: string; error?: string }> {
   try {
-    const baseUrl = getMuxBaseUrl();
+    const baseUrl = overrideBaseUrl || (await getMuxBaseUrl());
     const credentials = btoa(`${tokenId}:${tokenSecret}`);
     const response = await fetch(`${baseUrl}/system/v1/whoami`, {
       headers: {


### PR DESCRIPTION
<!-- claude --resume de65c1df-24ef-42de-9b20-f557cdf760fe -->

> [!NOTE]
> This was authored by @claude, not @jrmann100.

## Summary
- Parses `MUX_BASE_URL` from `--env-file` during `mux login`
- If nonstandard (not `https://api.mux.com`), saves it as `baseUrl` in the environment's config.json
- `getMuxBaseUrl()` now checks: env var > config > default, so subsequent commands use the configured base URL without needing the env var set
- `whoami` displays `API endpoint` when using a nonstandard base URL

## Test plan
- [x] All 699 existing + new tests pass
- [x] `mux login --env-file` with a `.env` containing non-empty `MUX_BASE_URL` saves `baseUrl` to config
- [x] `mux login --env-file` without `MUX_BASE_URL` does not add `baseUrl` to config
- [x] `mux whoami` uses the stored `baseUrl` without `MUX_BASE_URL` env var set
- [x] `mux whoami` shows `API endpoint` only when nonstandard

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the CLI chooses the API endpoint and persists it to config, which can redirect all subsequent API calls for an environment if misconfigured; scope is contained and covered by new tests.
> 
> **Overview**
> Adds support for a configurable Mux API endpoint: `mux login --env-file` now parses `MUX_BASE_URL`, validates credentials against that URL, and persists a non-default `baseUrl` into the saved environment config.
> 
> Updates base-URL resolution to prefer `MUX_BASE_URL` env var, then per-environment config, then the default; commands that fetch from the API (`whoami`, webhook `listen`, error permission probing) now use the resolved base URL, and `whoami` prints the active endpoint when non-default. Includes new/updated tests for `.env` parsing and `getMuxBaseUrl` precedence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0017213e0cde8cc38a1596bdf76eb747aea9e22b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->