### PR TITLE
fix: codesign darwin binaries and smoke-test on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,9 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - name: Build binary
         run: bun build --compile --minify --sourcemap ./src/index.ts --target=bun-${{ matrix.target }} --outfile ./dist/mux-${{ matrix.target }}
+      - name: Codesign darwin binary (ad-hoc)
+        if: startsWith(matrix.target, 'darwin-')
+        run: codesign --sign - --force ./dist/mux-${{ matrix.target }}
       - name: Smoke test binary
         run: ./dist/mux-${{ matrix.target }} --version
       - name: Verify darwin binary is codesigned

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,4 +63,4 @@ jobs:
         run: ./dist/mux-${{ matrix.target }} --version
       - name: Verify darwin binary is codesigned
         if: startsWith(matrix.target, 'darwin-')
-        run: codesign --verify --strict ./dist/mux-${{ matrix.target }}
+        run: codesign -vvv --verify --strict ./dist/mux-${{ matrix.target }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,3 +61,6 @@ jobs:
         run: bun build --compile --minify --sourcemap ./src/index.ts --target=bun-${{ matrix.target }} --outfile ./dist/mux-${{ matrix.target }}
       - name: Smoke test binary
         run: ./dist/mux-${{ matrix.target }} --version
+      - name: Verify darwin binary is codesigned
+        if: startsWith(matrix.target, 'darwin-')
+        run: codesign --verify --strict ./dist/mux-${{ matrix.target }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,3 +59,5 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - name: Build binary
         run: bun build --compile --minify --sourcemap ./src/index.ts --target=bun-${{ matrix.target }} --outfile ./dist/mux-${{ matrix.target }}
+      - name: Smoke test binary
+        run: ./dist/mux-${{ matrix.target }} --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,9 @@ jobs:
         run: bun build --compile --minify --sourcemap ./src/index.ts --target=bun-${{ matrix.target }} --outfile ./dist/mux-${{ matrix.target }}
       - name: Codesign darwin binary (ad-hoc)
         if: startsWith(matrix.target, 'darwin-')
-        run: codesign --sign - --force ./dist/mux-${{ matrix.target }}
+        run: |
+          codesign --remove-signature ./dist/mux-${{ matrix.target }}
+          codesign --sign - ./dist/mux-${{ matrix.target }}
       - name: Smoke test binary
         run: ./dist/mux-${{ matrix.target }} --version
       - name: Verify darwin binary is codesigned

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,9 @@ jobs:
         run: bun build --compile --minify --sourcemap ./src/index.ts --target=bun-${{ matrix.target }} --outfile ./dist/mux-${{ matrix.target }}
       - name: Codesign darwin binary (ad-hoc)
         if: startsWith(matrix.target, 'darwin-')
-        run: codesign --sign - --force ./dist/mux-${{ matrix.target }}
+        run: |
+          codesign --remove-signature ./dist/mux-${{ matrix.target }}
+          codesign --sign - ./dist/mux-${{ matrix.target }}
       - name: Smoke test binary
         run: ./dist/mux-${{ matrix.target }} --version
       - name: Verify darwin binary is codesigned

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,9 @@ jobs:
         run: node -e "const fs=require('fs');const p=JSON.parse(fs.readFileSync('package.json','utf8'));p.version='${GITHUB_REF_NAME#v}';fs.writeFileSync('package.json',JSON.stringify(p,null,2)+'\n');"
       - name: Build binary
         run: bun build --compile --minify --sourcemap ./src/index.ts --target=bun-${{ matrix.target }} --outfile ./dist/mux-${{ matrix.target }}
+      - name: Codesign darwin binary (ad-hoc)
+        if: startsWith(matrix.target, 'darwin-')
+        run: codesign --sign - --force ./dist/mux-${{ matrix.target }}
       - name: Smoke test binary
         run: ./dist/mux-${{ matrix.target }} --version
       - name: Verify darwin binary is codesigned

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,9 @@ jobs:
         run: bun build --compile --minify --sourcemap ./src/index.ts --target=bun-${{ matrix.target }} --outfile ./dist/mux-${{ matrix.target }}
       - name: Smoke test binary
         run: ./dist/mux-${{ matrix.target }} --version
+      - name: Verify darwin binary is codesigned
+        if: startsWith(matrix.target, 'darwin-')
+        run: codesign --verify --strict ./dist/mux-${{ matrix.target }}
       - uses: actions/upload-artifact@v4
         with:
           name: mux-${{ matrix.target }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,8 @@ jobs:
         run: node -e "const fs=require('fs');const p=JSON.parse(fs.readFileSync('package.json','utf8'));p.version='${GITHUB_REF_NAME#v}';fs.writeFileSync('package.json',JSON.stringify(p,null,2)+'\n');"
       - name: Build binary
         run: bun build --compile --minify --sourcemap ./src/index.ts --target=bun-${{ matrix.target }} --outfile ./dist/mux-${{ matrix.target }}
+      - name: Smoke test binary
+        run: ./dist/mux-${{ matrix.target }} --version
       - uses: actions/upload-artifact@v4
         with:
           name: mux-${{ matrix.target }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
         run: ./dist/mux-${{ matrix.target }} --version
       - name: Verify darwin binary is codesigned
         if: startsWith(matrix.target, 'darwin-')
-        run: codesign --verify --strict ./dist/mux-${{ matrix.target }}
+        run: codesign -vvv --verify --strict ./dist/mux-${{ matrix.target }}
       - uses: actions/upload-artifact@v4
         with:
           name: mux-${{ matrix.target }}


### PR DESCRIPTION
## Summary
- bun 1.3.12 regressed ad-hoc signing for `bun build --compile` on darwin-arm64 (1.3.11 produced `adhoc,linker-signed` Mach-O; 1.3.12 produces no signature at all),
- this made the binary unusable on macOS
- This is broken in 1.3.0 that just went out moments ago

This PR

- [x] **smoke test to catch this in CI** 
- [x] **codesign fix** — adds explicit `codesign --sign` for darwin targets so we don't depend on toolchain-implicit signing (follow-up commit, pushed after the first CI run)

## Test plan
- [x] Confirm CI fails on the `Build (darwin-arm64)` smoke-test step on the first commit
- [x] After the codesign fix is pushed, confirm CI goes green
- [ ] Cut v1.3.1 after merge and verify \`mux --version\` runs on a real arm64 Mac

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only changes that affect build/release validation; main risk is CI/release failures if signing commands or runner environments behave differently across macOS targets.
> 
> **Overview**
> Adds explicit **ad-hoc codesigning** for `darwin-*` build outputs in both `ci.yml` and `release.yml` by stripping any existing signature and re-signing via `codesign --sign -`.
> 
> Adds a **smoke test** step to run `./dist/mux-<target> --version` for every built target, and verifies macOS artifacts are properly codesigned with `codesign --verify --strict` before uploading/releasing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2171b14cf862404c33ae98d51ef0ab91f8f51d8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->