### PR TITLE
Add docs manifest fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,14 @@
   "bin": {
     "mux": "bin/mux"
   },
+  "pi": {
+    "skills": [
+      "skills/mux-cli"
+    ]
+  },
   "files": [
     "bin",
+    "skills",
     "README.md",
     "LICENSE"
   ],

--- a/skills/mux-cli/SKILL.md
+++ b/skills/mux-cli/SKILL.md
@@ -1,50 +1,92 @@
 ---
 name: mux-cli
-description: Use the Mux CLI to interact with Mux APIs and search/read Mux documentation. Use when answering questions about Mux, developing Mux integrations, or operating Mux resources from a terminal.
+description: Use for all questions about Mux APIs, Mux SDKs, Mux CLI, webhooks, assets, uploads, playback, live streaming, Mux Data, Mux Robots, or Mux docs. The agent must use `mux docs search --json` and `mux docs read` before web search or answering from memory.
 ---
 
 # Mux CLI
 
 Use the `mux` command for Mux API operations and documentation lookup.
 
-## Documentation workflow
+## Mandatory docs workflow
 
-Before answering Mux-specific implementation questions, prefer the local docs interface instead of guessing:
+For any Mux API, SDK, CLI, webhook, playback, upload, asset, live streaming, Data, Robots, or docs question, use the local Mux docs commands before using web search or answering from memory.
+
+Do not search the web first.
+
+First run:
+
+```bash
+mux docs search "<topic>" --json
+```
+
+Then read the most relevant doc:
+
+```bash
+mux docs read "<doc-id>" --format markdown
+```
+
+Only use web search if:
+
+1. `mux docs search` fails,
+2. the docs index has no relevant result, or
+3. the user explicitly asks for external or web results.
+
+## Command resolution
+
+If `mux` is available, use:
 
 ```bash
 mux docs search "<topic>" --json
 mux docs read "<doc-id>" --format markdown
 ```
 
-Use `mux docs search` first to identify the right page. Use `mux docs read` when you need full details or code examples.
-
-## Docs sources
-
-The CLI resolves docs in this order:
-
-1. `--source <path>`
-2. `MUX_DOCS_PATH`
-3. A sibling `../mux.com` checkout for local Mux development
-4. The CLI docs cache populated by `mux docs update`
-
-For local Mux development, the docs repository is usually available as a sibling checkout:
+If working inside the Mux CLI repo and `mux` is not installed, use:
 
 ```bash
-MUX_DOCS_PATH=../mux.com mux docs search "webhook signatures" --json
+pnpm dev docs search "<topic>" --json
+pnpm dev docs read "<doc-id>" --format markdown
 ```
 
-For public/default usage, refresh the cache from the mux.com repository:
+If the docs cache has not been populated, run:
 
 ```bash
 mux docs update
 ```
 
-This downloads the published docs manifest and index from `docs.mux.com`. The index contains only `.mdx` files from `apps/web/app/docs/_guides`.
+For local pre-deploy testing with generated artifacts, run:
+
+```bash
+mux docs update --artifact-path ../mux.com/apps/web/public/.well-known/mux-docs
+```
+
+## Docs sources
+
+The CLI resolves docs in this order:
+
+1. cached published manifest/index populated by `mux docs update`
+2. `--source <path>`
+3. `MUX_DOCS_PATH`
+4. a sibling `../mux.com` checkout for local Mux development
+
+The published docs index is downloaded from `docs.mux.com` and contains only `.mdx` files from `apps/web/app/docs/_guides`.
+
+## Example
+
+User: "How do I verify Mux webhook signatures?"
+
+Run:
+
+```bash
+mux docs search "verify webhook signatures" --json
+mux docs read verify-webhook-signatures --format markdown
+```
+
+Then answer using the retrieved docs. Cite the docs page by `doc.id` and `doc.url` when possible.
 
 ## Agent usage guidelines
 
-- Prefer `--json` for search results.
-- Cite docs by `doc.id` and `doc.url` when possible.
+- Use `mux docs search --json` before answering Mux-specific questions.
 - Use `mux docs read <doc-id>` before providing detailed API behavior or code examples.
+- Cite docs by `doc.id` and `doc.url` when possible.
 - Do not mutate Mux resources unless the user explicitly asks you to.
 - For write/delete/update operations, explain the intended action and confirm if there is any ambiguity.

--- a/skills/mux-cli/SKILL.md
+++ b/skills/mux-cli/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: mux-cli
+description: Use the Mux CLI to interact with Mux APIs and search/read Mux documentation. Use when answering questions about Mux, developing Mux integrations, or operating Mux resources from a terminal.
+---
+
+# Mux CLI
+
+Use the `mux` command for Mux API operations and documentation lookup.
+
+## Documentation workflow
+
+Before answering Mux-specific implementation questions, prefer the local docs interface instead of guessing:
+
+```bash
+mux docs search "<topic>" --json
+mux docs read "<doc-id>" --format markdown
+```
+
+Use `mux docs search` first to identify the right page. Use `mux docs read` when you need full details or code examples.
+
+## Docs sources
+
+The CLI resolves docs in this order:
+
+1. `--source <path>`
+2. `MUX_DOCS_PATH`
+3. A sibling `../mux.com` checkout for local Mux development
+4. The CLI docs cache populated by `mux docs update`
+
+For local Mux development, the docs repository is usually available as a sibling checkout:
+
+```bash
+MUX_DOCS_PATH=../mux.com mux docs search "webhook signatures" --json
+```
+
+For public/default usage, refresh the cache from the mux.com repository:
+
+```bash
+mux docs update
+```
+
+This downloads the published docs manifest and index from `docs.mux.com`. The index contains only `.mdx` files from `apps/web/app/docs/_guides`.
+
+## Agent usage guidelines
+
+- Prefer `--json` for search results.
+- Cite docs by `doc.id` and `doc.url` when possible.
+- Use `mux docs read <doc-id>` before providing detailed API behavior or code examples.
+- Do not mutate Mux resources unless the user explicitly asks you to.
+- For write/delete/update operations, explain the intended action and confirm if there is any ambiguity.

--- a/src/commands/docs/index.test.ts
+++ b/src/commands/docs/index.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from 'bun:test';
+import { docsCommand } from './index.ts';
+import { readCommand } from './read.ts';
+import { searchCommand } from './search.ts';
+import { sourceCommand } from './source.ts';
+import { updateCommand } from './update.ts';
+
+describe('mux docs command', () => {
+  test('has a docs-focused description', () => {
+    expect(docsCommand.getDescription()).toMatch(/Mux docs/i);
+  });
+
+  test('registers docs subcommands', () => {
+    const commandNames = docsCommand
+      .getCommands()
+      .map((command) => command.getName());
+
+    expect(commandNames).toContain('search');
+    expect(commandNames).toContain('read');
+    expect(commandNames).toContain('update');
+    expect(commandNames).toContain('source');
+  });
+});
+
+describe('mux docs search command', () => {
+  test('describes docs search', () => {
+    expect(searchCommand.getDescription()).toMatch(/search.*docs/i);
+  });
+
+  test('accepts a query argument', () => {
+    const args = searchCommand.getArguments();
+
+    expect(args.length).toBeGreaterThanOrEqual(1);
+    expect(args[0]?.name).toMatch(/query/i);
+  });
+
+  test('has agent-friendly output and source options', () => {
+    const optionNames = searchCommand.getOptions().map((option) => option.name);
+
+    expect(optionNames).toContain('json');
+    expect(optionNames).toContain('limit');
+    expect(optionNames).toContain('source');
+  });
+});
+
+describe('mux docs read command', () => {
+  test('describes reading a docs page', () => {
+    expect(readCommand.getDescription()).toMatch(/read.*docs/i);
+  });
+
+  test('accepts a doc id argument', () => {
+    const args = readCommand.getArguments();
+
+    expect(args.length).toBe(1);
+    expect(args[0]?.name).toMatch(/doc.*id|id/i);
+  });
+
+  test('has markdown and JSON output options', () => {
+    const optionNames = readCommand.getOptions().map((option) => option.name);
+
+    expect(optionNames).toContain('format');
+    expect(optionNames).toContain('json');
+    expect(optionNames).toContain('source');
+  });
+});
+
+describe('mux docs update command', () => {
+  test('describes refreshing the docs cache', () => {
+    expect(updateCommand.getDescription()).toMatch(/update|refresh/i);
+  });
+
+  test('has source, force, and JSON options', () => {
+    const optionNames = updateCommand.getOptions().map((option) => option.name);
+
+    expect(optionNames).toContain('source');
+    expect(optionNames).toContain('force');
+    expect(optionNames).toContain('json');
+  });
+});
+
+describe('mux docs source command', () => {
+  test('describes showing the active docs source', () => {
+    expect(sourceCommand.getDescription()).toMatch(/source/i);
+  });
+
+  test('has a JSON option', () => {
+    const optionNames = sourceCommand.getOptions().map((option) => option.name);
+
+    expect(optionNames).toContain('json');
+  });
+});

--- a/src/commands/docs/index.ts
+++ b/src/commands/docs/index.ts
@@ -1,0 +1,15 @@
+import { Command } from '@cliffy/command';
+import { readCommand } from './read.ts';
+import { searchCommand } from './search.ts';
+import { sourceCommand } from './source.ts';
+import { updateCommand } from './update.ts';
+
+export const docsCommand = new Command()
+  .description('Search, read, and refresh Mux docs')
+  .action(function () {
+    this.showHelp();
+  })
+  .command('search', searchCommand)
+  .command('read', readCommand)
+  .command('update', updateCommand)
+  .command('source', sourceCommand);

--- a/src/commands/docs/read.ts
+++ b/src/commands/docs/read.ts
@@ -1,0 +1,68 @@
+import { Command } from '@cliffy/command';
+import { findDocById, loadDocsIndex, readDocContent } from '@/lib/docs.ts';
+
+interface ReadOptions {
+  format?: 'markdown' | 'raw';
+  json?: boolean;
+  source?: string;
+}
+
+export const readCommand = new Command()
+  .description('Read a Mux docs page')
+  .arguments('<doc-id:string>')
+  .option('--format <format:string>', 'Output format: markdown or raw', {
+    default: 'markdown',
+    value: (value: string): 'markdown' | 'raw' => {
+      if (value !== 'markdown' && value !== 'raw') {
+        throw new Error('Invalid format. Must be "markdown" or "raw".');
+      }
+      return value;
+    },
+  })
+  .option('--json', 'Output JSON instead of pretty format')
+  .option('--source <path:string>', 'Path to a local mux.com docs repository')
+  .action(async (options: ReadOptions, docId: string) => {
+    try {
+      const { index, source } = await loadDocsIndex({
+        explicitPath: options.source,
+      });
+      const doc = findDocById(index, docId);
+
+      if (!doc) {
+        throw new Error(`Docs page not found: ${docId}`);
+      }
+
+      const content = await readDocContent(doc);
+
+      if (options.json) {
+        console.log(
+          JSON.stringify(
+            {
+              source,
+              doc,
+              content,
+            },
+            null,
+            2,
+          ),
+        );
+        return;
+      }
+
+      console.log(content);
+    } catch (error) {
+      printDocsError(error, options);
+    }
+  });
+
+function printDocsError(error: unknown, options: ReadOptions): never {
+  const message = error instanceof Error ? error.message : String(error);
+
+  if (options.json) {
+    console.error(JSON.stringify({ error: message }, null, 2));
+  } else {
+    console.error(`Error: ${message}`);
+  }
+
+  process.exit(1);
+}

--- a/src/commands/docs/read.ts
+++ b/src/commands/docs/read.ts
@@ -1,5 +1,10 @@
 import { Command } from '@cliffy/command';
-import { findDocById, loadDocsIndex, readDocContent } from '@/lib/docs.ts';
+import {
+  findDocById,
+  formatDocContent,
+  loadDocsIndex,
+  readDocContent,
+} from '@/lib/docs.ts';
 
 interface ReadOptions {
   format?: 'markdown' | 'raw';
@@ -32,7 +37,10 @@ export const readCommand = new Command()
         throw new Error(`Docs page not found: ${docId}`);
       }
 
-      const content = await readDocContent(doc);
+      const content = formatDocContent(
+        await readDocContent(doc),
+        options.format,
+      );
 
       if (options.json) {
         console.log(

--- a/src/commands/docs/search.ts
+++ b/src/commands/docs/search.ts
@@ -1,0 +1,83 @@
+import { Command } from '@cliffy/command';
+import { loadDocsIndex, searchDocsIndex } from '@/lib/docs.ts';
+
+interface SearchOptions {
+  json?: boolean;
+  limit?: number;
+  source?: string;
+}
+
+export const searchCommand = new Command()
+  .description('Search Mux docs')
+  .arguments('<query:string>')
+  .option('--json', 'Output JSON instead of pretty format')
+  .option('--limit <number:number>', 'Number of results to return', {
+    default: 10,
+  })
+  .option('--source <path:string>', 'Path to a local mux.com docs repository')
+  .action(async (options: SearchOptions, query: string) => {
+    try {
+      const { index, source } = await loadDocsIndex({
+        explicitPath: options.source,
+      });
+      const results = searchDocsIndex(index, query, { limit: options.limit });
+
+      if (options.json) {
+        console.log(
+          JSON.stringify(
+            {
+              query,
+              source,
+              results: results.map((result) => ({
+                score: result.score,
+                snippet: result.snippet,
+                doc: {
+                  id: result.entry.id,
+                  title: result.entry.title,
+                  description: result.entry.description,
+                  product: result.entry.product,
+                  route: result.entry.route,
+                  url: result.entry.url,
+                  relativePath: result.entry.relativePath,
+                  headings: result.entry.headings,
+                },
+              })),
+            },
+            null,
+            2,
+          ),
+        );
+        return;
+      }
+
+      if (results.length === 0) {
+        console.log('No docs found.');
+        return;
+      }
+
+      for (const result of results) {
+        console.log(`${result.entry.title} (${result.entry.id})`);
+        console.log(`  ${result.entry.url}`);
+        if (result.entry.description) {
+          console.log(`  ${result.entry.description}`);
+        } else {
+          console.log(`  ${result.snippet}`);
+        }
+        console.log('');
+      }
+    } catch (error) {
+      printDocsError(error, options);
+    }
+  });
+
+function printDocsError(error: unknown, options: SearchOptions): never {
+  const message = error instanceof Error ? error.message : String(error);
+
+  if (options.json) {
+    console.error(JSON.stringify({ error: message }, null, 2));
+  } else {
+    console.error(`Error: ${message}`);
+  }
+
+  process.exit(1);
+}

--- a/src/commands/docs/source.ts
+++ b/src/commands/docs/source.ts
@@ -1,6 +1,6 @@
 import { Command } from '@cliffy/command';
 import {
-  getPublishedDocsSource,
+  getCachedDocsSource,
   hasCachedDocsIndex,
   readCachedDocsIndex,
   resolveDocsSource,
@@ -17,16 +17,22 @@ export const sourceCommand = new Command()
     try {
       if (!process.env.MUX_DOCS_PATH && hasCachedDocsIndex()) {
         const index = await readCachedDocsIndex();
-        const source = getPublishedDocsSource(index);
+        const source = getCachedDocsSource(index);
 
         if (options.json) {
           console.log(JSON.stringify(source, null, 2));
           return;
         }
 
-        console.log('Source: published');
-        console.log(`Index: ${source.indexPath}`);
-        console.log(`Manifest: ${source.manifestPath}`);
+        console.log(`Source: ${source.source}`);
+        if (source.source === 'published') {
+          console.log(`Index: ${source.indexPath}`);
+          console.log(`Manifest: ${source.manifestPath}`);
+        } else {
+          console.log(`Repository: ${source.repoPath}`);
+          console.log(`Docs root: ${source.docsRoot}`);
+          console.log(`Remote: ${source.repoUrl}`);
+        }
         console.log(`Documents: ${index.entries.length}`);
         return;
       }

--- a/src/commands/docs/source.ts
+++ b/src/commands/docs/source.ts
@@ -1,0 +1,54 @@
+import { Command } from '@cliffy/command';
+import {
+  getPublishedDocsSource,
+  hasCachedDocsIndex,
+  readCachedDocsIndex,
+  resolveDocsSource,
+} from '@/lib/docs.ts';
+
+interface SourceOptions {
+  json?: boolean;
+}
+
+export const sourceCommand = new Command()
+  .description('Show the active Mux docs source')
+  .option('--json', 'Output JSON instead of pretty format')
+  .action(async (options: SourceOptions) => {
+    try {
+      if (!process.env.MUX_DOCS_PATH && hasCachedDocsIndex()) {
+        const index = await readCachedDocsIndex();
+        const source = getPublishedDocsSource(index);
+
+        if (options.json) {
+          console.log(JSON.stringify(source, null, 2));
+          return;
+        }
+
+        console.log('Source: published');
+        console.log(`Index: ${source.indexPath}`);
+        console.log(`Manifest: ${source.manifestPath}`);
+        console.log(`Documents: ${index.entries.length}`);
+        return;
+      }
+
+      const source = await resolveDocsSource();
+
+      if (options.json) {
+        console.log(JSON.stringify(source, null, 2));
+        return;
+      }
+
+      console.log(`Source: ${source.source}`);
+      console.log(`Repository: ${source.repoPath}`);
+      console.log(`Docs root: ${source.docsRoot}`);
+      console.log(`Remote: ${source.repoUrl}`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (options.json) {
+        console.error(JSON.stringify({ error: message }, null, 2));
+      } else {
+        console.error(`Error: ${message}`);
+      }
+      process.exit(1);
+    }
+  });

--- a/src/commands/docs/update.ts
+++ b/src/commands/docs/update.ts
@@ -1,0 +1,98 @@
+import { Command } from '@cliffy/command';
+import {
+  buildDocsIndex,
+  resolveDocsSource,
+  updatePublishedDocsCache,
+  writeDocsIndexCache,
+} from '@/lib/docs.ts';
+
+interface UpdateOptions {
+  source?: string;
+  artifactPath?: string;
+  manifestUrl?: string;
+  indexUrl?: string;
+  force?: boolean;
+  json?: boolean;
+}
+
+interface UpdateOutput {
+  source: string;
+  indexedDocuments: number;
+  generatedAt: string;
+  version?: string;
+}
+
+export const updateCommand = new Command()
+  .description('Update or refresh the local Mux docs cache')
+  .option('--source <path:string>', 'Path to a local mux.com docs repository')
+  .option(
+    '--artifact-path <path:string>',
+    'Path to local generated mux docs artifacts (manifest.json and index.json)',
+  )
+  .option('--manifest-url <url:string>', 'URL for the published docs manifest')
+  .option('--index-url <url:string>', 'URL for the published docs index')
+  .option('--force', 'Refresh cached docs artifacts')
+  .option('--json', 'Output JSON instead of pretty format')
+  .action(async (options: UpdateOptions) => {
+    try {
+      const output = options.source
+        ? await updateFromLocalSource(options.source)
+        : await updateFromPublishedArtifacts(options);
+
+      if (options.json) {
+        console.log(JSON.stringify(output, null, 2));
+        return;
+      }
+
+      console.log(
+        `Updated Mux docs index with ${output.indexedDocuments} document(s).`,
+      );
+      console.log(`Source: ${output.source}`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (options.json) {
+        console.error(JSON.stringify({ error: message }, null, 2));
+      } else {
+        console.error(`Error: ${message}`);
+      }
+      process.exit(1);
+    }
+  });
+
+async function updateFromLocalSource(
+  sourcePath: string,
+): Promise<UpdateOutput> {
+  const source = await resolveDocsSource({ explicitPath: sourcePath });
+  const index = await buildDocsIndex({
+    repoPath: source.repoPath,
+    repoUrl: source.repoUrl,
+  });
+  await writeDocsIndexCache(index);
+
+  return {
+    source: source.repoPath,
+    indexedDocuments: index.entries.length,
+    generatedAt: index.generatedAt,
+    version: index.version,
+  };
+}
+
+async function updateFromPublishedArtifacts(
+  options: UpdateOptions,
+): Promise<UpdateOutput> {
+  const { manifest, index } = await updatePublishedDocsCache({
+    artifactPath: options.artifactPath,
+    manifestUrl: options.manifestUrl,
+    indexUrl: options.indexUrl,
+  });
+
+  return {
+    source:
+      options.artifactPath ??
+      process.env.MUX_DOCS_ARTIFACT_PATH ??
+      manifest.indexUrl,
+    indexedDocuments: index.entries.length,
+    generatedAt: index.generatedAt,
+    version: manifest.version,
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { assetsCommand } from './commands/assets/index.ts';
 import { completionsInstallCommand } from './commands/completions-install.ts';
 import { deliveryUsageCommand } from './commands/delivery-usage/index.ts';
 import { dimensionsCommand } from './commands/dimensions/index.ts';
+import { docsCommand } from './commands/docs/index.ts';
 import { drmConfigurationsCommand } from './commands/drm-configurations/index.ts';
 import { envCommand } from './commands/env/index.ts';
 import { errorsCommand } from './commands/errors/index.ts';
@@ -77,6 +78,7 @@ const cli = new Command()
   .command('uploads', uploadsCommand)
   .command('transcription-vocabularies', transcriptionVocabulariesCommand)
   .command('delivery-usage', deliveryUsageCommand)
+  .command('docs', docsCommand)
   .command('drm-configurations', drmConfigurationsCommand)
   .command('video-views', videoViewsCommand)
   .command('metrics', metricsCommand)

--- a/src/lib/docs.test.ts
+++ b/src/lib/docs.test.ts
@@ -4,14 +4,13 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
   buildDocsIndex,
-  DOCS_GUIDES_MDX_SPARSE_PATTERN,
   DOCS_GUIDES_RELATIVE_ROOT,
   DOCS_RELATIVE_ROOT,
   findDocById,
+  formatDocContent,
+  getCachedDocsSource,
   getDocsArtifactCachePaths,
   getDocsRepoCachePath,
-  getDocsSparseCheckoutArgs,
-  getDocsSparseCloneArgs,
   MUX_DOCS_INDEX_URL,
   MUX_DOCS_MANIFEST_URL,
   MUX_DOCS_REPO_URL,
@@ -20,6 +19,7 @@ import {
   resolveDocsSource,
   searchDocsIndex,
   updatePublishedDocsCache,
+  writeDocsIndexCache,
 } from './docs.ts';
 
 async function writeDoc(
@@ -131,34 +131,6 @@ describe('Mux docs source resolution', () => {
     await expect(
       resolveDocsSource({ explicitPath: invalidRepo, cwd: testDir }),
     ).rejects.toThrow(/apps\/web\/app\/docs/);
-  });
-});
-
-describe('Mux docs cache git arguments', () => {
-  it('uses a shallow partial sparse clone for the mux.com docs repo', () => {
-    const repoPath = '/tmp/mux-docs-cache';
-
-    expect(getDocsSparseCloneArgs(MUX_DOCS_REPO_URL, repoPath)).toEqual([
-      'clone',
-      '--depth=1',
-      '--filter=blob:none',
-      '--sparse',
-      MUX_DOCS_REPO_URL,
-      repoPath,
-    ]);
-  });
-
-  it('sets the sparse checkout to only the docs root', () => {
-    const repoPath = '/tmp/mux-docs-cache';
-
-    expect(getDocsSparseCheckoutArgs(repoPath)).toEqual([
-      '-C',
-      repoPath,
-      'sparse-checkout',
-      'set',
-      '--no-cone',
-      DOCS_GUIDES_MDX_SPARSE_PATTERN,
-    ]);
   });
 });
 
@@ -279,11 +251,62 @@ describe('Mux published docs artifacts', () => {
     const doc = findDocById(index, 'create-assets');
 
     expect(index.source).toBe('published');
+    expect(index.repoUrl).toBe(MUX_DOCS_REPO_URL);
     expect(results[0]?.entry.id).toBe('create-assets');
     expect(doc?.relativePath).toBe(
       'app/docs/_guides/developer/create-assets.mdx',
     );
     expect(doc ? await readDocContent(doc) : '').toContain('Upload and encode');
+  });
+
+  it('preserves locally generated docs indexes written to the cache', async () => {
+    const repoPath = join(testDir, 'mux.com');
+    const generatedAt = new Date().toISOString();
+    const absolutePath = join(
+      repoPath,
+      DOCS_GUIDES_RELATIVE_ROOT,
+      'developer/create-assets.mdx',
+    );
+    const localIndex = {
+      generatedAt,
+      repoPath,
+      repoUrl: MUX_DOCS_REPO_URL,
+      docsRoot: join(repoPath, DOCS_RELATIVE_ROOT),
+      source: 'local' as const,
+      entries: [
+        {
+          id: 'create-assets',
+          title: 'Create assets',
+          description: 'Create Mux video assets.',
+          product: 'video',
+          relativePath: 'apps/web/app/docs/_guides/developer/create-assets.mdx',
+          absolutePath,
+          route: '/guides/developer/create-assets',
+          url: 'https://docs.mux.com/guides/developer/create-assets',
+          headings: ['Create assets'],
+          content: '# Create assets\n\nUpload and encode video with Mux.',
+        },
+      ],
+    };
+
+    await writeDocsIndexCache(localIndex);
+
+    const index = await readCachedDocsIndex();
+    const doc = findDocById(
+      index,
+      'apps/web/app/docs/_guides/developer/create-assets.mdx',
+    );
+    const source = getCachedDocsSource(index);
+
+    expect(index).toEqual(localIndex);
+    expect(doc?.absolutePath).toBe(absolutePath);
+    expect(source).toEqual({
+      kind: 'cache',
+      source: 'cache',
+      repoPath,
+      docsRoot: join(repoPath, DOCS_RELATIVE_ROOT),
+      repoUrl: MUX_DOCS_REPO_URL,
+    });
   });
 
   it('uses public docs artifact URLs by default', async () => {
@@ -426,5 +449,24 @@ Use assets when you want to upload, ingest, encode, and play video with Mux.
 
     expect(content).toContain('title: Verify webhook signatures');
     expect(content).toContain('mux-signature');
+  });
+
+  it('formats docs content as markdown or raw MDX', () => {
+    const content = `---
+title: Verify webhook signatures
+---
+
+# Verify webhook signatures
+
+Mux includes a \`mux-signature\` header.
+`;
+
+    expect(
+      formatDocContent(content, 'markdown'),
+    ).toBe(`# Verify webhook signatures
+
+Mux includes a \`mux-signature\` header.
+`);
+    expect(formatDocContent(content, 'raw')).toBe(content);
   });
 });

--- a/src/lib/docs.test.ts
+++ b/src/lib/docs.test.ts
@@ -361,6 +361,36 @@ Use assets when you want to upload, ingest, encode, and play video with Mux.
 
     await writeDoc(
       repoPath,
+      'developer/upload-files-directly.mdx',
+      `---
+title: Upload files directly
+product: video
+description: Direct Uploads let browser clients upload video files to Mux.
+---
+
+# Upload files directly
+
+Create a direct upload when you want users to upload videos from the browser.
+`,
+    );
+
+    await writeDoc(
+      repoPath,
+      'developer/secure-video-playback.mdx',
+      `---
+title: Secure video playback
+product: video
+description: Use signed playback URLs and JWTs to protect video playback.
+---
+
+# Create a signed playback URL
+
+Use a playback ID with a signed playback policy and create a JWT playback token.
+`,
+    );
+
+    await writeDoc(
+      repoPath,
       'developer/not-indexed.md',
       '# Markdown files are not indexed or checked out for end users',
     );
@@ -385,7 +415,7 @@ Use assets when you want to upload, ingest, encode, and play video with Mux.
   it('builds an index from MDX docs under apps/web/app/docs', async () => {
     const index = await buildDocsIndex({ repoPath });
 
-    expect(index.entries).toHaveLength(2);
+    expect(index.entries).toHaveLength(4);
     expect(index.generatedAt).toBeDefined();
     expect(index.repoUrl).toBe(MUX_DOCS_REPO_URL);
 
@@ -410,10 +440,51 @@ Use assets when you want to upload, ingest, encode, and play video with Mux.
       limit: 5,
     });
 
-    expect(results).toHaveLength(1);
     expect(results[0]?.entry.id).toBe('verify-webhook-signatures');
     expect(results[0]?.score).toBeGreaterThan(0);
-    expect(results[0]?.snippet).toMatch(/HMAC|signature/i);
+    expect(results[0]?.snippet).toMatch(/HMAC|signature|signing/i);
+  });
+
+  it('normalizes natural language upload queries', async () => {
+    const index = await buildDocsIndex({ repoPath });
+    const results = searchDocsIndex(
+      index,
+      'how can users upload videos from the browser',
+      { limit: 3 },
+    );
+
+    expect(results[0]?.entry.id).toBe('upload-files-directly');
+  });
+
+  it('expands Mux product synonyms for signed playback queries', async () => {
+    const index = await buildDocsIndex({ repoPath });
+    const results = searchDocsIndex(
+      index,
+      'secure videos with jwt signed urls',
+      {
+        limit: 3,
+      },
+    );
+
+    expect(results[0]?.entry.id).toBe('secure-video-playback');
+  });
+
+  it('normalizes separators and plural terms', async () => {
+    const index = await buildDocsIndex({ repoPath });
+    const playbackResults = searchDocsIndex(index, 'playback_id policy', {
+      limit: 3,
+    });
+    const assetResults = searchDocsIndex(index, 'assets', { limit: 3 });
+
+    expect(playbackResults[0]?.entry.id).toBe('secure-video-playback');
+    expect(assetResults[0]?.entry.id).toBe('create-assets');
+  });
+
+  it('expands shorthand terms for webhook signatures', async () => {
+    const index = await buildDocsIndex({ repoPath });
+    const results = searchDocsIndex(index, 'webhook sig', { limit: 3 });
+
+    expect(results[0]?.entry.id).toBe('verify-webhook-signatures');
   });
 
   it('honors search result limits', async () => {

--- a/src/lib/docs.test.ts
+++ b/src/lib/docs.test.ts
@@ -1,0 +1,430 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  buildDocsIndex,
+  DOCS_GUIDES_MDX_SPARSE_PATTERN,
+  DOCS_GUIDES_RELATIVE_ROOT,
+  DOCS_RELATIVE_ROOT,
+  findDocById,
+  getDocsArtifactCachePaths,
+  getDocsRepoCachePath,
+  getDocsSparseCheckoutArgs,
+  getDocsSparseCloneArgs,
+  MUX_DOCS_INDEX_URL,
+  MUX_DOCS_MANIFEST_URL,
+  MUX_DOCS_REPO_URL,
+  readCachedDocsIndex,
+  readDocContent,
+  resolveDocsSource,
+  searchDocsIndex,
+  updatePublishedDocsCache,
+} from './docs.ts';
+
+async function writeDoc(
+  repoPath: string,
+  relativePath: string,
+  content: string,
+) {
+  const filePath = join(repoPath, DOCS_GUIDES_RELATIVE_ROOT, relativePath);
+  await mkdir(join(filePath, '..'), { recursive: true });
+  await writeFile(filePath, content);
+}
+
+describe('Mux docs source resolution', () => {
+  let testDir: string;
+  let originalMuxDocsPath: string | undefined;
+  let originalXdgCacheHome: string | undefined;
+
+  beforeEach(async () => {
+    testDir = await mkdtemp(join(tmpdir(), 'mux-docs-test-'));
+    originalMuxDocsPath = process.env.MUX_DOCS_PATH;
+    originalXdgCacheHome = process.env.XDG_CACHE_HOME;
+    delete process.env.MUX_DOCS_PATH;
+    process.env.XDG_CACHE_HOME = join(testDir, 'cache');
+  });
+
+  afterEach(async () => {
+    if (originalMuxDocsPath === undefined) {
+      delete process.env.MUX_DOCS_PATH;
+    } else {
+      process.env.MUX_DOCS_PATH = originalMuxDocsPath;
+    }
+
+    if (originalXdgCacheHome === undefined) {
+      delete process.env.XDG_CACHE_HOME;
+    } else {
+      process.env.XDG_CACHE_HOME = originalXdgCacheHome;
+    }
+
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  it('uses an explicit path before all other sources', async () => {
+    const explicitRepo = join(testDir, 'explicit-mux.com');
+    const envRepo = join(testDir, 'env-mux.com');
+    await mkdir(join(explicitRepo, DOCS_GUIDES_RELATIVE_ROOT), {
+      recursive: true,
+    });
+    await mkdir(join(envRepo, DOCS_GUIDES_RELATIVE_ROOT), { recursive: true });
+    process.env.MUX_DOCS_PATH = envRepo;
+
+    const source = await resolveDocsSource({
+      explicitPath: explicitRepo,
+      cwd: join(testDir, 'cli'),
+    });
+
+    expect(source).toEqual({
+      kind: 'local',
+      source: 'explicit',
+      repoPath: explicitRepo,
+      docsRoot: join(explicitRepo, DOCS_RELATIVE_ROOT),
+      repoUrl: MUX_DOCS_REPO_URL,
+    });
+  });
+
+  it('uses MUX_DOCS_PATH when no explicit path is provided', async () => {
+    const envRepo = join(testDir, 'env-mux.com');
+    await mkdir(join(envRepo, DOCS_GUIDES_RELATIVE_ROOT), { recursive: true });
+    process.env.MUX_DOCS_PATH = envRepo;
+
+    const source = await resolveDocsSource({ cwd: join(testDir, 'cli') });
+
+    expect(source.source).toBe('env');
+    expect(source.repoPath).toBe(envRepo);
+    expect(source.docsRoot).toBe(join(envRepo, DOCS_RELATIVE_ROOT));
+  });
+
+  it('auto-detects a sibling mux.com checkout for local development', async () => {
+    const workspace = join(testDir, 'mux-projects');
+    const cliRepo = join(workspace, 'cli');
+    const docsRepo = join(workspace, 'mux.com');
+    await mkdir(cliRepo, { recursive: true });
+    await mkdir(join(docsRepo, DOCS_GUIDES_RELATIVE_ROOT), {
+      recursive: true,
+    });
+
+    const source = await resolveDocsSource({ cwd: cliRepo });
+
+    expect(source.source).toBe('sibling');
+    expect(source.repoPath).toBe(docsRepo);
+    expect(source.docsRoot).toBe(join(docsRepo, DOCS_RELATIVE_ROOT));
+  });
+
+  it('falls back to the XDG docs repo cache path', async () => {
+    const source = await resolveDocsSource({ cwd: join(testDir, 'other') });
+
+    expect(source.kind).toBe('cache');
+    expect(source.source).toBe('cache');
+    expect(source.repoPath).toBe(getDocsRepoCachePath());
+    expect(source.docsRoot).toBe(
+      join(getDocsRepoCachePath(), DOCS_RELATIVE_ROOT),
+    );
+    expect(source.repoUrl).toBe(MUX_DOCS_REPO_URL);
+  });
+
+  it('rejects configured paths that do not contain the docs root', async () => {
+    const invalidRepo = join(testDir, 'not-docs');
+    await mkdir(invalidRepo, { recursive: true });
+
+    await expect(
+      resolveDocsSource({ explicitPath: invalidRepo, cwd: testDir }),
+    ).rejects.toThrow(/apps\/web\/app\/docs/);
+  });
+});
+
+describe('Mux docs cache git arguments', () => {
+  it('uses a shallow partial sparse clone for the mux.com docs repo', () => {
+    const repoPath = '/tmp/mux-docs-cache';
+
+    expect(getDocsSparseCloneArgs(MUX_DOCS_REPO_URL, repoPath)).toEqual([
+      'clone',
+      '--depth=1',
+      '--filter=blob:none',
+      '--sparse',
+      MUX_DOCS_REPO_URL,
+      repoPath,
+    ]);
+  });
+
+  it('sets the sparse checkout to only the docs root', () => {
+    const repoPath = '/tmp/mux-docs-cache';
+
+    expect(getDocsSparseCheckoutArgs(repoPath)).toEqual([
+      '-C',
+      repoPath,
+      'sparse-checkout',
+      'set',
+      '--no-cone',
+      DOCS_GUIDES_MDX_SPARSE_PATTERN,
+    ]);
+  });
+});
+
+describe('Mux published docs artifacts', () => {
+  let testDir: string;
+  let originalXdgCacheHome: string | undefined;
+
+  beforeEach(async () => {
+    testDir = await mkdtemp(join(tmpdir(), 'mux-docs-artifact-test-'));
+    originalXdgCacheHome = process.env.XDG_CACHE_HOME;
+    process.env.XDG_CACHE_HOME = join(testDir, 'cache');
+  });
+
+  afterEach(async () => {
+    if (originalXdgCacheHome === undefined) {
+      delete process.env.XDG_CACHE_HOME;
+    } else {
+      process.env.XDG_CACHE_HOME = originalXdgCacheHome;
+    }
+
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  it('copies published manifest and index artifacts into the CLI cache', async () => {
+    const artifactPath = join(testDir, 'artifacts');
+    await mkdir(artifactPath, { recursive: true });
+
+    const manifest = {
+      version: 'abc123',
+      commit: 'commit123',
+      generatedAt: '2026-05-18T00:00:00.000Z',
+      docsRoot: 'app/docs/_guides',
+      indexUrl: MUX_DOCS_INDEX_URL,
+      fileCount: 1,
+      files: [
+        {
+          id: 'verify-webhook-signatures',
+          path: 'app/docs/_guides/core/verify-webhook-signatures.mdx',
+          route: '/guides/core/verify-webhook-signatures',
+          url: 'https://docs.mux.com/guides/core/verify-webhook-signatures',
+          sha256: 'hash123',
+        },
+      ],
+    };
+    const publishedIndex = {
+      version: 'abc123',
+      commit: 'commit123',
+      generatedAt: '2026-05-18T00:00:00.000Z',
+      docsRoot: 'app/docs/_guides',
+      entries: [
+        {
+          id: 'verify-webhook-signatures',
+          title: 'Verify webhook signatures',
+          description: 'Verify webhook requests from Mux.',
+          product: 'system',
+          path: 'app/docs/_guides/core/verify-webhook-signatures.mdx',
+          route: '/guides/core/verify-webhook-signatures',
+          url: 'https://docs.mux.com/guides/core/verify-webhook-signatures',
+          headings: ['Obtain your signing secret'],
+          sha256: 'hash123',
+          content:
+            '---\ntitle: Verify webhook signatures\n---\n\nMux signature docs.',
+        },
+      ],
+    };
+
+    await writeFile(
+      join(artifactPath, 'manifest.json'),
+      JSON.stringify(manifest, null, 2),
+    );
+    await writeFile(
+      join(artifactPath, 'index.json'),
+      JSON.stringify(publishedIndex, null, 2),
+    );
+
+    const result = await updatePublishedDocsCache({ artifactPath });
+    const cachePaths = getDocsArtifactCachePaths();
+
+    expect(result.manifest.version).toBe('abc123');
+    expect(result.index.entries).toHaveLength(1);
+    expect(
+      JSON.parse(await readFile(cachePaths.manifestPath, 'utf-8')),
+    ).toEqual(manifest);
+    expect(JSON.parse(await readFile(cachePaths.indexPath, 'utf-8'))).toEqual(
+      publishedIndex,
+    );
+  });
+
+  it('normalizes cached published index entries for search and read', async () => {
+    const cachePaths = getDocsArtifactCachePaths();
+    await mkdir(join(cachePaths.indexPath, '..'), { recursive: true });
+    await writeFile(
+      cachePaths.indexPath,
+      JSON.stringify({
+        version: 'abc123',
+        commit: 'commit123',
+        generatedAt: '2026-05-18T00:00:00.000Z',
+        docsRoot: 'app/docs/_guides',
+        entries: [
+          {
+            id: 'create-assets',
+            title: 'Create assets',
+            description: 'Create Mux video assets.',
+            product: 'video',
+            path: 'app/docs/_guides/developer/create-assets.mdx',
+            route: '/guides/developer/create-assets',
+            url: 'https://docs.mux.com/guides/developer/create-assets',
+            headings: ['Create assets'],
+            sha256: 'hash123',
+            content: '# Create assets\n\nUpload and encode video with Mux.',
+          },
+        ],
+      }),
+    );
+
+    const index = await readCachedDocsIndex();
+    const results = searchDocsIndex(index, 'upload encode video', { limit: 1 });
+    const doc = findDocById(index, 'create-assets');
+
+    expect(index.source).toBe('published');
+    expect(results[0]?.entry.id).toBe('create-assets');
+    expect(doc?.relativePath).toBe(
+      'app/docs/_guides/developer/create-assets.mdx',
+    );
+    expect(doc ? await readDocContent(doc) : '').toContain('Upload and encode');
+  });
+
+  it('uses public docs artifact URLs by default', async () => {
+    expect(MUX_DOCS_MANIFEST_URL).toBe(
+      'https://docs.mux.com/.well-known/mux-docs/manifest.json',
+    );
+    expect(MUX_DOCS_INDEX_URL).toBe(
+      'https://docs.mux.com/.well-known/mux-docs/index.json',
+    );
+  });
+});
+
+describe('Mux docs indexing and lookup', () => {
+  let repoPath: string;
+
+  beforeEach(async () => {
+    repoPath = await mkdtemp(join(tmpdir(), 'mux-docs-index-test-'));
+
+    await writeDoc(
+      repoPath,
+      'core/verify-webhook-signatures.mdx',
+      `---
+title: Verify webhook signatures
+product: system
+description: Verify webhook requests that Mux sends to your endpoints.
+---
+
+## Obtain your signing secret
+
+Mux includes a \`mux-signature\` header with the timestamp and signature.
+
+## How to verify webhook signatures
+
+Compute an HMAC with SHA-256 and compare it to the request signature.
+`,
+    );
+
+    await writeDoc(
+      repoPath,
+      'developer/create-assets.mdx',
+      `---
+title: Create assets
+product: video
+description: Create Mux video assets from remote URLs or direct uploads.
+---
+
+# Create assets
+
+Use assets when you want to upload, ingest, encode, and play video with Mux.
+`,
+    );
+
+    await writeDoc(
+      repoPath,
+      'developer/not-indexed.md',
+      '# Markdown files are not indexed or checked out for end users',
+    );
+    await mkdir(join(repoPath, DOCS_RELATIVE_ROOT, 'other'), {
+      recursive: true,
+    });
+    await writeFile(
+      join(repoPath, DOCS_RELATIVE_ROOT, 'other', 'not-indexed.mdx'),
+      '# MDX outside _guides should not be indexed',
+    );
+    await mkdir(join(repoPath, 'node_modules', 'ignored'), { recursive: true });
+    await writeFile(
+      join(repoPath, 'node_modules', 'ignored', 'README.md'),
+      '# Should not be indexed',
+    );
+  });
+
+  afterEach(async () => {
+    await rm(repoPath, { recursive: true, force: true });
+  });
+
+  it('builds an index from MDX docs under apps/web/app/docs', async () => {
+    const index = await buildDocsIndex({ repoPath });
+
+    expect(index.entries).toHaveLength(2);
+    expect(index.generatedAt).toBeDefined();
+    expect(index.repoUrl).toBe(MUX_DOCS_REPO_URL);
+
+    const webhookDoc = index.entries.find(
+      (entry) => entry.id === 'verify-webhook-signatures',
+    );
+    expect(webhookDoc).toMatchObject({
+      title: 'Verify webhook signatures',
+      product: 'system',
+      description: 'Verify webhook requests that Mux sends to your endpoints.',
+      relativePath:
+        'apps/web/app/docs/_guides/core/verify-webhook-signatures.mdx',
+      route: '/guides/core/verify-webhook-signatures',
+      url: 'https://docs.mux.com/guides/core/verify-webhook-signatures',
+    });
+    expect(webhookDoc?.headings).toContain('Obtain your signing secret');
+  });
+
+  it('searches docs by title, description, headings, and content', async () => {
+    const index = await buildDocsIndex({ repoPath });
+    const results = searchDocsIndex(index, 'webhook signature hmac', {
+      limit: 5,
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.entry.id).toBe('verify-webhook-signatures');
+    expect(results[0]?.score).toBeGreaterThan(0);
+    expect(results[0]?.snippet).toMatch(/HMAC|signature/i);
+  });
+
+  it('honors search result limits', async () => {
+    const index = await buildDocsIndex({ repoPath });
+    const results = searchDocsIndex(index, 'mux video', { limit: 1 });
+
+    expect(results).toHaveLength(1);
+  });
+
+  it('finds docs by id, route, or relative path', async () => {
+    const index = await buildDocsIndex({ repoPath });
+
+    expect(findDocById(index, 'create-assets')?.title).toBe('Create assets');
+    expect(findDocById(index, '/guides/developer/create-assets')?.title).toBe(
+      'Create assets',
+    );
+    expect(
+      findDocById(
+        index,
+        'apps/web/app/docs/_guides/developer/create-assets.mdx',
+      )?.title,
+    ).toBe('Create assets');
+  });
+
+  it('reads raw markdown content for a selected doc', async () => {
+    const index = await buildDocsIndex({ repoPath });
+    const doc = findDocById(index, 'verify-webhook-signatures');
+
+    if (!doc) {
+      throw new Error('Expected verify-webhook-signatures doc to exist');
+    }
+    const content = await readDocContent(doc);
+
+    expect(content).toContain('title: Verify webhook signatures');
+    expect(content).toContain('mux-signature');
+  });
+});

--- a/src/lib/docs.ts
+++ b/src/lib/docs.ts
@@ -1,11 +1,10 @@
 import { existsSync } from 'node:fs';
-import { mkdir, readdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdir, readdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname, extname, join, relative, resolve } from 'node:path';
 import { getCacheDir } from './xdg.ts';
 
 export const DOCS_RELATIVE_ROOT = 'apps/web/app/docs';
 export const DOCS_GUIDES_RELATIVE_ROOT = `${DOCS_RELATIVE_ROOT}/_guides`;
-export const DOCS_GUIDES_MDX_SPARSE_PATTERN = `/${DOCS_GUIDES_RELATIVE_ROOT}/**/*.mdx`;
 export const MUX_DOCS_REPO_URL = 'https://github.com/muxinc/mux.com.git';
 export const DOCS_BASE_URL = 'https://docs.mux.com';
 export const MUX_DOCS_MANIFEST_URL = `${DOCS_BASE_URL}/.well-known/mux-docs/manifest.json`;
@@ -121,16 +120,19 @@ export interface SearchDocsIndexOptions {
   limit?: number;
 }
 
-/**
- * Get the cache checkout path for the mux.com docs repository.
- */
+export type DocsContentFormat = 'markdown' | 'raw';
+
+interface JsonFetchResponse {
+  ok: boolean;
+  status: number;
+  text(): Promise<string>;
+  json(): Promise<unknown>;
+}
+
 export function getDocsRepoCachePath(): string {
   return join(getCacheDir(), 'docs', 'mux.com');
 }
 
-/**
- * Get the path where the generated docs search index is cached.
- */
 export function getDocsIndexCachePath(): string {
   return join(getCacheDir(), 'docs', 'index.json');
 }
@@ -177,10 +179,10 @@ export async function updatePublishedDocsCache(
 
 export async function readCachedDocsIndex(): Promise<DocsIndex> {
   const cachePaths = getDocsArtifactCachePaths();
-  const publishedIndex = await readJson<PublishedDocsIndex>(
+  const cachedIndex = await readJson<PublishedDocsIndex | DocsIndex>(
     cachePaths.indexPath,
   );
-  return normalizePublishedDocsIndex(publishedIndex, cachePaths.indexPath);
+  return normalizeCachedDocsIndex(cachedIndex, cachePaths.indexPath);
 }
 
 export function hasCachedDocsIndex(): boolean {
@@ -200,6 +202,45 @@ export function getPublishedDocsSource(index: DocsIndex): PublishedDocsSource {
   };
 }
 
+export function getCachedDocsSource(index: DocsIndex): DocsIndexSource {
+  if (index.source === 'published') {
+    return getPublishedDocsSource(index);
+  }
+
+  return {
+    kind: 'cache',
+    source: 'cache',
+    repoPath: index.repoPath,
+    docsRoot: index.docsRoot,
+    repoUrl: index.repoUrl,
+  };
+}
+
+function normalizeCachedDocsIndex(
+  index: PublishedDocsIndex | DocsIndex,
+  cachePath: string,
+): DocsIndex {
+  if (isDocsIndex(index)) {
+    return index;
+  }
+
+  return normalizePublishedDocsIndex(index, cachePath);
+}
+
+function isDocsIndex(
+  index: PublishedDocsIndex | DocsIndex,
+): index is DocsIndex {
+  const firstEntry = index.entries[0];
+
+  return (
+    'repoPath' in index &&
+    'repoUrl' in index &&
+    'docsRoot' in index &&
+    (firstEntry === undefined ||
+      ('relativePath' in firstEntry && 'absolutePath' in firstEntry))
+  );
+}
+
 function normalizePublishedDocsIndex(
   index: PublishedDocsIndex,
   cachePath: string,
@@ -207,7 +248,7 @@ function normalizePublishedDocsIndex(
   return {
     generatedAt: index.generatedAt,
     repoPath: dirname(cachePath),
-    repoUrl: MUX_DOCS_INDEX_URL,
+    repoUrl: MUX_DOCS_REPO_URL,
     docsRoot: index.docsRoot,
     source: 'published',
     version: index.version,
@@ -232,57 +273,19 @@ async function readJson<T>(path: string): Promise<T> {
 }
 
 async function fetchJson<T>(url: string): Promise<T> {
-  const response = await fetch(url);
+  const response = (await fetch(url)) as unknown as JsonFetchResponse;
 
   if (!response.ok) {
-    throw new Error(`Failed to fetch ${url}: ${response.status}`);
+    const body = await response.text();
+    const details = body.trim();
+    throw new Error(
+      `Failed to fetch ${url}: ${response.status}${details ? ` ${details}` : ''}`,
+    );
   }
 
   return (await response.json()) as T;
 }
 
-/**
- * Git arguments for a shallow, partial, sparse clone of the mux.com repository.
- *
- * This avoids checking out or downloading blobs for the rest of the application
- * repository. Git may still download commit and tree metadata, but file content
- * outside MDX files under DOCS_GUIDES_RELATIVE_ROOT is not fetched into the
- * local checkout.
- */
-export function getDocsSparseCloneArgs(
-  repoUrl: string,
-  repoPath: string,
-): string[] {
-  return [
-    'clone',
-    '--depth=1',
-    '--filter=blob:none',
-    '--sparse',
-    repoUrl,
-    repoPath,
-  ];
-}
-
-export function getDocsSparseCheckoutArgs(repoPath: string): string[] {
-  return [
-    '-C',
-    repoPath,
-    'sparse-checkout',
-    'set',
-    '--no-cone',
-    DOCS_GUIDES_MDX_SPARSE_PATTERN,
-  ];
-}
-
-/**
- * Resolve the docs source for the current command.
- *
- * Precedence:
- * 1. Explicit command option
- * 2. MUX_DOCS_PATH
- * 3. Sibling ../mux.com checkout for local Mux development
- * 4. XDG cache checkout used by `mux docs update`
- */
 export async function resolveDocsSource(
   options: ResolveDocsSourceOptions = {},
 ): Promise<DocsSource> {
@@ -351,84 +354,6 @@ function hasDocsRoot(repoPath: string): boolean {
 }
 
 /**
- * Clone or refresh the cached mux.com checkout used as the default docs source.
- */
-export async function updateCachedDocsRepo(
-  options: { force?: boolean; repoUrl?: string } = {},
-): Promise<DocsSource> {
-  const repoUrl = options.repoUrl ?? MUX_DOCS_REPO_URL;
-  const repoPath = getDocsRepoCachePath();
-
-  if (options.force) {
-    await rm(repoPath, { recursive: true, force: true });
-  }
-
-  if (existsSync(join(repoPath, '.git'))) {
-    if (!(await isSparseDocsCheckout(repoPath))) {
-      await rm(repoPath, { recursive: true, force: true });
-      await cloneSparseDocsRepo(repoUrl, repoPath);
-    } else {
-      await runGit(getDocsSparseCheckoutArgs(repoPath));
-      await runGit(['-C', repoPath, 'pull', '--ff-only']);
-    }
-  } else {
-    await rm(repoPath, { recursive: true, force: true });
-    await cloneSparseDocsRepo(repoUrl, repoPath);
-  }
-
-  if (!hasDocsRoot(repoPath)) {
-    throw new Error(
-      `The docs repository did not contain ${DOCS_GUIDES_RELATIVE_ROOT}: ${repoPath}`,
-    );
-  }
-
-  return {
-    kind: 'cache',
-    source: 'cache',
-    repoPath,
-    docsRoot: join(repoPath, DOCS_RELATIVE_ROOT),
-    repoUrl,
-  };
-}
-
-async function cloneSparseDocsRepo(
-  repoUrl: string,
-  repoPath: string,
-): Promise<void> {
-  await mkdir(dirname(repoPath), { recursive: true });
-  await runGit(getDocsSparseCloneArgs(repoUrl, repoPath));
-  await runGit(getDocsSparseCheckoutArgs(repoPath));
-}
-
-async function isSparseDocsCheckout(repoPath: string): Promise<boolean> {
-  const sparseCheckoutPath = join(repoPath, '.git', 'info', 'sparse-checkout');
-
-  if (!existsSync(sparseCheckoutPath)) {
-    return false;
-  }
-
-  const content = await readFile(sparseCheckoutPath, 'utf-8');
-  return content.includes(DOCS_GUIDES_MDX_SPARSE_PATTERN);
-}
-
-async function runGit(args: string[]): Promise<void> {
-  const proc = Bun.spawn(['git', ...args], {
-    stdout: 'pipe',
-    stderr: 'pipe',
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
-    proc.exited,
-  ]);
-
-  if (exitCode !== 0) {
-    const message = stderr.trim() || stdout.trim() || `git ${args.join(' ')}`;
-    throw new Error(message);
-  }
-}
-
-/**
  * Build a lightweight local search index from docs markdown and MDX files.
  */
 export async function loadDocsIndex(
@@ -440,7 +365,7 @@ export async function loadDocsIndex(
     hasCachedDocsIndex()
   ) {
     const index = await readCachedDocsIndex();
-    return { index, source: getPublishedDocsSource(index) };
+    return { index, source: getCachedDocsSource(index) };
   }
 
   const source = await resolveDocsSource({
@@ -604,9 +529,6 @@ function toPosixPath(path: string): string {
   return path.split('\\').join('/');
 }
 
-/**
- * Search a generated docs index using simple deterministic term scoring.
- */
 export function searchDocsIndex(
   index: DocsIndex,
   query: string,
@@ -750,6 +672,27 @@ export async function readDocContent(entry: DocsIndexEntry): Promise<string> {
   }
 
   return readFile(entry.absolutePath, 'utf-8');
+}
+
+export function formatDocContent(
+  content: string,
+  format: DocsContentFormat = 'markdown',
+): string {
+  if (format === 'raw') {
+    return content;
+  }
+
+  return stripFrontmatterBlock(content);
+}
+
+function stripFrontmatterBlock(content: string): string {
+  const match = content.match(/^---\r?\n[\s\S]*?\r?\n---[ \t]*(?:\r?\n|$)/);
+
+  if (!match) {
+    return content;
+  }
+
+  return content.slice(match[0].length).replace(/^\s*\r?\n/, '');
 }
 
 export async function writeDocsIndexCache(index: DocsIndex): Promise<void> {

--- a/src/lib/docs.ts
+++ b/src/lib/docs.ts
@@ -353,9 +353,6 @@ function hasDocsRoot(repoPath: string): boolean {
   return existsSync(join(repoPath, DOCS_GUIDES_RELATIVE_ROOT));
 }
 
-/**
- * Build a lightweight local search index from docs markdown and MDX files.
- */
 export async function loadDocsIndex(
   options: { explicitPath?: string } = {},
 ): Promise<{ index: DocsIndex; source: DocsIndexSource }> {
@@ -534,19 +531,19 @@ export function searchDocsIndex(
   query: string,
   options: SearchDocsIndexOptions = {},
 ): DocsSearchResult[] {
-  const terms = tokenize(query);
-  if (terms.length === 0) return [];
+  const normalizedQuery = normalizeDocsSearchQuery(query);
+  if (normalizedQuery.terms.length === 0) return [];
 
   const results: DocsSearchResult[] = [];
 
   for (const entry of index.entries) {
-    const score = scoreEntry(entry, terms, query);
+    const score = scoreEntry(entry, normalizedQuery);
     if (score <= 0) continue;
 
     results.push({
       entry,
       score,
-      snippet: makeSnippet(entry, terms),
+      snippet: makeSnippet(entry, normalizedQuery),
     });
   }
 
@@ -556,10 +553,94 @@ export function searchDocsIndex(
   return results.slice(0, options.limit ?? 10);
 }
 
+interface NormalizedDocsSearchQuery {
+  terms: string[];
+  phrases: string[];
+}
+
+const STOP_WORDS = new Set([
+  'a',
+  'about',
+  'an',
+  'and',
+  'are',
+  'as',
+  'at',
+  'be',
+  'can',
+  'do',
+  'does',
+  'for',
+  'from',
+  'get',
+  'how',
+  'i',
+  'in',
+  'is',
+  'it',
+  'me',
+  'my',
+  'of',
+  'on',
+  'or',
+  'the',
+  'to',
+  'use',
+  'using',
+  'with',
+]);
+
+const SHORT_SEARCH_TERMS = new Set([
+  'ai',
+  'api',
+  'drm',
+  'hls',
+  'id',
+  'jwt',
+  'mp4',
+  'sdk',
+  'srt',
+]);
+
+const TERM_SYNONYMS: Record<string, string[]> = {
+  browser: ['direct', 'upload'],
+  caption: ['subtitle', 'subtitles', 'text', 'track', 'transcript'],
+  captions: ['subtitle', 'subtitles', 'text', 'track', 'transcript'],
+  drm: ['digital', 'rights', 'management', 'protected'],
+  hls: ['playback', 'streaming', 'm3u8'],
+  jwt: ['signed', 'playback', 'token', 'url'],
+  sig: ['signature', 'mux', 'hmac'],
+  signature: ['mux', 'hmac'],
+  signatures: ['signature', 'mux', 'hmac'],
+  subtitle: ['caption', 'captions', 'text', 'track', 'transcript'],
+  subtitles: ['caption', 'captions', 'text', 'track', 'transcript'],
+  token: ['jwt', 'signed'],
+  tokens: ['jwt', 'signed'],
+  transcript: ['captions', 'subtitles', 'text', 'track'],
+};
+
+const PHRASE_SYNONYMS: Array<[string, string[]]> = [
+  [
+    'webhook sig',
+    ['webhook signature', 'mux signature', 'mux-signature', 'hmac'],
+  ],
+  ['webhook signature', ['mux-signature', 'hmac']],
+  ['signed url', ['signed playback', 'playback token', 'jwt']],
+  ['signed urls', ['signed playback', 'playback token', 'jwt']],
+  ['signed playback', ['jwt', 'playback token', 'signed url']],
+  ['playback id', ['playback-id', 'playback_id', 'playback ids']],
+  ['playback ids', ['playback-id', 'playback_id', 'playback id']],
+  ['direct upload', ['browser upload', 'upload files directly']],
+  ['browser upload', ['direct upload', 'upload files directly']],
+  ['upload from browser', ['direct upload', 'upload files directly']],
+  ['stream key', ['live stream', 'rtmp']],
+  ['live stream', ['stream key', 'rtmp', 'broadcast']],
+  ['text track', ['captions', 'subtitles', 'transcripts']],
+];
+
 function scoreEntry(
   entry: DocsIndexEntry,
-  terms: string[],
-  query: string,
+  query: NormalizedDocsSearchQuery,
 ): number {
   const fields = [
     { value: entry.title, weight: 8 },
@@ -567,42 +648,42 @@ function scoreEntry(
     { value: entry.headings.join(' '), weight: 4 },
     { value: entry.id, weight: 3 },
     { value: entry.content, weight: 1 },
-  ];
+  ].map((field) => ({
+    value: normalizeSearchText(field.value),
+    weight: field.weight,
+  }));
 
   let score = 0;
-  for (const term of terms) {
+  for (const term of query.terms) {
     for (const field of fields) {
-      score += countOccurrences(field.value, term) * field.weight;
+      score += countTermOccurrences(field.value, term) * field.weight;
     }
   }
 
-  const phrase = query.toLowerCase().trim();
-  if (phrase) {
-    if (entry.title.toLowerCase().includes(phrase)) score += 50;
-    if ((entry.description ?? '').toLowerCase().includes(phrase)) score += 25;
-    if (entry.headings.join(' ').toLowerCase().includes(phrase)) score += 20;
-    if (entry.content.toLowerCase().includes(phrase)) score += 5;
+  for (const phrase of query.phrases) {
+    for (const field of fields) {
+      if (field.value.includes(phrase)) {
+        score += field.weight * phrase.split(' ').length * 6;
+      }
+    }
   }
 
   return score;
 }
 
-function countOccurrences(value: string, term: string): number {
+function countTermOccurrences(value: string, term: string): number {
   if (!value) return 0;
 
-  const normalized = value.toLowerCase();
-  let count = 0;
-  let index = normalized.indexOf(term);
-
-  while (index !== -1) {
-    count += 1;
-    index = normalized.indexOf(term, index + term.length);
-  }
-
-  return count;
+  const escapedTerm = term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return Array.from(
+    value.matchAll(new RegExp(`(?:^|\\s)${escapedTerm}(?=\\s|$)`, 'g')),
+  ).length;
 }
 
-function makeSnippet(entry: DocsIndexEntry, terms: string[]): string {
+function makeSnippet(
+  entry: DocsIndexEntry,
+  query: NormalizedDocsSearchQuery,
+): string {
   const lines = entry.content
     .replace(/^---[\s\S]*?---\s*/, '')
     .split('\n')
@@ -610,8 +691,11 @@ function makeSnippet(entry: DocsIndexEntry, terms: string[]): string {
     .filter(Boolean);
 
   const matchingLine = lines.find((line) => {
-    const normalized = line.toLowerCase();
-    return terms.some((term) => normalized.includes(term));
+    const normalized = normalizeSearchText(line);
+    return (
+      query.phrases.some((phrase) => normalized.includes(phrase)) ||
+      query.terms.some((term) => normalized.includes(term))
+    );
   });
 
   return truncate(matchingLine ?? entry.description ?? entry.title, 220);
@@ -622,21 +706,98 @@ function truncate(value: string, maxLength: number): string {
   return `${value.slice(0, maxLength - 1)}…`;
 }
 
-function tokenize(query: string): string[] {
-  return Array.from(
-    new Set(
-      query
-        .toLowerCase()
-        .split(/[^a-z0-9_/-]+/)
-        .map((term) => term.trim())
-        .filter(Boolean),
+function normalizeDocsSearchQuery(query: string): NormalizedDocsSearchQuery {
+  const normalized = normalizeSearchText(query);
+  const terms = new Set(tokenizeNormalizedText(normalized));
+  const phrases = new Set<string>([normalized].filter(Boolean));
+
+  for (const term of Array.from(terms)) {
+    for (const synonym of TERM_SYNONYMS[term] ?? []) {
+      for (const synonymTerm of tokenizeNormalizedText(
+        normalizeSearchText(synonym),
+      )) {
+        terms.add(synonymTerm);
+      }
+    }
+  }
+
+  for (const [phrase, synonyms] of PHRASE_SYNONYMS) {
+    const normalizedPhrase = normalizeSearchText(phrase);
+    if (!normalized.includes(normalizedPhrase)) continue;
+
+    addPhraseWithTerms(normalizedPhrase, phrases, terms);
+    for (const synonym of synonyms) {
+      addPhraseWithTerms(normalizeSearchText(synonym), phrases, terms);
+    }
+  }
+
+  if (
+    terms.has('upload') &&
+    ['browser', 'web', 'client', 'user'].some((term) => terms.has(term))
+  ) {
+    addPhraseWithTerms('direct upload', phrases, terms);
+    addPhraseWithTerms('upload files directly', phrases, terms);
+  }
+
+  return {
+    terms: Array.from(terms),
+    phrases: Array.from(phrases).filter(
+      (phrase) => phrase.split(' ').length > 1,
     ),
-  );
+  };
 }
 
-/**
- * Find a docs entry by id, route, URL, or repository-relative path.
- */
+function addPhraseWithTerms(
+  phrase: string,
+  phrases: Set<string>,
+  terms: Set<string>,
+): void {
+  if (!phrase) return;
+
+  phrases.add(phrase);
+  for (const phraseTerm of tokenizeNormalizedText(phrase)) {
+    terms.add(phraseTerm);
+  }
+}
+
+function normalizeSearchText(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[_/-]+/g, ' ')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim()
+    .replace(/\s+/g, ' ');
+}
+
+function tokenizeNormalizedText(value: string): string[] {
+  const terms = new Set<string>();
+
+  for (const term of value.split(' ')) {
+    if (!isSearchableTerm(term)) continue;
+
+    terms.add(term);
+    const stemmed = stemSearchTerm(term);
+    if (stemmed !== term && isSearchableTerm(stemmed)) {
+      terms.add(stemmed);
+    }
+  }
+
+  return Array.from(terms);
+}
+
+function isSearchableTerm(term: string): boolean {
+  if (!term || STOP_WORDS.has(term)) return false;
+  return term.length > 2 || SHORT_SEARCH_TERMS.has(term);
+}
+
+function stemSearchTerm(term: string): string {
+  if (term.length <= 3) return term;
+  if (term.endsWith('ies') && term.length > 4) return `${term.slice(0, -3)}y`;
+  if (term.endsWith('sses')) return term.slice(0, -2);
+  if (term.endsWith('s') && !term.endsWith('ss')) return term.slice(0, -1);
+  return term;
+}
+
 export function findDocById(
   index: DocsIndex,
   idOrPath: string,
@@ -663,9 +824,6 @@ function normalizeIdentifier(value: string): string {
     .replace(/^\/+/, '');
 }
 
-/**
- * Read raw markdown/MDX content for an indexed docs entry.
- */
 export async function readDocContent(entry: DocsIndexEntry): Promise<string> {
   if (entry.content) {
     return entry.content;

--- a/src/lib/docs.ts
+++ b/src/lib/docs.ts
@@ -1,0 +1,759 @@
+import { existsSync } from 'node:fs';
+import { mkdir, readdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { dirname, extname, join, relative, resolve } from 'node:path';
+import { getCacheDir } from './xdg.ts';
+
+export const DOCS_RELATIVE_ROOT = 'apps/web/app/docs';
+export const DOCS_GUIDES_RELATIVE_ROOT = `${DOCS_RELATIVE_ROOT}/_guides`;
+export const DOCS_GUIDES_MDX_SPARSE_PATTERN = `/${DOCS_GUIDES_RELATIVE_ROOT}/**/*.mdx`;
+export const MUX_DOCS_REPO_URL = 'https://github.com/muxinc/mux.com.git';
+export const DOCS_BASE_URL = 'https://docs.mux.com';
+export const MUX_DOCS_MANIFEST_URL = `${DOCS_BASE_URL}/.well-known/mux-docs/manifest.json`;
+export const MUX_DOCS_INDEX_URL = `${DOCS_BASE_URL}/.well-known/mux-docs/index.json`;
+
+const SKIPPED_DIRECTORIES = new Set([
+  '.git',
+  '.next',
+  '.turbo',
+  'dist',
+  'node_modules',
+]);
+
+export interface ResolveDocsSourceOptions {
+  explicitPath?: string;
+  cwd?: string;
+  repoUrl?: string;
+}
+
+export interface DocsSource {
+  kind: 'local' | 'cache';
+  source: 'explicit' | 'env' | 'sibling' | 'cache';
+  repoPath: string;
+  docsRoot: string;
+  repoUrl: string;
+}
+
+export interface PublishedDocsSource {
+  kind: 'cache';
+  source: 'published';
+  indexPath: string;
+  manifestPath: string;
+  version?: string;
+  generatedAt: string;
+  documents: number;
+}
+
+export type DocsIndexSource = DocsSource | PublishedDocsSource;
+
+export interface BuildDocsIndexOptions {
+  repoPath: string;
+  repoUrl?: string;
+}
+
+export interface PublishedDocsManifest {
+  version: string;
+  commit?: string | null;
+  generatedAt: string;
+  docsRoot: string;
+  indexUrl: string;
+  fileCount: number;
+  files: Array<{
+    id: string;
+    path: string;
+    route: string;
+    url: string;
+    sha256: string;
+  }>;
+}
+
+export interface PublishedDocsIndexEntry {
+  id: string;
+  title: string;
+  description?: string;
+  product?: string;
+  path: string;
+  route: string;
+  url: string;
+  headings: string[];
+  sha256: string;
+  content: string;
+}
+
+export interface PublishedDocsIndex {
+  version: string;
+  commit?: string | null;
+  generatedAt: string;
+  docsRoot: string;
+  entries: PublishedDocsIndexEntry[];
+}
+
+export interface DocsIndexEntry {
+  id: string;
+  title: string;
+  description?: string;
+  product?: string;
+  relativePath: string;
+  absolutePath: string;
+  route: string;
+  url: string;
+  headings: string[];
+  content: string;
+}
+
+export interface DocsIndex {
+  generatedAt: string;
+  repoPath: string;
+  repoUrl: string;
+  docsRoot: string;
+  entries: DocsIndexEntry[];
+  source?: 'local' | 'published';
+  version?: string;
+  commit?: string | null;
+}
+
+export interface DocsSearchResult {
+  entry: DocsIndexEntry;
+  score: number;
+  snippet: string;
+}
+
+export interface SearchDocsIndexOptions {
+  limit?: number;
+}
+
+/**
+ * Get the cache checkout path for the mux.com docs repository.
+ */
+export function getDocsRepoCachePath(): string {
+  return join(getCacheDir(), 'docs', 'mux.com');
+}
+
+/**
+ * Get the path where the generated docs search index is cached.
+ */
+export function getDocsIndexCachePath(): string {
+  return join(getCacheDir(), 'docs', 'index.json');
+}
+
+export function getDocsArtifactCachePaths(): {
+  manifestPath: string;
+  indexPath: string;
+} {
+  return {
+    manifestPath: join(getCacheDir(), 'docs', 'manifest.json'),
+    indexPath: getDocsIndexCachePath(),
+  };
+}
+
+export async function updatePublishedDocsCache(
+  options: {
+    artifactPath?: string;
+    manifestUrl?: string;
+    indexUrl?: string;
+  } = {},
+): Promise<{ manifest: PublishedDocsManifest; index: PublishedDocsIndex }> {
+  const artifactPath =
+    options.artifactPath ?? process.env.MUX_DOCS_ARTIFACT_PATH;
+  const manifest = artifactPath
+    ? await readJson<PublishedDocsManifest>(join(artifactPath, 'manifest.json'))
+    : await fetchJson<PublishedDocsManifest>(
+        options.manifestUrl ??
+          process.env.MUX_DOCS_MANIFEST_URL ??
+          MUX_DOCS_MANIFEST_URL,
+      );
+  const index = artifactPath
+    ? await readJson<PublishedDocsIndex>(join(artifactPath, 'index.json'))
+    : await fetchJson<PublishedDocsIndex>(
+        options.indexUrl ?? process.env.MUX_DOCS_INDEX_URL ?? manifest.indexUrl,
+      );
+
+  const cachePaths = getDocsArtifactCachePaths();
+  await mkdir(dirname(cachePaths.manifestPath), { recursive: true });
+  await writeFile(cachePaths.manifestPath, JSON.stringify(manifest, null, 2));
+  await writeFile(cachePaths.indexPath, JSON.stringify(index, null, 2));
+
+  return { manifest, index };
+}
+
+export async function readCachedDocsIndex(): Promise<DocsIndex> {
+  const cachePaths = getDocsArtifactCachePaths();
+  const publishedIndex = await readJson<PublishedDocsIndex>(
+    cachePaths.indexPath,
+  );
+  return normalizePublishedDocsIndex(publishedIndex, cachePaths.indexPath);
+}
+
+export function hasCachedDocsIndex(): boolean {
+  return existsSync(getDocsArtifactCachePaths().indexPath);
+}
+
+export function getPublishedDocsSource(index: DocsIndex): PublishedDocsSource {
+  const cachePaths = getDocsArtifactCachePaths();
+  return {
+    kind: 'cache',
+    source: 'published',
+    indexPath: cachePaths.indexPath,
+    manifestPath: cachePaths.manifestPath,
+    version: index.version,
+    generatedAt: index.generatedAt,
+    documents: index.entries.length,
+  };
+}
+
+function normalizePublishedDocsIndex(
+  index: PublishedDocsIndex,
+  cachePath: string,
+): DocsIndex {
+  return {
+    generatedAt: index.generatedAt,
+    repoPath: dirname(cachePath),
+    repoUrl: MUX_DOCS_INDEX_URL,
+    docsRoot: index.docsRoot,
+    source: 'published',
+    version: index.version,
+    commit: index.commit,
+    entries: index.entries.map((entry) => ({
+      id: entry.id,
+      title: entry.title,
+      description: entry.description,
+      product: entry.product,
+      relativePath: entry.path,
+      absolutePath: `published:${entry.id}`,
+      route: entry.route,
+      url: entry.url,
+      headings: entry.headings,
+      content: entry.content,
+    })),
+  };
+}
+
+async function readJson<T>(path: string): Promise<T> {
+  return JSON.parse(await readFile(path, 'utf-8')) as T;
+}
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${url}: ${response.status}`);
+  }
+
+  return (await response.json()) as T;
+}
+
+/**
+ * Git arguments for a shallow, partial, sparse clone of the mux.com repository.
+ *
+ * This avoids checking out or downloading blobs for the rest of the application
+ * repository. Git may still download commit and tree metadata, but file content
+ * outside MDX files under DOCS_GUIDES_RELATIVE_ROOT is not fetched into the
+ * local checkout.
+ */
+export function getDocsSparseCloneArgs(
+  repoUrl: string,
+  repoPath: string,
+): string[] {
+  return [
+    'clone',
+    '--depth=1',
+    '--filter=blob:none',
+    '--sparse',
+    repoUrl,
+    repoPath,
+  ];
+}
+
+export function getDocsSparseCheckoutArgs(repoPath: string): string[] {
+  return [
+    '-C',
+    repoPath,
+    'sparse-checkout',
+    'set',
+    '--no-cone',
+    DOCS_GUIDES_MDX_SPARSE_PATTERN,
+  ];
+}
+
+/**
+ * Resolve the docs source for the current command.
+ *
+ * Precedence:
+ * 1. Explicit command option
+ * 2. MUX_DOCS_PATH
+ * 3. Sibling ../mux.com checkout for local Mux development
+ * 4. XDG cache checkout used by `mux docs update`
+ */
+export async function resolveDocsSource(
+  options: ResolveDocsSourceOptions = {},
+): Promise<DocsSource> {
+  const cwd = options.cwd ?? process.cwd();
+  const repoUrl = options.repoUrl ?? MUX_DOCS_REPO_URL;
+
+  if (options.explicitPath) {
+    return resolveConfiguredSource(
+      resolve(cwd, options.explicitPath),
+      'explicit',
+      repoUrl,
+    );
+  }
+
+  if (process.env.MUX_DOCS_PATH) {
+    return resolveConfiguredSource(
+      resolve(cwd, process.env.MUX_DOCS_PATH),
+      'env',
+      repoUrl,
+    );
+  }
+
+  const siblingPath = resolve(cwd, '..', 'mux.com');
+  if (hasDocsRoot(siblingPath)) {
+    return {
+      kind: 'local',
+      source: 'sibling',
+      repoPath: siblingPath,
+      docsRoot: join(siblingPath, DOCS_RELATIVE_ROOT),
+      repoUrl,
+    };
+  }
+
+  const cachePath = getDocsRepoCachePath();
+  return {
+    kind: 'cache',
+    source: 'cache',
+    repoPath: cachePath,
+    docsRoot: join(cachePath, DOCS_RELATIVE_ROOT),
+    repoUrl,
+  };
+}
+
+async function resolveConfiguredSource(
+  repoPath: string,
+  source: 'explicit' | 'env',
+  repoUrl: string,
+): Promise<DocsSource> {
+  if (!hasDocsRoot(repoPath)) {
+    throw new Error(
+      `Docs source does not contain ${DOCS_GUIDES_RELATIVE_ROOT}: ${repoPath}`,
+    );
+  }
+
+  return {
+    kind: 'local',
+    source,
+    repoPath,
+    docsRoot: join(repoPath, DOCS_RELATIVE_ROOT),
+    repoUrl,
+  };
+}
+
+function hasDocsRoot(repoPath: string): boolean {
+  return existsSync(join(repoPath, DOCS_GUIDES_RELATIVE_ROOT));
+}
+
+/**
+ * Clone or refresh the cached mux.com checkout used as the default docs source.
+ */
+export async function updateCachedDocsRepo(
+  options: { force?: boolean; repoUrl?: string } = {},
+): Promise<DocsSource> {
+  const repoUrl = options.repoUrl ?? MUX_DOCS_REPO_URL;
+  const repoPath = getDocsRepoCachePath();
+
+  if (options.force) {
+    await rm(repoPath, { recursive: true, force: true });
+  }
+
+  if (existsSync(join(repoPath, '.git'))) {
+    if (!(await isSparseDocsCheckout(repoPath))) {
+      await rm(repoPath, { recursive: true, force: true });
+      await cloneSparseDocsRepo(repoUrl, repoPath);
+    } else {
+      await runGit(getDocsSparseCheckoutArgs(repoPath));
+      await runGit(['-C', repoPath, 'pull', '--ff-only']);
+    }
+  } else {
+    await rm(repoPath, { recursive: true, force: true });
+    await cloneSparseDocsRepo(repoUrl, repoPath);
+  }
+
+  if (!hasDocsRoot(repoPath)) {
+    throw new Error(
+      `The docs repository did not contain ${DOCS_GUIDES_RELATIVE_ROOT}: ${repoPath}`,
+    );
+  }
+
+  return {
+    kind: 'cache',
+    source: 'cache',
+    repoPath,
+    docsRoot: join(repoPath, DOCS_RELATIVE_ROOT),
+    repoUrl,
+  };
+}
+
+async function cloneSparseDocsRepo(
+  repoUrl: string,
+  repoPath: string,
+): Promise<void> {
+  await mkdir(dirname(repoPath), { recursive: true });
+  await runGit(getDocsSparseCloneArgs(repoUrl, repoPath));
+  await runGit(getDocsSparseCheckoutArgs(repoPath));
+}
+
+async function isSparseDocsCheckout(repoPath: string): Promise<boolean> {
+  const sparseCheckoutPath = join(repoPath, '.git', 'info', 'sparse-checkout');
+
+  if (!existsSync(sparseCheckoutPath)) {
+    return false;
+  }
+
+  const content = await readFile(sparseCheckoutPath, 'utf-8');
+  return content.includes(DOCS_GUIDES_MDX_SPARSE_PATTERN);
+}
+
+async function runGit(args: string[]): Promise<void> {
+  const proc = Bun.spawn(['git', ...args], {
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+
+  if (exitCode !== 0) {
+    const message = stderr.trim() || stdout.trim() || `git ${args.join(' ')}`;
+    throw new Error(message);
+  }
+}
+
+/**
+ * Build a lightweight local search index from docs markdown and MDX files.
+ */
+export async function loadDocsIndex(
+  options: { explicitPath?: string } = {},
+): Promise<{ index: DocsIndex; source: DocsIndexSource }> {
+  if (
+    !options.explicitPath &&
+    !process.env.MUX_DOCS_PATH &&
+    hasCachedDocsIndex()
+  ) {
+    const index = await readCachedDocsIndex();
+    return { index, source: getPublishedDocsSource(index) };
+  }
+
+  const source = await resolveDocsSource({
+    explicitPath: options.explicitPath,
+  });
+  return {
+    source,
+    index: await buildDocsIndex({
+      repoPath: source.repoPath,
+      repoUrl: source.repoUrl,
+    }),
+  };
+}
+
+export async function buildDocsIndex(
+  options: BuildDocsIndexOptions,
+): Promise<DocsIndex> {
+  const repoPath = options.repoPath;
+  const repoUrl = options.repoUrl ?? MUX_DOCS_REPO_URL;
+  const docsRoot = join(repoPath, DOCS_RELATIVE_ROOT);
+  const guidesRoot = join(repoPath, DOCS_GUIDES_RELATIVE_ROOT);
+
+  if (!existsSync(guidesRoot)) {
+    throw new Error(
+      `Docs guides root not found at ${guidesRoot}. Run 'mux docs update' or set MUX_DOCS_PATH.`,
+    );
+  }
+
+  const files = await collectDocsFiles(guidesRoot);
+  const entries = await Promise.all(
+    files.map((filePath) => buildDocsIndexEntry(repoPath, docsRoot, filePath)),
+  );
+
+  entries.sort((a, b) => a.title.localeCompare(b.title));
+
+  return {
+    generatedAt: new Date().toISOString(),
+    repoPath,
+    repoUrl,
+    docsRoot,
+    source: 'local',
+    entries,
+  };
+}
+
+async function collectDocsFiles(root: string): Promise<string[]> {
+  const results: string[] = [];
+
+  async function walk(directory: string): Promise<void> {
+    const entries = await readdir(directory, { withFileTypes: true });
+
+    for (const entry of entries) {
+      const path = join(directory, entry.name);
+
+      if (entry.isDirectory()) {
+        if (!SKIPPED_DIRECTORIES.has(entry.name)) {
+          await walk(path);
+        }
+        continue;
+      }
+
+      if (entry.isFile() && extname(entry.name) === '.mdx') {
+        results.push(path);
+      }
+    }
+  }
+
+  await walk(root);
+  results.sort();
+  return results;
+}
+
+async function buildDocsIndexEntry(
+  repoPath: string,
+  docsRoot: string,
+  filePath: string,
+): Promise<DocsIndexEntry> {
+  const rawContent = await readFile(filePath, 'utf-8');
+  const { frontmatter, body } = parseFrontmatter(rawContent);
+  const headings = extractHeadings(body);
+  const route = buildRoute(docsRoot, filePath);
+  const relativePath = toPosixPath(relative(repoPath, filePath));
+  const id =
+    route.split('/').filter(Boolean).at(-1) ?? stripExtension(filePath);
+  const title = frontmatter.title ?? titleFromId(id);
+
+  return {
+    id,
+    title,
+    description: frontmatter.description,
+    product: frontmatter.product,
+    relativePath,
+    absolutePath: filePath,
+    route,
+    url: `${DOCS_BASE_URL}${route}`,
+    headings,
+    content: rawContent,
+  };
+}
+
+function parseFrontmatter(content: string): {
+  frontmatter: Record<string, string>;
+  body: string;
+} {
+  if (!content.startsWith('---\n')) {
+    return { frontmatter: {}, body: content };
+  }
+
+  const end = content.indexOf('\n---', 4);
+  if (end === -1) {
+    return { frontmatter: {}, body: content };
+  }
+
+  const yaml = content.slice(4, end).trim();
+  const body = content.slice(end + 4).replace(/^\s*\n/, '');
+  const frontmatter: Record<string, string> = {};
+
+  for (const line of yaml.split('\n')) {
+    const match = line.match(/^([A-Za-z0-9_-]+):\s*(.*)$/);
+    if (!match) continue;
+
+    const [, key, rawValue] = match;
+    frontmatter[key] = rawValue.replace(/^['"]|['"]$/g, '').trim();
+  }
+
+  return { frontmatter, body };
+}
+
+function extractHeadings(content: string): string[] {
+  return content
+    .split('\n')
+    .map((line) => line.match(/^#{1,6}\s+(.+)$/)?.[1]?.trim())
+    .filter((heading): heading is string => Boolean(heading));
+}
+
+function buildRoute(docsRoot: string, filePath: string): string {
+  const withoutExtension = stripExtension(
+    toPosixPath(relative(docsRoot, filePath)),
+  );
+  const parts = withoutExtension
+    .split('/')
+    .filter((part) => part !== 'index')
+    .map((part) => part.replace(/^_+/, ''));
+
+  return `/${parts.join('/')}`;
+}
+
+function stripExtension(path: string): string {
+  return path.replace(/\.(md|mdx)$/i, '');
+}
+
+function titleFromId(id: string): string {
+  return id
+    .split('-')
+    .filter(Boolean)
+    .map((word) => `${word.charAt(0).toUpperCase()}${word.slice(1)}`)
+    .join(' ');
+}
+
+function toPosixPath(path: string): string {
+  return path.split('\\').join('/');
+}
+
+/**
+ * Search a generated docs index using simple deterministic term scoring.
+ */
+export function searchDocsIndex(
+  index: DocsIndex,
+  query: string,
+  options: SearchDocsIndexOptions = {},
+): DocsSearchResult[] {
+  const terms = tokenize(query);
+  if (terms.length === 0) return [];
+
+  const results: DocsSearchResult[] = [];
+
+  for (const entry of index.entries) {
+    const score = scoreEntry(entry, terms, query);
+    if (score <= 0) continue;
+
+    results.push({
+      entry,
+      score,
+      snippet: makeSnippet(entry, terms),
+    });
+  }
+
+  results.sort(
+    (a, b) => b.score - a.score || a.entry.title.localeCompare(b.entry.title),
+  );
+  return results.slice(0, options.limit ?? 10);
+}
+
+function scoreEntry(
+  entry: DocsIndexEntry,
+  terms: string[],
+  query: string,
+): number {
+  const fields = [
+    { value: entry.title, weight: 8 },
+    { value: entry.description ?? '', weight: 5 },
+    { value: entry.headings.join(' '), weight: 4 },
+    { value: entry.id, weight: 3 },
+    { value: entry.content, weight: 1 },
+  ];
+
+  let score = 0;
+  for (const term of terms) {
+    for (const field of fields) {
+      score += countOccurrences(field.value, term) * field.weight;
+    }
+  }
+
+  const phrase = query.toLowerCase().trim();
+  if (phrase) {
+    if (entry.title.toLowerCase().includes(phrase)) score += 50;
+    if ((entry.description ?? '').toLowerCase().includes(phrase)) score += 25;
+    if (entry.headings.join(' ').toLowerCase().includes(phrase)) score += 20;
+    if (entry.content.toLowerCase().includes(phrase)) score += 5;
+  }
+
+  return score;
+}
+
+function countOccurrences(value: string, term: string): number {
+  if (!value) return 0;
+
+  const normalized = value.toLowerCase();
+  let count = 0;
+  let index = normalized.indexOf(term);
+
+  while (index !== -1) {
+    count += 1;
+    index = normalized.indexOf(term, index + term.length);
+  }
+
+  return count;
+}
+
+function makeSnippet(entry: DocsIndexEntry, terms: string[]): string {
+  const lines = entry.content
+    .replace(/^---[\s\S]*?---\s*/, '')
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  const matchingLine = lines.find((line) => {
+    const normalized = line.toLowerCase();
+    return terms.some((term) => normalized.includes(term));
+  });
+
+  return truncate(matchingLine ?? entry.description ?? entry.title, 220);
+}
+
+function truncate(value: string, maxLength: number): string {
+  if (value.length <= maxLength) return value;
+  return `${value.slice(0, maxLength - 1)}…`;
+}
+
+function tokenize(query: string): string[] {
+  return Array.from(
+    new Set(
+      query
+        .toLowerCase()
+        .split(/[^a-z0-9_/-]+/)
+        .map((term) => term.trim())
+        .filter(Boolean),
+    ),
+  );
+}
+
+/**
+ * Find a docs entry by id, route, URL, or repository-relative path.
+ */
+export function findDocById(
+  index: DocsIndex,
+  idOrPath: string,
+): DocsIndexEntry | undefined {
+  const normalized = normalizeIdentifier(idOrPath);
+
+  return index.entries.find((entry) => {
+    const identifiers = [
+      entry.id,
+      entry.route,
+      entry.route.replace(/^\//, ''),
+      entry.relativePath,
+      entry.url,
+    ].map(normalizeIdentifier);
+
+    return identifiers.includes(normalized);
+  });
+}
+
+function normalizeIdentifier(value: string): string {
+  return value
+    .trim()
+    .replace(/^https:\/\/docs\.mux\.com/, '')
+    .replace(/^\/+/, '');
+}
+
+/**
+ * Read raw markdown/MDX content for an indexed docs entry.
+ */
+export async function readDocContent(entry: DocsIndexEntry): Promise<string> {
+  if (entry.content) {
+    return entry.content;
+  }
+
+  return readFile(entry.absolutePath, 'utf-8');
+}
+
+export async function writeDocsIndexCache(index: DocsIndex): Promise<void> {
+  const cachePath = getDocsIndexCachePath();
+  await mkdir(dirname(cachePath), { recursive: true });
+  await writeFile(cachePath, JSON.stringify(index, null, 2));
+}


### PR DESCRIPTION
Added the ability to fetch a Docs manifest from the mux.com repo. This way agents can access docs without pulling the entire mux.com repo or any files other than an index.json with all of the docs content. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new docs subsystem that fetches and caches documentation indexes from `docs.mux.com` (network + local cache), introducing new I/O paths and CLI surface area that could affect reliability and error handling.
> 
> **Overview**
> **Adds a new `mux docs` command group** (`search`, `read`, `update`, `source`) and wires it into the root CLI.
> 
> Docs can now be **indexed from a local `mux.com` checkout** or **pulled as published `manifest.json`/`index.json` artifacts from `docs.mux.com` and cached under the XDG cache dir**, enabling `search`/`read` without cloning the full repo. Includes new search/query normalization logic, JSON-friendly outputs for agents, and comprehensive Bun tests for indexing, caching, and command wiring.
> 
> Package publishing is updated to include a new `skills/mux-cli` skill definition in npm artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc0d437b1e37d2475873d8e08e2c8eaf6cc5751b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->