### PR TITLE
Agent experience: env-var auth fallback, structured JSON errors, --agent rework

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,25 @@ mux login --name staging --env-file .env.staging
 
 The first environment you add becomes the default. See [Authentication & Environment Management](#authentication--environment-management) for more details.
 
+#### Credential sources and precedence
+
+The CLI resolves credentials from two sources, in order:
+
+1. **Environment variables** — `MUX_TOKEN_ID` and `MUX_TOKEN_SECRET`. Used only when both are set and non-empty; a lone variable is ignored.
+2. **Stored login** — the environment saved by `mux login`.
+
+Environment variables take precedence over the stored login, matching the convention of tools like the GitHub, Stripe, and Vercel CLIs. When they shadow a stored login, the CLI prints a one-line notice on stderr (suppressed in agent mode).
+
+All values in a credential bundle come from the same source — the CLI never mixes sources:
+
+| Variable | Purpose |
+|----------|---------|
+| `MUX_TOKEN_ID` / `MUX_TOKEN_SECRET` | API credentials (both required to take effect) |
+| `MUX_BASE_URL` | API host override (applies to either source) |
+| `MUX_SIGNING_KEY` / `MUX_PRIVATE_KEY` | Signing key pair for `mux sign` (both required to take effect) |
+
+When credentials come from environment variables, the API host is `MUX_BASE_URL` or the default `https://api.mux.com` — never a stored environment's custom host. Similarly, `mux sign` only falls back to a stored environment's signing keys when that environment matches the active credentials, so tokens for one environment cannot mint tokens with another environment's key.
+
 ## Common Options
 
 These options are available on most commands and are not repeated in individual command docs below.
@@ -142,7 +161,7 @@ These options are available on most commands and are not repeated in individual 
 | `--compact` | One-line-per-item output, grep-friendly. Available on `list` commands. |
 | `--limit <n>` | Number of results to return (default: 25). Available on `list` commands. |
 | `--page <n>` | Page number for pagination (default: 1). Available on `list` commands. |
-| `-f, --force` | Skip confirmation prompts on destructive actions. **Required** when combining `--json` with `delete` commands. |
+| `-f, --force` | Skip confirmation prompts on destructive actions. **Required** for `delete` commands with `--json` or in agent mode. |
 | `--wait` | Poll until the resource is ready before returning. Available on `create` commands. |
 
 ## Webhook Forwarding
@@ -1035,7 +1054,7 @@ mux exports list                                       # list video view export 
 Authenticate with Mux and save credentials.
 
 **Options:**
-- `-f, --env-file <path>` - Path to .env file containing `MUX_TOKEN_ID` and `MUX_TOKEN_SECRET`
+- `-f, --env-file <path>` - Path to .env file containing `MUX_TOKEN_ID` and `MUX_TOKEN_SECRET`, and optionally `MUX_SIGNING_KEY` and `MUX_PRIVATE_KEY` (saved for `mux sign` when both are present)
 - `-n, --name <name>` - Name for this environment (default: `default`)
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ All values in a credential bundle come from the same source — the CLI never mi
 |----------|---------|
 | `MUX_TOKEN_ID` / `MUX_TOKEN_SECRET` | API credentials (both required to take effect) |
 | `MUX_BASE_URL` | API host override (applies to either source) |
-| `MUX_SIGNING_KEY` / `MUX_PRIVATE_KEY` | Signing key pair for `mux sign` (both required to take effect) |
+| `MUX_SIGNING_KEY` / `MUX_PRIVATE_KEY` | Signing key pair for `mux sign` (both required to take effect; used alongside API credentials, not instead of them) |
 
 When credentials come from environment variables, the API host is `MUX_BASE_URL` or the default `https://api.mux.com` — never a stored environment's custom host. Similarly, `mux sign` only falls back to a stored environment's signing keys when that environment matches the active credentials, so tokens for one environment cannot mint tokens with another environment's key.
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ All values in a credential bundle come from the same source — the CLI never mi
 |----------|---------|
 | `MUX_TOKEN_ID` / `MUX_TOKEN_SECRET` | API credentials (both required to take effect) |
 | `MUX_BASE_URL` | API host override (applies to either source) |
-| `MUX_SIGNING_KEY` / `MUX_PRIVATE_KEY` | Signing key pair for `mux sign` (both required to take effect; used alongside API credentials, not instead of them) |
+| `MUX_SIGNING_KEY` / `MUX_PRIVATE_KEY` | Signing key pair for `mux sign` (setting only one of the pair is an error; used alongside API credentials, not instead of them) |
 
 When credentials come from environment variables, the API host is `MUX_BASE_URL` or the default `https://api.mux.com` — never a stored environment's custom host. Similarly, `mux sign` only falls back to a stored environment's signing keys when that environment matches the active credentials, so tokens for one environment cannot mint tokens with another environment's key.
 

--- a/src/commands/annotations/create.ts
+++ b/src/commands/annotations/create.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 
@@ -37,7 +38,7 @@ export const createCommand = new Command()
 
       const annotation = await mux.data.annotations.create(body as never);
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify(annotation, null, 2));
       } else {
         console.log(`Annotation ID: ${annotation.id}`);

--- a/src/commands/annotations/delete.ts
+++ b/src/commands/annotations/delete.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 import { confirmPrompt } from '@/lib/prompt.ts';
@@ -22,9 +23,9 @@ export const deleteCommand = new Command()
       // Confirm deletion unless --force flag is provided
       if (!options.force) {
         // For JSON mode, require explicit --force flag for safety
-        if (options.json) {
+        if (wantsJson(options)) {
           throw new Error(
-            'Deletion requires --force flag when using --json output',
+            'Deletion requires the --force flag with --json or in agent mode',
           );
         }
 
@@ -41,7 +42,7 @@ export const deleteCommand = new Command()
 
       await mux.data.annotations.delete(annotationId);
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify({ success: true, annotationId }, null, 2));
       } else {
         console.log(`Annotation ${annotationId} deleted successfully.`);

--- a/src/commands/annotations/get.ts
+++ b/src/commands/annotations/get.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 
@@ -16,7 +17,7 @@ export const getCommand = new Command()
 
       const annotation = await mux.data.annotations.retrieve(annotationId);
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify(annotation, null, 2));
       } else {
         console.log(`Annotation ID: ${annotation.id}`);

--- a/src/commands/annotations/list.ts
+++ b/src/commands/annotations/list.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 
@@ -56,7 +57,7 @@ export const listCommand = new Command()
 
       const response = await mux.data.annotations.list(params as never);
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify(response, null, 2));
         return;
       }

--- a/src/commands/annotations/update.ts
+++ b/src/commands/annotations/update.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 
@@ -41,7 +42,7 @@ export const updateCommand = new Command()
         body as never,
       );
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify(annotation, null, 2));
       } else {
         console.log('Annotation updated successfully.');

--- a/src/commands/assets/create.test.ts
+++ b/src/commands/assets/create.test.ts
@@ -10,6 +10,7 @@ import {
 import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { setAgentMode } from '@/lib/context.ts';
 import { createCommand } from './create.ts';
 
 // Note: These tests focus on CLI flag parsing and input validation
@@ -36,6 +37,7 @@ describe('mux assets create command', () => {
     await rm(tempDir, { recursive: true, force: true });
     exitSpy?.mockRestore();
     consoleErrorSpy?.mockRestore();
+    setAgentMode(false);
   });
 
   describe('Flag combinations and validation', () => {
@@ -190,6 +192,83 @@ describe('mux assets create command', () => {
       const errorMessage = consoleErrorSpy.mock.calls[0][0];
       expect(errorMessage).toMatch(/No files found matching pattern/i);
     });
+
+    test('fails fast in agent mode when multiple files need confirmation and -y is omitted', async () => {
+      setAgentMode(true);
+      const fileA = join(tempDir, 'a.mp4');
+      const fileB = join(tempDir, 'b.mp4');
+      await writeFile(fileA, 'fake video content');
+      await writeFile(fileB, 'fake video content');
+
+      try {
+        await createCommand.parse(['--upload', fileA, '--upload', fileB]);
+      } catch (_error) {
+        // Expected to throw via mocked process.exit
+      }
+
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      const parsed = JSON.parse(String(consoleErrorSpy.mock.calls[0][0]));
+      expect(parsed.error).toMatch(/-y/);
+      expect(parsed.error).toMatch(/2 files/);
+    });
+
+    test('fails fast with --json when multiple files need confirmation and -y is omitted', async () => {
+      const fileA = join(tempDir, 'a.mp4');
+      const fileB = join(tempDir, 'b.mp4');
+      await writeFile(fileA, 'fake video content');
+      await writeFile(fileB, 'fake video content');
+
+      try {
+        await createCommand.parse([
+          '--upload',
+          fileA,
+          '--upload',
+          fileB,
+          '--json',
+        ]);
+      } catch (_error) {
+        // Expected to throw via mocked process.exit
+      }
+
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      const parsed = JSON.parse(String(consoleErrorSpy.mock.calls[0][0]));
+      expect(parsed.error).toMatch(/-y/);
+    });
+
+    test('does not require -y for a single file in agent mode', async () => {
+      // Isolate credentials so the command fails at the auth step, which
+      // comes after the confirmation check, without touching the network.
+      const originalXdg = process.env.XDG_CONFIG_HOME;
+      const originalTokenId = process.env.MUX_TOKEN_ID;
+      const originalTokenSecret = process.env.MUX_TOKEN_SECRET;
+      process.env.XDG_CONFIG_HOME = tempDir;
+      delete process.env.MUX_TOKEN_ID;
+      delete process.env.MUX_TOKEN_SECRET;
+
+      try {
+        setAgentMode(true);
+        const fileA = join(tempDir, 'a.mp4');
+        await writeFile(fileA, 'fake video content');
+
+        try {
+          await createCommand.parse(['--upload', fileA]);
+        } catch (_error) {
+          // Expected to fail at the auth step
+        }
+
+        expect(exitSpy).toHaveBeenCalledWith(1);
+        const errorMessage = String(consoleErrorSpy.mock.calls[0]?.[0] || '');
+        expect(errorMessage).not.toContain('-y');
+      } finally {
+        if (originalXdg === undefined) delete process.env.XDG_CONFIG_HOME;
+        else process.env.XDG_CONFIG_HOME = originalXdg;
+        if (originalTokenId === undefined) delete process.env.MUX_TOKEN_ID;
+        else process.env.MUX_TOKEN_ID = originalTokenId;
+        if (originalTokenSecret === undefined)
+          delete process.env.MUX_TOKEN_SECRET;
+        else process.env.MUX_TOKEN_SECRET = originalTokenSecret;
+      }
+    });
   });
 
   describe('Output formatting flags', () => {
@@ -205,6 +284,26 @@ describe('mux assets create command', () => {
         .getOptions()
         .find((opt) => opt.name === 'yes');
       expect(yesOption).toBeDefined();
+    });
+
+    test('emits machine-readable JSON errors in agent mode without --json', async () => {
+      setAgentMode(true);
+
+      try {
+        await createCommand.parse([
+          '--url',
+          'https://example.com/video.mp4',
+          '--file',
+          join(tempDir, 'config.json'),
+        ]);
+      } catch (_error) {
+        // Expected to throw via mocked process.exit
+      }
+
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      const errorMessage = String(consoleErrorSpy.mock.calls[0][0]);
+      const parsed = JSON.parse(errorMessage);
+      expect(parsed.error).toMatch(/Cannot use multiple input methods/);
     });
   });
 

--- a/src/commands/assets/create.ts
+++ b/src/commands/assets/create.ts
@@ -1,5 +1,6 @@
 import { Command } from '@cliffy/command';
 import type Mux from '@mux/mux-node';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { expandGlobPattern, uploadFile } from '@/lib/file-upload.ts';
 import { parseAssetConfig } from '@/lib/json-config.ts';
@@ -112,7 +113,7 @@ async function createFromUploads(
 
   // Show files and confirm (unless -y flag)
   if (!options.yes && files.length > 1) {
-    if (!options.json) {
+    if (!wantsJson(options)) {
       console.log(`Found ${files.length} files to upload:`);
       const totalSize = files.reduce((sum, f) => sum + f.size, 0);
       for (const file of files) {
@@ -136,7 +137,7 @@ async function createFromUploads(
 
   // Upload each file
   for (const file of files) {
-    if (!options.json) {
+    if (!wantsJson(options)) {
       console.log(`Uploading ${file.name}...`);
     }
 
@@ -187,7 +188,7 @@ async function createFromUploads(
 
     // Upload the file
     await uploadFile(file.path, upload.url, upload.id, (percent) => {
-      if (!options.json && percent === 100) {
+      if (!wantsJson(options) && percent === 100) {
         console.log(`${file.name} uploaded`);
       }
     });
@@ -348,6 +349,7 @@ export const createCommand = new Command()
   // biome-ignore lint: Cliffy infers upload as string but collect makes it string[]
   .action(async (options: any, ...args: unknown[]) => {
     const opts = options as CreateOptions;
+    const json = wantsJson(opts);
     // Merge positional args (from shell glob expansion) into upload list
     const extraFiles = args
       .flat()
@@ -381,6 +383,14 @@ export const createCommand = new Command()
             `No files found matching pattern: ${opts.upload.join(', ')}`,
           );
         }
+        // Interactive confirmation is not possible in machine-readable mode;
+        // fail fast with recovery guidance instead of blocking on stdin.
+        const uniqueFileCount = new Set(allFiles.map((f) => f.path)).size;
+        if (json && !opts.yes && uniqueFileCount > 1) {
+          throw new Error(
+            `Uploading ${uniqueFileCount} files requires confirmation, which is not available with --json or in agent mode. Re-run with -y/--yes to skip the prompt.`,
+          );
+        }
       }
 
       // Initialize authenticated Mux client
@@ -392,7 +402,7 @@ export const createCommand = new Command()
       if (opts.url) {
         result = await createFromUrl(mux, opts.url, opts);
 
-        if (opts.json) {
+        if (json) {
           console.log(JSON.stringify(result, null, 2));
         } else {
           console.log(`Asset created: ${result.id}`);
@@ -406,7 +416,7 @@ export const createCommand = new Command()
       } else if (opts.upload) {
         result = await createFromUploads(mux, opts.upload, opts);
 
-        if (opts.json) {
+        if (json) {
           console.log(JSON.stringify(result, null, 2));
         } else {
           console.log(`\n${result.length} file(s) uploaded successfully`);
@@ -417,7 +427,7 @@ export const createCommand = new Command()
       } else if (opts.file) {
         result = await createFromConfig(mux, opts.file, opts);
 
-        if (opts.json) {
+        if (json) {
           console.log(JSON.stringify(result, null, 2));
         } else {
           console.log(`Asset created: ${result.id}`);
@@ -435,7 +445,7 @@ export const createCommand = new Command()
 
       // Wait for asset processing if requested
       if (opts.wait && !Array.isArray(result) && result.id) {
-        if (!opts.json) {
+        if (!json) {
           console.log('\nWaiting for asset to be ready...');
         }
 
@@ -448,17 +458,17 @@ export const createCommand = new Command()
           asset = await mux.video.assets.retrieve(result.id);
           attempts++;
 
-          if (!opts.json) {
+          if (!json) {
             process.stdout.write('.');
           }
         }
 
-        if (!opts.json) {
+        if (!json) {
           console.log();
         }
 
         if (asset.status === 'ready') {
-          if (!opts.json) {
+          if (!json) {
             console.log('Asset is ready!');
           }
         } else if (asset.status === 'errored') {
@@ -466,14 +476,14 @@ export const createCommand = new Command()
             `Asset processing failed: ${asset.errors?.messages?.join(', ') || 'Unknown error'}`,
           );
         } else {
-          if (!opts.json) {
+          if (!json) {
             console.log(
               `WARNING: Asset is still processing. Run 'mux assets get ${asset.id}' to check status.`,
             );
           }
         }
 
-        if (opts.json) {
+        if (json) {
           console.log(JSON.stringify(asset, null, 2));
         }
       }

--- a/src/commands/assets/create.ts
+++ b/src/commands/assets/create.ts
@@ -402,9 +402,11 @@ export const createCommand = new Command()
       if (opts.url) {
         result = await createFromUrl(mux, opts.url, opts);
 
-        if (json) {
+        // With --wait, JSON mode prints only the final asset state below so
+        // stdout stays a single JSON document.
+        if (json && !(opts.wait && result.id)) {
           console.log(JSON.stringify(result, null, 2));
-        } else {
+        } else if (!json) {
           console.log(`Asset created: ${result.id}`);
           console.log(`  Status: ${result.status}`);
           if (result.playback_ids && result.playback_ids.length > 0) {
@@ -427,9 +429,11 @@ export const createCommand = new Command()
       } else if (opts.file) {
         result = await createFromConfig(mux, opts.file, opts);
 
-        if (json) {
+        // With --wait, JSON mode prints only the final asset state below so
+        // stdout stays a single JSON document.
+        if (json && !(opts.wait && result.id)) {
           console.log(JSON.stringify(result, null, 2));
-        } else {
+        } else if (!json) {
           console.log(`Asset created: ${result.id}`);
           console.log(`  Status: ${result.status}`);
           if (result.playback_ids && result.playback_ids.length > 0) {

--- a/src/commands/assets/delete.test.ts
+++ b/src/commands/assets/delete.test.ts
@@ -7,6 +7,7 @@ import {
   spyOn,
   test,
 } from 'bun:test';
+import { setAgentMode } from '@/lib/context.ts';
 import { deleteCommand } from './delete.ts';
 
 // Note: These tests focus on CLI flag parsing and command structure
@@ -40,6 +41,34 @@ describe('mux assets delete command', () => {
       const args = deleteCommand.getArguments();
       expect(args.length).toBeGreaterThan(0);
       expect(args[0].name).toBe('asset-id');
+    });
+  });
+
+  describe('Force guard', () => {
+    test('agent mode without --force fails with guidance that names agent mode', async () => {
+      const originalTokenId = process.env.MUX_TOKEN_ID;
+      const originalTokenSecret = process.env.MUX_TOKEN_SECRET;
+      process.env.MUX_TOKEN_ID = 'env_id';
+      process.env.MUX_TOKEN_SECRET = 'env_secret';
+      setAgentMode(true);
+
+      try {
+        await deleteCommand.parse(['asset-123']);
+      } catch (_error) {
+        // Expected to throw via mocked process.exit
+      } finally {
+        setAgentMode(false);
+        if (originalTokenId === undefined) delete process.env.MUX_TOKEN_ID;
+        else process.env.MUX_TOKEN_ID = originalTokenId;
+        if (originalTokenSecret === undefined)
+          delete process.env.MUX_TOKEN_SECRET;
+        else process.env.MUX_TOKEN_SECRET = originalTokenSecret;
+      }
+
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      const parsed = JSON.parse(String(consoleErrorSpy.mock.calls[0][0]));
+      expect(parsed.error).toContain('--force');
+      expect(parsed.error).toContain('agent mode');
     });
   });
 

--- a/src/commands/assets/delete.ts
+++ b/src/commands/assets/delete.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 import { confirmPrompt } from '@/lib/prompt.ts';
@@ -21,9 +22,9 @@ export const deleteCommand = new Command()
       // Confirm deletion unless --force flag is provided
       if (!options.force) {
         // For JSON mode, require explicit --force flag for safety
-        if (options.json) {
+        if (wantsJson(options)) {
           throw new Error(
-            'Deletion requires --force flag when using --json output',
+            'Deletion requires the --force flag with --json or in agent mode',
           );
         }
 
@@ -41,7 +42,7 @@ export const deleteCommand = new Command()
       // Delete the asset
       await mux.video.assets.delete(assetId);
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify({ success: true, assetId }, null, 2));
       } else {
         console.log(`Asset ${assetId} deleted successfully`);

--- a/src/commands/assets/get.ts
+++ b/src/commands/assets/get.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { formatAsset } from '@/lib/formatters.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
@@ -19,7 +20,7 @@ export const getCommand = new Command()
       // Fetch asset details
       const asset = await mux.video.assets.retrieve(assetId);
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify(asset, null, 2));
       } else {
         formatAsset(asset);

--- a/src/commands/assets/input-info.ts
+++ b/src/commands/assets/input-info.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 
@@ -16,7 +17,7 @@ export const inputInfoCommand = new Command()
 
       const inputInfo = await mux.video.assets.retrieveInputInfo(assetId);
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify(inputInfo, null, 2));
       } else {
         if (inputInfo.length === 0) {

--- a/src/commands/assets/list.ts
+++ b/src/commands/assets/list.ts
@@ -1,5 +1,6 @@
 import { Command } from '@cliffy/command';
 import type { Asset } from '@mux/mux-node/resources/video/assets';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import {
   formatAssetStatus,
@@ -59,7 +60,7 @@ export const listCommand = new Command()
       // Fetch assets
       const response = await mux.video.assets.list(params);
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify(response, null, 2));
       } else if (options.compact) {
         // Compact output - one line per asset, grep-friendly

--- a/src/commands/assets/playback-ids/create.ts
+++ b/src/commands/assets/playback-ids/create.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 import { createPlaybackId, type PlaybackIdPolicy } from '@/lib/playback-ids.ts';
@@ -35,7 +36,7 @@ export const createCommand = new Command()
 
       const playbackId = await createPlaybackId(mux, assetId, policy);
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(
           JSON.stringify(
             {

--- a/src/commands/assets/playback-ids/delete.ts
+++ b/src/commands/assets/playback-ids/delete.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 import { deletePlaybackId } from '@/lib/playback-ids.ts';
@@ -20,9 +21,9 @@ export const deleteCommand = new Command()
         const mux = await createAuthenticatedMuxClient();
 
         if (!options.force) {
-          if (options.json) {
+          if (wantsJson(options)) {
             throw new Error(
-              'Deletion requires --force flag when using --json output',
+              'Deletion requires the --force flag with --json or in agent mode',
             );
           }
 
@@ -39,7 +40,7 @@ export const deleteCommand = new Command()
 
         await deletePlaybackId(mux, assetId, playbackId);
 
-        if (options.json) {
+        if (wantsJson(options)) {
           console.log(
             JSON.stringify({ success: true, assetId, playbackId }, null, 2),
           );

--- a/src/commands/assets/playback-ids/list.ts
+++ b/src/commands/assets/playback-ids/list.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 import { getPlayerUrl, getStreamUrl } from '@/lib/urls.ts';
@@ -18,7 +19,7 @@ export const listCommand = new Command()
       const asset = await mux.video.assets.retrieve(assetId);
       const playbackIds = asset.playback_ids ?? [];
 
-      if (options.json) {
+      if (wantsJson(options)) {
         const output = playbackIds.map((p) => ({
           id: p.id,
           policy: p.policy,

--- a/src/commands/assets/static-renditions/create.ts
+++ b/src/commands/assets/static-renditions/create.ts
@@ -1,5 +1,6 @@
 import { Command } from '@cliffy/command';
 import type Mux from '@mux/mux-node';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 
@@ -79,11 +80,11 @@ export const createCommand = new Command()
           mux,
           assetId,
           rendition.id as string,
-          options.json,
+          wantsJson(options),
         );
-        outputRendition(finalRendition, options.json, false);
+        outputRendition(finalRendition, wantsJson(options), false);
       } else {
-        outputRendition(rendition, options.json, !options.wait);
+        outputRendition(rendition, wantsJson(options), !options.wait);
       }
     } catch (error) {
       await handleCommandError(error, 'assets', 'create', options);

--- a/src/commands/assets/static-renditions/delete.ts
+++ b/src/commands/assets/static-renditions/delete.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 import { confirmPrompt } from '@/lib/prompt.ts';
@@ -19,9 +20,9 @@ export const deleteCommand = new Command()
         const mux = await createAuthenticatedMuxClient();
 
         if (!options.force) {
-          if (options.json) {
+          if (wantsJson(options)) {
             throw new Error(
-              'Deletion requires --force flag when using --json output',
+              'Deletion requires the --force flag with --json or in agent mode',
             );
           }
 
@@ -38,7 +39,7 @@ export const deleteCommand = new Command()
 
         await mux.video.assets.deleteStaticRendition(assetId, renditionId);
 
-        if (options.json) {
+        if (wantsJson(options)) {
           console.log(
             JSON.stringify(
               {

--- a/src/commands/assets/static-renditions/list.ts
+++ b/src/commands/assets/static-renditions/list.ts
@@ -1,5 +1,6 @@
 import { Command } from '@cliffy/command';
 import type { Asset } from '@mux/mux-node/resources/video/assets';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 
@@ -23,7 +24,7 @@ export const listCommand = new Command()
       const staticRenditions = asset.static_renditions;
       const files = staticRenditions?.files ?? [];
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(
           JSON.stringify(
             files.map((file) => formatFileForJson(file)),

--- a/src/commands/assets/tracks/create.ts
+++ b/src/commands/assets/tracks/create.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 
@@ -89,7 +90,7 @@ export const createCommand = new Command()
         params as never,
       );
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify(track, null, 2));
       } else {
         console.log('Track created successfully');

--- a/src/commands/assets/tracks/delete.ts
+++ b/src/commands/assets/tracks/delete.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 import { confirmPrompt } from '@/lib/prompt.ts';
@@ -20,9 +21,9 @@ export const deleteCommand = new Command()
       const mux = await createAuthenticatedMuxClient();
 
       if (!options.force) {
-        if (options.json) {
+        if (wantsJson(options)) {
           throw new Error(
-            'Deletion requires --force flag when using --json output',
+            'Deletion requires the --force flag with --json or in agent mode',
           );
         }
 
@@ -39,7 +40,7 @@ export const deleteCommand = new Command()
 
       await mux.video.assets.deleteTrack(assetId, trackId);
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(
           JSON.stringify({ success: true, assetId, trackId }, null, 2),
         );

--- a/src/commands/assets/tracks/generate-subtitles.ts
+++ b/src/commands/assets/tracks/generate-subtitles.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 
@@ -54,7 +55,7 @@ export const generateSubtitlesCommand = new Command()
           { generated_subtitles: [subtitle as never] },
         );
 
-        if (options.json) {
+        if (wantsJson(options)) {
           console.log(JSON.stringify(result, null, 2));
         } else {
           console.log('Subtitle generation started successfully');

--- a/src/commands/assets/update-master-access.ts
+++ b/src/commands/assets/update-master-access.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { formatAsset } from '@/lib/formatters.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
@@ -35,7 +36,7 @@ export const updateMasterAccessCommand = new Command()
         master_access: options.masterAccess as 'temporary' | 'none',
       });
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify(asset, null, 2));
       } else {
         console.log('Master access updated successfully.\n');

--- a/src/commands/assets/update.ts
+++ b/src/commands/assets/update.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { formatAsset } from '@/lib/formatters.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
@@ -72,7 +73,7 @@ export const updateCommand = new Command()
 
       const asset = await mux.video.assets.update(assetId, updateParams);
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify(asset, null, 2));
       } else {
         console.log('Asset updated successfully.\n');

--- a/src/commands/delivery-usage/list.ts
+++ b/src/commands/delivery-usage/list.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 
@@ -48,7 +49,7 @@ export const listCommand = new Command()
 
       const reports = await mux.video.deliveryUsage.list(params as never);
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify(reports, null, 2));
         return;
       }

--- a/src/commands/dimensions/list.ts
+++ b/src/commands/dimensions/list.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 
@@ -15,7 +16,7 @@ export const listCommand = new Command()
 
       const response = await mux.data.dimensions.list();
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify(response, null, 2));
         return;
       }

--- a/src/commands/dimensions/values.ts
+++ b/src/commands/dimensions/values.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { buildDataFilterParams } from '@/lib/data-filters.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
@@ -53,7 +54,7 @@ export const valuesCommand = new Command()
         params as never,
       );
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify(response, null, 2));
         return;
       }

--- a/src/commands/drm-configurations/get.ts
+++ b/src/commands/drm-configurations/get.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 
@@ -17,7 +18,7 @@ export const getCommand = new Command()
       const config =
         await mux.video.drmConfigurations.retrieve(drmConfigurationId);
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify(config, null, 2));
       } else {
         console.log(`DRM Configuration ID: ${config.id}`);

--- a/src/commands/drm-configurations/list.ts
+++ b/src/commands/drm-configurations/list.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 
@@ -26,7 +27,7 @@ export const listCommand = new Command()
         page: options.page,
       });
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify(configurations, null, 2));
         return;
       }

--- a/src/commands/errors/list.ts
+++ b/src/commands/errors/list.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { buildDataFilterParams } from '@/lib/data-filters.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
@@ -40,7 +41,7 @@ export const listCommand = new Command()
 
       const response = await mux.data.errors.list(params as never);
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify(response, null, 2));
         return;
       }

--- a/src/commands/exports/list.ts
+++ b/src/commands/exports/list.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 
@@ -15,7 +16,7 @@ export const listCommand = new Command()
 
       const response = await mux.data.exports.listVideoViews();
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify(response, null, 2));
         return;
       }

--- a/src/commands/incidents/get.ts
+++ b/src/commands/incidents/get.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 
@@ -17,7 +18,7 @@ export const getCommand = new Command()
       const response = await mux.data.incidents.retrieve(incidentId);
       const incident = response.data;
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify(response, null, 2));
       } else {
         console.log(`Incident ID: ${incident.id}`);

--- a/src/commands/incidents/list.ts
+++ b/src/commands/incidents/list.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 
@@ -88,7 +89,7 @@ export const listCommand = new Command()
 
       const response = await mux.data.incidents.list(params as never);
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify(response, null, 2));
         return;
       }

--- a/src/commands/incidents/related.ts
+++ b/src/commands/incidents/related.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 
@@ -56,7 +57,7 @@ export const relatedCommand = new Command()
         params as never,
       );
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify(response, null, 2));
         return;
       }

--- a/src/commands/live/complete.ts
+++ b/src/commands/live/complete.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 
@@ -18,7 +19,7 @@ export const completeCommand = new Command()
 
       await mux.video.liveStreams.complete(streamId);
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify({ success: true, streamId }, null, 2));
       } else {
         console.log(`Live stream ${streamId} completed successfully`);

--- a/src/commands/live/create.test.ts
+++ b/src/commands/live/create.test.ts
@@ -19,6 +19,7 @@ describe('mux live create command', () => {
   let exitSpy: Mock<typeof process.exit>;
   let consoleErrorSpy: Mock<typeof console.error>;
   let consoleLogSpy: Mock<typeof console.log>;
+  let muxClientSpy: Mock<typeof muxModule.createAuthenticatedMuxClient>;
   let mockMuxClient: {
     video: {
       liveStreams: {
@@ -61,15 +62,18 @@ describe('mux live create command', () => {
     };
 
     // Mock createAuthenticatedMuxClient
-    spyOn(muxModule, 'createAuthenticatedMuxClient').mockResolvedValue(
-      mockMuxClient as unknown as Mux,
-    );
+    muxClientSpy = spyOn(
+      muxModule,
+      'createAuthenticatedMuxClient',
+    ).mockResolvedValue(mockMuxClient as unknown as Mux);
   });
 
   afterEach(() => {
     exitSpy?.mockRestore();
     consoleErrorSpy?.mockRestore();
     consoleLogSpy?.mockRestore();
+    // Restore the module spy so later test files get the real client
+    muxClientSpy?.mockRestore();
   });
 
   describe('Command metadata', () => {

--- a/src/commands/live/create.ts
+++ b/src/commands/live/create.ts
@@ -1,5 +1,6 @@
 import { Command } from '@cliffy/command';
 import type Mux from '@mux/mux-node';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 
@@ -102,7 +103,7 @@ export const createCommand = new Command()
         params as Mux.Video.LiveStreamCreateParams,
       );
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify(liveStream, null, 2));
       } else {
         console.log(`Live stream created: ${liveStream.id}`);

--- a/src/commands/live/delete-new-asset-static-renditions.ts
+++ b/src/commands/live/delete-new-asset-static-renditions.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 import { confirmPrompt } from '@/lib/prompt.ts';
@@ -24,9 +25,9 @@ export const deleteNewAssetStaticRenditionsCommand = new Command()
         const mux = await createAuthenticatedMuxClient();
 
         if (!options.force) {
-          if (options.json) {
+          if (wantsJson(options)) {
             throw new Error(
-              'Deletion requires --force flag when using --json output',
+              'Deletion requires the --force flag with --json or in agent mode',
             );
           }
 
@@ -45,7 +46,7 @@ export const deleteNewAssetStaticRenditionsCommand = new Command()
           streamId,
         );
 
-        if (options.json) {
+        if (wantsJson(options)) {
           console.log(JSON.stringify({ success: true, streamId }, null, 2));
         } else {
           console.log(

--- a/src/commands/live/delete.ts
+++ b/src/commands/live/delete.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 import { confirmPrompt } from '@/lib/prompt.ts';
@@ -21,9 +22,9 @@ export const deleteCommand = new Command()
       // Confirm deletion unless --force flag is provided
       if (!options.force) {
         // For JSON mode, require explicit --force flag for safety
-        if (options.json) {
+        if (wantsJson(options)) {
           throw new Error(
-            'Deletion requires --force flag when using --json output',
+            'Deletion requires the --force flag with --json or in agent mode',
           );
         }
 
@@ -41,7 +42,7 @@ export const deleteCommand = new Command()
       // Delete the live stream
       await mux.video.liveStreams.delete(streamId);
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify({ success: true, streamId }, null, 2));
       } else {
         console.log(`Live stream ${streamId} deleted successfully`);

--- a/src/commands/live/disable.ts
+++ b/src/commands/live/disable.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 
@@ -18,7 +19,7 @@ export const disableCommand = new Command()
 
       await mux.video.liveStreams.disable(streamId);
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify({ success: true, streamId }, null, 2));
       } else {
         console.log(`Live stream ${streamId} disabled successfully`);

--- a/src/commands/live/enable.ts
+++ b/src/commands/live/enable.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 
@@ -18,7 +19,7 @@ export const enableCommand = new Command()
 
       await mux.video.liveStreams.enable(streamId);
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify({ success: true, streamId }, null, 2));
       } else {
         console.log(`Live stream ${streamId} enabled successfully`);

--- a/src/commands/live/get.ts
+++ b/src/commands/live/get.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { formatLiveStream } from '@/lib/formatters.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
@@ -19,7 +20,7 @@ export const getCommand = new Command()
       // Fetch live stream details
       const stream = await mux.video.liveStreams.retrieve(streamId);
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify(stream, null, 2));
       } else {
         formatLiveStream(stream);

--- a/src/commands/live/list.ts
+++ b/src/commands/live/list.ts
@@ -1,5 +1,6 @@
 import { Command } from '@cliffy/command';
 import type { LiveStream } from '@mux/mux-node/resources/video/live-streams';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import {
   formatCreatedAt,
@@ -43,7 +44,7 @@ export const listCommand = new Command()
       // Fetch live streams
       const response = await mux.video.liveStreams.list(params);
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify(response, null, 2));
       } else if (options.compact) {
         // Compact output - one line per stream, grep-friendly

--- a/src/commands/live/playback-ids/create.ts
+++ b/src/commands/live/playback-ids/create.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 import {
@@ -42,7 +43,7 @@ export const createCommand = new Command()
         policy,
       );
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(
           JSON.stringify(
             {

--- a/src/commands/live/playback-ids/delete.ts
+++ b/src/commands/live/playback-ids/delete.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 import { deleteLiveStreamPlaybackId } from '@/lib/playback-ids.ts';
@@ -24,9 +25,9 @@ export const deleteCommand = new Command()
         const mux = await createAuthenticatedMuxClient();
 
         if (!options.force) {
-          if (options.json) {
+          if (wantsJson(options)) {
             throw new Error(
-              'Deletion requires --force flag when using --json output',
+              'Deletion requires the --force flag with --json or in agent mode',
             );
           }
 
@@ -43,7 +44,7 @@ export const deleteCommand = new Command()
 
         await deleteLiveStreamPlaybackId(mux, liveStreamId, playbackId);
 
-        if (options.json) {
+        if (wantsJson(options)) {
           console.log(
             JSON.stringify(
               { success: true, liveStreamId, playbackId },

--- a/src/commands/live/playback-ids/list.ts
+++ b/src/commands/live/playback-ids/list.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 import { getPlayerUrl, getStreamUrl } from '@/lib/urls.ts';
@@ -18,7 +19,7 @@ export const listCommand = new Command()
       const liveStream = await mux.video.liveStreams.retrieve(liveStreamId);
       const playbackIds = liveStream.playback_ids ?? [];
 
-      if (options.json) {
+      if (wantsJson(options)) {
         const output = playbackIds.map((p) => ({
           id: p.id,
           policy: p.policy,

--- a/src/commands/live/reset-stream-key.ts
+++ b/src/commands/live/reset-stream-key.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { formatLiveStream } from '@/lib/formatters.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
@@ -21,9 +22,9 @@ export const resetStreamKeyCommand = new Command()
       const mux = await createAuthenticatedMuxClient();
 
       if (!options.force) {
-        if (options.json) {
+        if (wantsJson(options)) {
           throw new Error(
-            'Resetting stream key requires --force flag when using --json output',
+            'Resetting stream key requires the --force flag with --json or in agent mode',
           );
         }
 
@@ -40,7 +41,7 @@ export const resetStreamKeyCommand = new Command()
 
       const stream = await mux.video.liveStreams.resetStreamKey(streamId);
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify(stream, null, 2));
       } else {
         console.log('Stream key reset successfully.\n');

--- a/src/commands/live/simulcast-targets/create.ts
+++ b/src/commands/live/simulcast-targets/create.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 
@@ -46,7 +47,7 @@ export const createCommand = new Command()
         params,
       );
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify(target, null, 2));
       } else {
         console.log(`Simulcast target created successfully`);

--- a/src/commands/live/simulcast-targets/delete.ts
+++ b/src/commands/live/simulcast-targets/delete.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 import { confirmPrompt } from '@/lib/prompt.ts';
@@ -21,9 +22,9 @@ export const deleteCommand = new Command()
         const mux = await createAuthenticatedMuxClient();
 
         if (!options.force) {
-          if (options.json) {
+          if (wantsJson(options)) {
             throw new Error(
-              'Deletion requires --force flag when using --json output',
+              'Deletion requires the --force flag with --json or in agent mode',
             );
           }
 
@@ -40,7 +41,7 @@ export const deleteCommand = new Command()
 
         await mux.video.liveStreams.deleteSimulcastTarget(streamId, targetId);
 
-        if (options.json) {
+        if (wantsJson(options)) {
           console.log(
             JSON.stringify({ success: true, streamId, targetId }, null, 2),
           );

--- a/src/commands/live/simulcast-targets/get.ts
+++ b/src/commands/live/simulcast-targets/get.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 
@@ -19,7 +20,7 @@ export const getCommand = new Command()
         targetId,
       );
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify(target, null, 2));
       } else {
         console.log(`Simulcast Target ID: ${target.id}`);

--- a/src/commands/live/update-embedded-subtitles.ts
+++ b/src/commands/live/update-embedded-subtitles.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { formatLiveStream } from '@/lib/formatters.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
@@ -72,7 +73,7 @@ export const updateEmbeddedSubtitlesCommand = new Command()
         { embedded_subtitles: embeddedSubtitles as never },
       );
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify(stream, null, 2));
       } else {
         if (options.clear) {

--- a/src/commands/live/update-generated-subtitles.ts
+++ b/src/commands/live/update-generated-subtitles.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { formatLiveStream } from '@/lib/formatters.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
@@ -70,7 +71,7 @@ export const updateGeneratedSubtitlesCommand = new Command()
           { generated_subtitles: generatedSubtitles as never },
         );
 
-        if (options.json) {
+        if (wantsJson(options)) {
           console.log(JSON.stringify(stream, null, 2));
         } else {
           if (options.clear) {

--- a/src/commands/live/update-new-asset-static-renditions.ts
+++ b/src/commands/live/update-new-asset-static-renditions.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { formatLiveStream } from '@/lib/formatters.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
@@ -68,7 +69,7 @@ export const updateNewAssetStaticRenditionsCommand = new Command()
             { static_renditions: staticRenditions },
           );
 
-        if (options.json) {
+        if (wantsJson(options)) {
           console.log(JSON.stringify(stream, null, 2));
         } else {
           console.log('Static rendition settings updated.\n');

--- a/src/commands/live/update.ts
+++ b/src/commands/live/update.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { formatLiveStream } from '@/lib/formatters.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
@@ -99,7 +100,7 @@ export const updateCommand = new Command()
 
       const stream = await mux.video.liveStreams.update(streamId, updateParams);
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify(stream, null, 2));
       } else {
         console.log('Live stream updated successfully.\n');

--- a/src/commands/login.test.ts
+++ b/src/commands/login.test.ts
@@ -497,6 +497,48 @@ describe('Login command - action', () => {
     expect(saved?.signingPrivateKey).toBe('private_base64');
   });
 
+  it('prefers the env file MUX_BASE_URL over the shell MUX_BASE_URL', async () => {
+    const originalBaseUrl = process.env.MUX_BASE_URL;
+    process.env.MUX_BASE_URL = 'https://shell.example.com';
+    const envPath = join(testConfigDir, '.env');
+    await Bun.write(
+      envPath,
+      'MUX_TOKEN_ID=file_id\nMUX_TOKEN_SECRET=file_secret\nMUX_BASE_URL=https://file.example.com',
+    );
+
+    try {
+      await loginCommand.parse(['--env-file', envPath]);
+    } finally {
+      if (originalBaseUrl === undefined) delete process.env.MUX_BASE_URL;
+      else process.env.MUX_BASE_URL = originalBaseUrl;
+    }
+
+    const saved = await getEnvironment('default');
+    expect(saved?.baseUrl).toBe('https://file.example.com');
+    const validationUrl = String(fetchSpy.mock.calls[0][0]);
+    expect(validationUrl.startsWith('https://file.example.com')).toBe(true);
+  });
+
+  it('falls back to the shell MUX_BASE_URL when the env file sets none', async () => {
+    const originalBaseUrl = process.env.MUX_BASE_URL;
+    process.env.MUX_BASE_URL = 'https://shell.example.com';
+    const envPath = join(testConfigDir, '.env');
+    await Bun.write(
+      envPath,
+      'MUX_TOKEN_ID=file_id\nMUX_TOKEN_SECRET=file_secret',
+    );
+
+    try {
+      await loginCommand.parse(['--env-file', envPath]);
+    } finally {
+      if (originalBaseUrl === undefined) delete process.env.MUX_BASE_URL;
+      else process.env.MUX_BASE_URL = originalBaseUrl;
+    }
+
+    const saved = await getEnvironment('default');
+    expect(saved?.baseUrl).toBe('https://shell.example.com');
+  });
+
   it('saves signing keys from environment variables when both are present', async () => {
     process.env.MUX_TOKEN_ID = 'env_id';
     process.env.MUX_TOKEN_SECRET = 'env_secret';

--- a/src/commands/login.test.ts
+++ b/src/commands/login.test.ts
@@ -1,8 +1,18 @@
-import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type Mock,
+  spyOn,
+} from 'bun:test';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { parseEnvFile } from './login.ts';
+import { getEnvironment } from '../lib/config.ts';
+import { setAgentMode } from '../lib/context.ts';
+import { credentialsFromEnv, loginCommand, parseEnvFile } from './login.ts';
 
 describe('Login command - parseEnvFile', () => {
   let testDir: string;
@@ -111,6 +121,22 @@ MUX_TOKEN_SECRET = test_secret_456`,
     expect(result.MUX_TOKEN_SECRET).toBe('test_secret_456');
   });
 
+  it('should parse MUX_SIGNING_KEY and MUX_PRIVATE_KEY', async () => {
+    const envPath = join(testDir, '.env');
+    await Bun.write(
+      envPath,
+      `MUX_TOKEN_ID=test_id_123
+MUX_TOKEN_SECRET=test_secret_456
+MUX_SIGNING_KEY=signing_key_id
+MUX_PRIVATE_KEY=private_key_base64`,
+    );
+
+    const result = await parseEnvFile(envPath);
+
+    expect(result.MUX_SIGNING_KEY).toBe('signing_key_id');
+    expect(result.MUX_PRIVATE_KEY).toBe('private_key_base64');
+  });
+
   it('should parse MUX_BASE_URL', async () => {
     const envPath = join(testDir, '.env');
     await Bun.write(
@@ -215,5 +241,291 @@ MUX_TOKEN_SECRET=secret=with=equals`,
 
     expect(result.MUX_TOKEN_ID).toBeUndefined();
     expect(result.MUX_TOKEN_SECRET).toBeUndefined();
+  });
+});
+
+describe('Login command - credentialsFromEnv', () => {
+  it('returns credentials when both token vars are present', () => {
+    const result = credentialsFromEnv({
+      MUX_TOKEN_ID: 'env_id',
+      MUX_TOKEN_SECRET: 'env_secret',
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.MUX_TOKEN_ID).toBe('env_id');
+    expect(result?.MUX_TOKEN_SECRET).toBe('env_secret');
+  });
+
+  it('includes MUX_BASE_URL when present', () => {
+    const result = credentialsFromEnv({
+      MUX_TOKEN_ID: 'env_id',
+      MUX_TOKEN_SECRET: 'env_secret',
+      MUX_BASE_URL: 'https://api.example.com',
+    });
+
+    expect(result?.MUX_BASE_URL).toBe('https://api.example.com');
+  });
+
+  it('returns null when MUX_TOKEN_ID is missing', () => {
+    expect(credentialsFromEnv({ MUX_TOKEN_SECRET: 'env_secret' })).toBeNull();
+  });
+
+  it('returns null when MUX_TOKEN_SECRET is missing', () => {
+    expect(credentialsFromEnv({ MUX_TOKEN_ID: 'env_id' })).toBeNull();
+  });
+
+  it('returns null when either var is an empty string', () => {
+    expect(
+      credentialsFromEnv({ MUX_TOKEN_ID: '', MUX_TOKEN_SECRET: 'secret' }),
+    ).toBeNull();
+    expect(
+      credentialsFromEnv({ MUX_TOKEN_ID: 'id', MUX_TOKEN_SECRET: '' }),
+    ).toBeNull();
+  });
+
+  it('defaults to process.env when no argument is given', () => {
+    const originalId = process.env.MUX_TOKEN_ID;
+    const originalSecret = process.env.MUX_TOKEN_SECRET;
+    process.env.MUX_TOKEN_ID = 'process_env_id';
+    process.env.MUX_TOKEN_SECRET = 'process_env_secret';
+
+    try {
+      const result = credentialsFromEnv();
+      expect(result?.MUX_TOKEN_ID).toBe('process_env_id');
+      expect(result?.MUX_TOKEN_SECRET).toBe('process_env_secret');
+    } finally {
+      if (originalId === undefined) delete process.env.MUX_TOKEN_ID;
+      else process.env.MUX_TOKEN_ID = originalId;
+      if (originalSecret === undefined) delete process.env.MUX_TOKEN_SECRET;
+      else process.env.MUX_TOKEN_SECRET = originalSecret;
+    }
+  });
+});
+
+describe('Login command - action', () => {
+  let testConfigDir: string;
+  let originalXdgConfigHome: string | undefined;
+  let originalTokenId: string | undefined;
+  let originalTokenSecret: string | undefined;
+  let logSpy: Mock<typeof console.log>;
+  let errorSpy: Mock<typeof console.error>;
+  let exitSpy: Mock<typeof process.exit>;
+  let fetchSpy: Mock<typeof fetch>;
+
+  beforeEach(async () => {
+    testConfigDir = await mkdtemp(join(tmpdir(), 'mux-cli-test-'));
+    originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
+    originalTokenId = process.env.MUX_TOKEN_ID;
+    originalTokenSecret = process.env.MUX_TOKEN_SECRET;
+    process.env.XDG_CONFIG_HOME = testConfigDir;
+    delete process.env.MUX_TOKEN_ID;
+    delete process.env.MUX_TOKEN_SECRET;
+
+    logSpy = spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = spyOn(console, 'error').mockImplementation(() => {});
+    exitSpy = spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit called');
+    }) as never);
+    // Mock the credential validation call (/system/v1/whoami)
+    fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(
+      (async () =>
+        new Response(
+          JSON.stringify({ data: { environment_id: 'env_mock_123' } }),
+          { status: 200 },
+        )) as unknown as typeof fetch,
+    );
+  });
+
+  afterEach(async () => {
+    if (originalXdgConfigHome === undefined) {
+      delete process.env.XDG_CONFIG_HOME;
+    } else {
+      process.env.XDG_CONFIG_HOME = originalXdgConfigHome;
+    }
+    if (originalTokenId === undefined) delete process.env.MUX_TOKEN_ID;
+    else process.env.MUX_TOKEN_ID = originalTokenId;
+    if (originalTokenSecret === undefined) delete process.env.MUX_TOKEN_SECRET;
+    else process.env.MUX_TOKEN_SECRET = originalTokenSecret;
+    logSpy?.mockRestore();
+    errorSpy?.mockRestore();
+    exitSpy?.mockRestore();
+    fetchSpy?.mockRestore();
+    setAgentMode(false);
+    await rm(testConfigDir, { recursive: true, force: true });
+  });
+
+  it('has a --json option', () => {
+    const opt = loginCommand.getOptions().find((o) => o.name === 'json');
+    expect(opt).toBeDefined();
+  });
+
+  it('uses MUX_TOKEN_ID/MUX_TOKEN_SECRET from the environment without prompting', async () => {
+    process.env.MUX_TOKEN_ID = 'env_id';
+    process.env.MUX_TOKEN_SECRET = 'env_secret';
+
+    await loginCommand.parse([]);
+
+    const saved = await getEnvironment('default');
+    expect(saved?.tokenId).toBe('env_id');
+    expect(saved?.tokenSecret).toBe('env_secret');
+  });
+
+  it('prefers --env-file over environment variables', async () => {
+    process.env.MUX_TOKEN_ID = 'env_id';
+    process.env.MUX_TOKEN_SECRET = 'env_secret';
+    const envPath = join(testConfigDir, '.env');
+    await Bun.write(
+      envPath,
+      'MUX_TOKEN_ID=file_id\nMUX_TOKEN_SECRET=file_secret',
+    );
+
+    await loginCommand.parse(['--env-file', envPath]);
+
+    const saved = await getEnvironment('default');
+    expect(saved?.tokenId).toBe('file_id');
+    expect(saved?.tokenSecret).toBe('file_secret');
+  });
+
+  it('outputs machine-readable JSON with --json', async () => {
+    process.env.MUX_TOKEN_ID = 'env_id';
+    process.env.MUX_TOKEN_SECRET = 'env_secret';
+
+    await loginCommand.parse(['--json']);
+
+    const output = logSpy.mock.calls.map((c) => String(c[0])).join('\n');
+    const parsed = JSON.parse(output);
+    expect(parsed.success).toBe(true);
+    expect(parsed.environment).toBe('default');
+    expect(parsed.config_path).toBeDefined();
+  });
+
+  it('accepts --json in agent mode without erroring (regression: --agent used to break login)', async () => {
+    process.env.MUX_TOKEN_ID = 'env_id';
+    process.env.MUX_TOKEN_SECRET = 'env_secret';
+    setAgentMode(true);
+
+    await loginCommand.parse([]);
+
+    const output = logSpy.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(JSON.parse(output).success).toBe(true);
+  });
+
+  it('fails fast with a JSON error on --json when no credentials are available', async () => {
+    try {
+      await loginCommand.parse(['--json']);
+    } catch (_error) {
+      // handleCommandError exits; the mocked process.exit throws to halt parse
+    }
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const parsed = JSON.parse(String(errorSpy.mock.calls[0][0]));
+    expect(parsed.error).toMatch(/MUX_TOKEN_ID and MUX_TOKEN_SECRET/);
+  });
+
+  it('fails fast with a JSON error in agent mode instead of prompting when no credentials are available', async () => {
+    setAgentMode(true);
+
+    try {
+      await loginCommand.parse([]);
+    } catch (_error) {
+      // handleCommandError exits; the mocked process.exit throws to halt parse
+    }
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const parsed = JSON.parse(String(errorSpy.mock.calls[0][0]));
+    expect(parsed.error).toMatch(/Interactive login is not available/);
+  });
+
+  it('reports credential validation failures as JSON in agent mode', async () => {
+    process.env.MUX_TOKEN_ID = 'bad_id';
+    process.env.MUX_TOKEN_SECRET = 'bad_secret';
+    setAgentMode(true);
+    fetchSpy.mockImplementation(
+      (async () =>
+        new Response(JSON.stringify({ error: 'unauthorized' }), {
+          status: 401,
+        })) as unknown as typeof fetch,
+    );
+
+    try {
+      await loginCommand.parse([]);
+    } catch (_error) {
+      // handleCommandError exits; the mocked process.exit throws to halt parse
+    }
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const parsed = JSON.parse(String(errorSpy.mock.calls[0][0]));
+    expect(parsed.error).toBeDefined();
+  });
+
+  it('keeps human-readable errors when not in JSON or agent mode', async () => {
+    const missingFile = join(testConfigDir, 'missing.env');
+
+    try {
+      await loginCommand.parse(['--env-file', missingFile]);
+    } catch (_error) {
+      // handleCommandError exits; the mocked process.exit throws to halt parse
+    }
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const message = String(errorSpy.mock.calls[0][0]);
+    expect(message).toMatch(/^Error: /);
+    expect(message).toMatch(/File not found/);
+  });
+
+  it('respects --name when logging in from environment variables', async () => {
+    process.env.MUX_TOKEN_ID = 'env_id';
+    process.env.MUX_TOKEN_SECRET = 'env_secret';
+
+    await loginCommand.parse(['--name', 'staging']);
+
+    const saved = await getEnvironment('staging');
+    expect(saved?.tokenId).toBe('env_id');
+  });
+
+  it('saves signing keys from the env file when both are present', async () => {
+    const envPath = join(testConfigDir, '.env');
+    await Bun.write(
+      envPath,
+      'MUX_TOKEN_ID=file_id\nMUX_TOKEN_SECRET=file_secret\nMUX_SIGNING_KEY=key_abc\nMUX_PRIVATE_KEY=private_base64',
+    );
+
+    await loginCommand.parse(['--env-file', envPath]);
+
+    const saved = await getEnvironment('default');
+    expect(saved?.signingKeyId).toBe('key_abc');
+    expect(saved?.signingPrivateKey).toBe('private_base64');
+  });
+
+  it('saves signing keys from environment variables when both are present', async () => {
+    process.env.MUX_TOKEN_ID = 'env_id';
+    process.env.MUX_TOKEN_SECRET = 'env_secret';
+    process.env.MUX_SIGNING_KEY = 'key_env';
+    process.env.MUX_PRIVATE_KEY = 'private_env';
+
+    try {
+      await loginCommand.parse([]);
+    } finally {
+      delete process.env.MUX_SIGNING_KEY;
+      delete process.env.MUX_PRIVATE_KEY;
+    }
+
+    const saved = await getEnvironment('default');
+    expect(saved?.signingKeyId).toBe('key_env');
+    expect(saved?.signingPrivateKey).toBe('private_env');
+  });
+
+  it('ignores signing keys when only one of the pair is present', async () => {
+    const envPath = join(testConfigDir, '.env');
+    await Bun.write(
+      envPath,
+      'MUX_TOKEN_ID=file_id\nMUX_TOKEN_SECRET=file_secret\nMUX_SIGNING_KEY=key_abc',
+    );
+
+    await loginCommand.parse(['--env-file', envPath]);
+
+    const saved = await getEnvironment('default');
+    expect(saved?.signingKeyId).toBeUndefined();
+    expect(saved?.signingPrivateKey).toBeUndefined();
   });
 });

--- a/src/commands/login.test.ts
+++ b/src/commands/login.test.ts
@@ -10,7 +10,7 @@ import {
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { getEnvironment } from '../lib/config.ts';
+import { getEnvironment, setEnvironment } from '../lib/config.ts';
 import { setAgentMode } from '../lib/context.ts';
 import { credentialsFromEnv, loginCommand, parseEnvFile } from './login.ts';
 
@@ -513,6 +513,87 @@ describe('Login command - action', () => {
     const saved = await getEnvironment('default');
     expect(saved?.signingKeyId).toBe('key_env');
     expect(saved?.signingPrivateKey).toBe('private_env');
+  });
+
+  it('preserves saved signing keys and forwardUrl when re-logging into the same environment', async () => {
+    // The mocked /whoami returns env_mock_123, so this entry matches the
+    // environment the new credentials belong to.
+    await setEnvironment('default', {
+      tokenId: 'old_id',
+      tokenSecret: 'old_secret',
+      environmentId: 'env_mock_123',
+      signingKeyId: 'key_saved',
+      signingPrivateKey: 'private_saved',
+      forwardUrl: 'http://localhost:3000/webhooks',
+    });
+    process.env.MUX_TOKEN_ID = 'new_id';
+    process.env.MUX_TOKEN_SECRET = 'new_secret';
+
+    await loginCommand.parse([]);
+
+    const saved = await getEnvironment('default');
+    expect(saved?.tokenId).toBe('new_id');
+    expect(saved?.signingKeyId).toBe('key_saved');
+    expect(saved?.signingPrivateKey).toBe('private_saved');
+    expect(saved?.forwardUrl).toBe('http://localhost:3000/webhooks');
+  });
+
+  it('does not carry signing keys over when the new credentials belong to a different environment', async () => {
+    await setEnvironment('default', {
+      tokenId: 'old_id',
+      tokenSecret: 'old_secret',
+      environmentId: 'env_different_999',
+      signingKeyId: 'key_saved',
+      signingPrivateKey: 'private_saved',
+      forwardUrl: 'http://localhost:3000/webhooks',
+    });
+    process.env.MUX_TOKEN_ID = 'new_id';
+    process.env.MUX_TOKEN_SECRET = 'new_secret';
+
+    await loginCommand.parse([]);
+
+    const saved = await getEnvironment('default');
+    expect(saved?.tokenId).toBe('new_id');
+    expect(saved?.signingKeyId).toBeUndefined();
+    expect(saved?.signingPrivateKey).toBeUndefined();
+    expect(saved?.forwardUrl).toBeUndefined();
+  });
+
+  it('does not preserve fields from a legacy entry with no environmentId', async () => {
+    await setEnvironment('default', {
+      tokenId: 'old_id',
+      tokenSecret: 'old_secret',
+      signingKeyId: 'key_saved',
+      signingPrivateKey: 'private_saved',
+    });
+    process.env.MUX_TOKEN_ID = 'new_id';
+    process.env.MUX_TOKEN_SECRET = 'new_secret';
+
+    await loginCommand.parse([]);
+
+    const saved = await getEnvironment('default');
+    expect(saved?.signingKeyId).toBeUndefined();
+  });
+
+  it('prefers newly provided signing keys over preserved ones', async () => {
+    await setEnvironment('default', {
+      tokenId: 'old_id',
+      tokenSecret: 'old_secret',
+      environmentId: 'env_mock_123',
+      signingKeyId: 'key_saved',
+      signingPrivateKey: 'private_saved',
+    });
+    const envPath = join(testConfigDir, '.env');
+    await Bun.write(
+      envPath,
+      'MUX_TOKEN_ID=file_id\nMUX_TOKEN_SECRET=file_secret\nMUX_SIGNING_KEY=key_new\nMUX_PRIVATE_KEY=private_new',
+    );
+
+    await loginCommand.parse(['--env-file', envPath]);
+
+    const saved = await getEnvironment('default');
+    expect(saved?.signingKeyId).toBe('key_new');
+    expect(saved?.signingPrivateKey).toBe('private_new');
   });
 
   it('ignores signing keys when only one of the pair is present', async () => {

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -150,9 +150,11 @@ export const loginCommand = new Command()
 
         tokenId = envVars.MUX_TOKEN_ID;
         tokenSecret = envVars.MUX_TOKEN_SECRET;
-        baseUrl = getMuxBaseUrl({
-          environment: { baseUrl: envVars.MUX_BASE_URL },
-        });
+        // The file is the credential bundle: its MUX_BASE_URL wins over the
+        // shell's, so a leftover shell variable cannot silently rebind the
+        // file's tokens (and the saved environment) to a different host. The
+        // ambient variable or default applies only when the file sets none.
+        baseUrl = envVars.MUX_BASE_URL || getMuxBaseUrl(null);
         if (envVars.MUX_SIGNING_KEY && envVars.MUX_PRIVATE_KEY) {
           signingKeys = {
             signingKeyId: envVars.MUX_SIGNING_KEY,

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -1,7 +1,11 @@
 import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { Command } from '@cliffy/command';
-import { listEnvironments, setEnvironment } from '../lib/config.ts';
+import {
+  getEnvironment,
+  listEnvironments,
+  setEnvironment,
+} from '../lib/config.ts';
 import { wantsJson } from '../lib/context.ts';
 import { handleCommandError } from '../lib/errors.ts';
 import {
@@ -220,8 +224,28 @@ export const loginCommand = new Command()
         throw new Error(validation.error || 'Invalid credentials');
       }
 
+      // Refreshing credentials must not destroy environment-bound state
+      // (signing keys, forward URL). Preserve those fields only when the
+      // new credentials verifiably belong to the same environment; carrying
+      // them across an environment change would desync the config.
+      const existing = await getEnvironment(envName);
+      const preserved =
+        existing?.environmentId &&
+        existing.environmentId === validation.environmentId
+          ? {
+              ...(existing.signingKeyId && {
+                signingKeyId: existing.signingKeyId,
+              }),
+              ...(existing.signingPrivateKey && {
+                signingPrivateKey: existing.signingPrivateKey,
+              }),
+              ...(existing.forwardUrl && { forwardUrl: existing.forwardUrl }),
+            }
+          : {};
+
       // Save to config
       await setEnvironment(envName, {
+        ...preserved,
         tokenId: tokenId.trim(),
         tokenSecret: tokenSecret.trim(),
         environmentId: validation.environmentId,

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -2,6 +2,8 @@ import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { Command } from '@cliffy/command';
 import { listEnvironments, setEnvironment } from '../lib/config.ts';
+import { wantsJson } from '../lib/context.ts';
+import { handleCommandError } from '../lib/errors.ts';
 import {
   DEFAULT_BASE_URL,
   getMuxBaseUrl,
@@ -14,6 +16,8 @@ export interface EnvVars {
   MUX_TOKEN_ID?: string;
   MUX_TOKEN_SECRET?: string;
   MUX_BASE_URL?: string;
+  MUX_SIGNING_KEY?: string;
+  MUX_PRIVATE_KEY?: string;
 }
 
 /**
@@ -55,11 +59,39 @@ export async function parseEnvFile(filePath: string): Promise<EnvVars> {
         envVars.MUX_TOKEN_SECRET = value;
       } else if (key === 'MUX_BASE_URL') {
         envVars.MUX_BASE_URL = value;
+      } else if (key === 'MUX_SIGNING_KEY') {
+        envVars.MUX_SIGNING_KEY = value;
+      } else if (key === 'MUX_PRIVATE_KEY') {
+        envVars.MUX_PRIVATE_KEY = value;
       }
     }
   }
 
   return envVars;
+}
+
+/**
+ * Read credentials from environment variables.
+ * Returns null unless both MUX_TOKEN_ID and MUX_TOKEN_SECRET are set
+ * and non-empty.
+ */
+export function credentialsFromEnv(
+  env: Record<string, string | undefined> = process.env,
+): EnvVars | null {
+  if (!env.MUX_TOKEN_ID || !env.MUX_TOKEN_SECRET) {
+    return null;
+  }
+
+  return {
+    MUX_TOKEN_ID: env.MUX_TOKEN_ID,
+    MUX_TOKEN_SECRET: env.MUX_TOKEN_SECRET,
+    ...(env.MUX_BASE_URL && { MUX_BASE_URL: env.MUX_BASE_URL }),
+    ...(env.MUX_SIGNING_KEY &&
+      env.MUX_PRIVATE_KEY && {
+        MUX_SIGNING_KEY: env.MUX_SIGNING_KEY,
+        MUX_PRIVATE_KEY: env.MUX_PRIVATE_KEY,
+      }),
+  };
 }
 
 export const loginCommand = new Command()
@@ -74,85 +106,155 @@ export const loginCommand = new Command()
     '-n, --name <name:string>',
     "Name for this environment (default: 'default')",
   )
+  .option('--json', 'Output JSON instead of pretty format')
   .action(async (options) => {
-    let tokenId: string;
-    let tokenSecret: string;
-    const envName = options.name || 'default';
+    const json = wantsJson(options);
+    try {
+      let tokenId: string;
+      let tokenSecret: string;
+      let source: 'env-file' | 'env' | 'interactive';
+      let signingKeys:
+        | { signingKeyId: string; signingPrivateKey: string }
+        | undefined;
+      const envName = options.name || 'default';
 
-    // Check if environment already exists
-    const existingEnvs = await listEnvironments();
-    if (existingEnvs.includes(envName)) {
-      console.log(
-        `⚠️  Environment "${envName}" already exists. It will be overwritten.`,
-      );
-    }
-
-    let baseUrl: string;
-
-    if (options.envFile) {
-      // Read from .env file
-      console.log(`Reading credentials from ${options.envFile}...`);
-
-      const envVars = await parseEnvFile(options.envFile);
-
-      if (!envVars.MUX_TOKEN_ID || !envVars.MUX_TOKEN_SECRET) {
-        throw new Error(
-          'Missing required variables in .env file. Expected: MUX_TOKEN_ID and MUX_TOKEN_SECRET.\n' +
-            'Generate API credentials here: https://dashboard.mux.com/settings/access-tokens',
+      // Check if environment already exists
+      const existingEnvs = await listEnvironments();
+      if (existingEnvs.includes(envName) && !json) {
+        console.log(
+          `⚠️  Environment "${envName}" already exists. It will be overwritten.`,
         );
       }
 
-      tokenId = envVars.MUX_TOKEN_ID;
-      tokenSecret = envVars.MUX_TOKEN_SECRET;
-      baseUrl = getMuxBaseUrl({
-        environment: { baseUrl: envVars.MUX_BASE_URL },
-      });
-    } else {
-      // Interactive prompts
-      console.log('Enter your Mux API credentials.');
-      console.log(
-        'Get your Token ID and Secret from https://dashboard.mux.com/settings/access-tokens\n',
+      let baseUrl: string;
+      const envCredentials = credentialsFromEnv();
+
+      if (options.envFile) {
+        // Read from .env file
+        if (!json) {
+          console.log(`Reading credentials from ${options.envFile}...`);
+        }
+
+        const envVars = await parseEnvFile(options.envFile);
+
+        if (!envVars.MUX_TOKEN_ID || !envVars.MUX_TOKEN_SECRET) {
+          throw new Error(
+            'Missing required variables in .env file. Expected: MUX_TOKEN_ID and MUX_TOKEN_SECRET.\n' +
+              'Generate API credentials here: https://dashboard.mux.com/settings/access-tokens',
+          );
+        }
+
+        tokenId = envVars.MUX_TOKEN_ID;
+        tokenSecret = envVars.MUX_TOKEN_SECRET;
+        baseUrl = getMuxBaseUrl({
+          environment: { baseUrl: envVars.MUX_BASE_URL },
+        });
+        if (envVars.MUX_SIGNING_KEY && envVars.MUX_PRIVATE_KEY) {
+          signingKeys = {
+            signingKeyId: envVars.MUX_SIGNING_KEY,
+            signingPrivateKey: envVars.MUX_PRIVATE_KEY,
+          };
+        }
+        source = 'env-file';
+      } else if (
+        envCredentials?.MUX_TOKEN_ID &&
+        envCredentials.MUX_TOKEN_SECRET
+      ) {
+        // Read from environment variables
+        if (!json) {
+          console.log(
+            'Using MUX_TOKEN_ID and MUX_TOKEN_SECRET from environment variables...',
+          );
+        }
+
+        tokenId = envCredentials.MUX_TOKEN_ID;
+        tokenSecret = envCredentials.MUX_TOKEN_SECRET;
+        baseUrl = getMuxBaseUrl({
+          environment: { baseUrl: envCredentials.MUX_BASE_URL },
+        });
+        if (envCredentials.MUX_SIGNING_KEY && envCredentials.MUX_PRIVATE_KEY) {
+          signingKeys = {
+            signingKeyId: envCredentials.MUX_SIGNING_KEY,
+            signingPrivateKey: envCredentials.MUX_PRIVATE_KEY,
+          };
+        }
+        source = 'env';
+      } else {
+        // Interactive prompts are not possible in machine-readable mode;
+        // fail fast with recovery guidance instead of blocking on stdin.
+        if (json) {
+          throw new Error(
+            'No credentials provided. Set MUX_TOKEN_ID and MUX_TOKEN_SECRET environment variables, or pass --env-file <path>. Interactive login is not available with --json or in agent mode.',
+          );
+        }
+
+        console.log('Enter your Mux API credentials.');
+        console.log(
+          'Get your Token ID and Secret from https://dashboard.mux.com/settings/access-tokens\n',
+        );
+
+        tokenId = await inputPrompt({ message: 'Mux Token ID:' });
+        if (!tokenId.trim()) {
+          throw new Error('Token ID is required');
+        }
+
+        tokenSecret = await secretPrompt({ message: 'Mux Token Secret:' });
+        if (!tokenSecret.trim()) {
+          throw new Error('Token Secret is required');
+        }
+
+        baseUrl = getMuxBaseUrl(null);
+        source = 'interactive';
+      }
+
+      if (!json) {
+        console.log('Validating credentials...');
+      }
+      const validation = await validateCredentials(
+        tokenId.trim(),
+        tokenSecret.trim(),
+        baseUrl,
       );
 
-      tokenId = await inputPrompt({ message: 'Mux Token ID:' });
-      if (!tokenId.trim()) {
-        throw new Error('Token ID is required');
+      if (!validation.valid) {
+        throw new Error(validation.error || 'Invalid credentials');
       }
 
-      tokenSecret = await secretPrompt({ message: 'Mux Token Secret:' });
-      if (!tokenSecret.trim()) {
-        throw new Error('Token Secret is required');
+      // Save to config
+      await setEnvironment(envName, {
+        tokenId: tokenId.trim(),
+        tokenSecret: tokenSecret.trim(),
+        environmentId: validation.environmentId,
+        ...(baseUrl !== DEFAULT_BASE_URL && { baseUrl }),
+        ...signingKeys,
+      });
+
+      if (json) {
+        console.log(
+          JSON.stringify(
+            {
+              success: true,
+              environment: envName,
+              environment_id: validation.environmentId,
+              config_path: getConfigPath(),
+              source,
+            },
+            null,
+            2,
+          ),
+        );
+        return;
       }
 
-      baseUrl = getMuxBaseUrl(null);
-    }
+      console.log('✅ Credentials validated successfully');
+      console.log(
+        `✅ Credentials saved to ${getConfigPath()} for environment: ${envName}`,
+      );
 
-    console.log('Validating credentials...');
-    const validation = await validateCredentials(
-      tokenId.trim(),
-      tokenSecret.trim(),
-      baseUrl,
-    );
-
-    if (!validation.valid) {
-      throw new Error(validation.error || 'Invalid credentials');
-    }
-
-    console.log('✅ Credentials validated successfully');
-
-    // Save to config
-    await setEnvironment(envName, {
-      tokenId: tokenId.trim(),
-      tokenSecret: tokenSecret.trim(),
-      environmentId: validation.environmentId,
-      ...(baseUrl !== DEFAULT_BASE_URL && { baseUrl }),
-    });
-
-    console.log(
-      `✅ Credentials saved to ${getConfigPath()} for environment: ${envName}`,
-    );
-
-    if (existingEnvs.length === 0) {
-      console.log(`✅ Set as default environment`);
+      if (existingEnvs.length === 0) {
+        console.log(`✅ Set as default environment`);
+      }
+    } catch (error) {
+      await handleCommandError(error, 'login', 'login', options);
     }
   });

--- a/src/commands/metrics/breakdown.ts
+++ b/src/commands/metrics/breakdown.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { buildDataFilterParams } from '@/lib/data-filters.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
@@ -100,7 +101,7 @@ export const breakdownCommand = new Command()
         params as never,
       );
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify(response, null, 2));
         return;
       }

--- a/src/commands/metrics/insights.ts
+++ b/src/commands/metrics/insights.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { buildDataFilterParams } from '@/lib/data-filters.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
@@ -64,7 +65,7 @@ export const insightsCommand = new Command()
         params as never,
       );
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify(response, null, 2));
         return;
       }

--- a/src/commands/metrics/list.ts
+++ b/src/commands/metrics/list.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { buildDataFilterParams } from '@/lib/data-filters.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
@@ -49,7 +50,7 @@ export const listCommand = new Command()
 
       const response = await mux.data.metrics.list(params as never);
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify(response, null, 2));
         return;
       }

--- a/src/commands/metrics/overall.ts
+++ b/src/commands/metrics/overall.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { buildDataFilterParams } from '@/lib/data-filters.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
@@ -62,7 +63,7 @@ export const overallCommand = new Command()
         params as never,
       );
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify(response, null, 2));
         return;
       }

--- a/src/commands/metrics/timeseries.ts
+++ b/src/commands/metrics/timeseries.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { buildDataFilterParams } from '@/lib/data-filters.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
@@ -81,7 +82,7 @@ export const timeseriesCommand = new Command()
         params as never,
       );
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify(response, null, 2));
         return;
       }

--- a/src/commands/monitoring/breakdown-timeseries.ts
+++ b/src/commands/monitoring/breakdown-timeseries.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 
@@ -75,7 +76,7 @@ export const breakdownTimeseriesCommand = new Command()
         params as never,
       );
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify(response, null, 2));
         return;
       }

--- a/src/commands/monitoring/breakdown.ts
+++ b/src/commands/monitoring/breakdown.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 
@@ -64,7 +65,7 @@ export const breakdownCommand = new Command()
         params as never,
       );
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify(response, null, 2));
         return;
       }

--- a/src/commands/monitoring/dimensions.ts
+++ b/src/commands/monitoring/dimensions.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 
@@ -15,7 +16,7 @@ export const dimensionsCommand = new Command()
 
       const response = await mux.data.monitoring.listDimensions();
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify(response, null, 2));
         return;
       }

--- a/src/commands/monitoring/histogram-timeseries.ts
+++ b/src/commands/monitoring/histogram-timeseries.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 
@@ -30,7 +31,7 @@ export const histogramTimeseriesCommand = new Command()
         params as never,
       );
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify(response, null, 2));
         return;
       }

--- a/src/commands/monitoring/metrics.ts
+++ b/src/commands/monitoring/metrics.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 
@@ -15,7 +16,7 @@ export const metricsListCommand = new Command()
 
       const response = await mux.data.monitoring.metrics.list();
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify(response, null, 2));
         return;
       }

--- a/src/commands/monitoring/timeseries.ts
+++ b/src/commands/monitoring/timeseries.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 
@@ -36,7 +37,7 @@ export const timeseriesCommand = new Command()
         params as never,
       );
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify(response, null, 2));
         return;
       }

--- a/src/commands/playback-ids/index.ts
+++ b/src/commands/playback-ids/index.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { formatAsset, formatLiveStream } from '@/lib/formatters.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
@@ -26,7 +27,7 @@ export const playbackIdsCommand = new Command()
           const asset = await mux.video.assets.retrieve(
             playbackIdInfo.object.id,
           );
-          if (options.json) {
+          if (wantsJson(options)) {
             console.log(JSON.stringify(asset, null, 2));
           } else {
             formatAsset(asset);
@@ -35,7 +36,7 @@ export const playbackIdsCommand = new Command()
           const stream = await mux.video.liveStreams.retrieve(
             playbackIdInfo.object.id,
           );
-          if (options.json) {
+          if (wantsJson(options)) {
             console.log(JSON.stringify(stream, null, 2));
           } else {
             formatLiveStream(stream);
@@ -47,7 +48,7 @@ export const playbackIdsCommand = new Command()
         }
       } else {
         // Just return the playback ID info
-        if (options.json) {
+        if (wantsJson(options)) {
           console.log(JSON.stringify(playbackIdInfo, null, 2));
         } else {
           console.log(`Playback ID: ${playbackIdInfo.id}`);

--- a/src/commands/playback-restrictions/create.ts
+++ b/src/commands/playback-restrictions/create.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 
@@ -41,7 +42,7 @@ export const createCommand = new Command()
         },
       });
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify(restriction, null, 2));
       } else {
         console.log('Playback restriction created successfully');

--- a/src/commands/playback-restrictions/delete.ts
+++ b/src/commands/playback-restrictions/delete.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 import { confirmPrompt } from '@/lib/prompt.ts';
@@ -18,9 +19,9 @@ export const deleteCommand = new Command()
       const mux = await createAuthenticatedMuxClient();
 
       if (!options.force) {
-        if (options.json) {
+        if (wantsJson(options)) {
           throw new Error(
-            'Deletion requires --force flag when using --json output',
+            'Deletion requires the --force flag with --json or in agent mode',
           );
         }
 
@@ -37,7 +38,7 @@ export const deleteCommand = new Command()
 
       await mux.video.playbackRestrictions.delete(restrictionId);
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify({ success: true, restrictionId }, null, 2));
       } else {
         console.log(

--- a/src/commands/playback-restrictions/get.ts
+++ b/src/commands/playback-restrictions/get.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 
@@ -17,7 +18,7 @@ export const getCommand = new Command()
       const restriction =
         await mux.video.playbackRestrictions.retrieve(restrictionId);
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify(restriction, null, 2));
       } else {
         console.log(`Restriction ID: ${restriction.id}`);

--- a/src/commands/playback-restrictions/list.ts
+++ b/src/commands/playback-restrictions/list.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 
@@ -26,7 +27,7 @@ export const listCommand = new Command()
         page: options.page,
       });
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify(restrictions, null, 2));
         return;
       }

--- a/src/commands/playback-restrictions/update-referrer.ts
+++ b/src/commands/playback-restrictions/update-referrer.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 
@@ -32,7 +33,7 @@ export const updateReferrerCommand = new Command()
         },
       );
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify(restriction, null, 2));
       } else {
         console.log('Referrer restriction updated successfully');

--- a/src/commands/playback-restrictions/update-user-agent.ts
+++ b/src/commands/playback-restrictions/update-user-agent.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 
@@ -34,7 +35,7 @@ export const updateUserAgentCommand = new Command()
         },
       );
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify(restriction, null, 2));
       } else {
         console.log('User agent restriction updated successfully');

--- a/src/commands/robots/_shared.test.ts
+++ b/src/commands/robots/_shared.test.ts
@@ -1,6 +1,16 @@
-import { describe, expect, test } from 'bun:test';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  type Mock,
+  mock,
+  spyOn,
+  test,
+} from 'bun:test';
+import type Mux from '@mux/mux-node';
 import type { AnyRobotsJob } from './_shared.ts';
-import { assertJobCompleted } from './_shared.ts';
+import { assertJobCompleted, pollForRobotsJob } from './_shared.ts';
 
 const baseJob = {
   id: 'rjob_xyz',
@@ -52,5 +62,93 @@ describe('assertJobCompleted', () => {
         status: 'errored',
       } as AnyRobotsJob),
     ).toThrow(/rjob_abc123/);
+  });
+});
+
+function makeMuxStub(statuses: string[]): Mux {
+  let call = 0;
+  const retrieve = mock(() => {
+    const status = statuses[Math.min(call, statuses.length - 1)];
+    call++;
+    return Promise.resolve({
+      ...baseJob,
+      id: 'rjob_test123',
+      status,
+    } as AnyRobotsJob);
+  });
+  return {
+    robotsPreview: {
+      jobs: { summarize: { retrieve } },
+    },
+  } as unknown as Mux;
+}
+
+describe('pollForRobotsJob', () => {
+  let stderrSpy: Mock<typeof process.stderr.write>;
+
+  beforeEach(() => {
+    stderrSpy = spyOn(process.stderr, 'write').mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    stderrSpy?.mockRestore();
+  });
+
+  test('returns the job once it reaches a terminal status', async () => {
+    const mux = makeMuxStub(['pending', 'processing', 'completed']);
+
+    const job = await pollForRobotsJob(mux, 'summarize', 'rjob_test123', {
+      json: true,
+      pollIntervalMs: 1,
+    });
+
+    expect(job.status).toBe('completed');
+  });
+
+  test('in JSON mode, polling is silent so stdout stays a single JSON result', async () => {
+    const stdoutSpy = spyOn(process.stdout, 'write').mockImplementation(
+      () => true,
+    );
+    const logSpy = spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      const mux = makeMuxStub(['pending', 'processing', 'completed']);
+      await pollForRobotsJob(mux, 'summarize', 'rjob_test123', {
+        json: true,
+        pollIntervalMs: 1,
+      });
+
+      expect(stderrSpy).not.toHaveBeenCalled();
+      expect(stdoutSpy).not.toHaveBeenCalled();
+      expect(logSpy).not.toHaveBeenCalled();
+    } finally {
+      stdoutSpy.mockRestore();
+      logSpy.mockRestore();
+    }
+  });
+
+  test('in pretty mode, keeps the existing dots progress on stderr', async () => {
+    const mux = makeMuxStub(['processing', 'completed']);
+
+    await pollForRobotsJob(mux, 'summarize', 'rjob_test123', {
+      json: false,
+      pollIntervalMs: 1,
+    });
+
+    const output = stderrSpy.mock.calls.map((c) => String(c[0])).join('');
+    expect(output).toContain('Waiting for job to complete');
+    expect(output).toContain('.');
+    expect(output).toContain('completed!');
+  });
+
+  test('resolves immediately when the job is already terminal', async () => {
+    const mux = makeMuxStub(['errored']);
+
+    const job = await pollForRobotsJob(mux, 'summarize', 'rjob_test123', {
+      json: true,
+      pollIntervalMs: 1,
+    });
+
+    expect(job.status).toBe('errored');
+    expect(stderrSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/commands/robots/_shared.ts
+++ b/src/commands/robots/_shared.ts
@@ -89,32 +89,36 @@ export function assertJobCompleted(job: AnyRobotsJob): void {
   throw new Error(`Job ${job.id} ended with status "${job.status}"${details}`);
 }
 
+export interface PollOptions {
+  json: boolean;
+  pollIntervalMs?: number;
+}
+
 export async function pollForRobotsJob(
   mux: Mux,
   workflow: RobotsWorkflow,
   jobId: string,
-  jsonOutput: boolean,
+  { json, pollIntervalMs = 3000 }: PollOptions,
 ): Promise<AnyRobotsJob> {
-  const POLL_INTERVAL_MS = 3000;
   const MAX_POLL_TIME_MS = 15 * 60 * 1000;
   const start = Date.now();
 
-  if (!jsonOutput) {
+  if (!json) {
     process.stderr.write('Waiting for job to complete');
   }
 
   while (Date.now() - start < MAX_POLL_TIME_MS) {
     const job = await retrieveRobotsJob(mux, workflow, jobId);
     if (isTerminalStatus(job.status)) {
-      if (!jsonOutput) {
+      if (!json) {
         process.stderr.write(` ${job.status}!\n`);
       }
       return job;
     }
-    if (!jsonOutput) {
+    if (!json) {
       process.stderr.write('.');
     }
-    await sleep(POLL_INTERVAL_MS);
+    await sleep(pollIntervalMs);
   }
 
   throw new Error(`Timed out waiting for job ${jobId} to complete`);

--- a/src/commands/robots/ask-questions.ts
+++ b/src/commands/robots/ask-questions.ts
@@ -3,6 +3,7 @@ import type {
   AskQuestionCreateParams,
   AskQuestionsJobParameters,
 } from '@mux/mux-node/resources/robots-preview/jobs';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 import {
@@ -119,22 +120,19 @@ export const askQuestionsCommand: Command<any> = new Command()
       const mux = await createAuthenticatedMuxClient();
       let job = await mux.robotsPreview.jobs.askQuestions.create(body);
 
-      if (!options.json) {
+      if (!wantsJson(options)) {
         console.log('Ask questions job created');
         console.log(`  Job ID: ${job.id}`);
         console.log(`  Status: ${job.status}`);
       }
 
       if (options.wait) {
-        job = (await pollForRobotsJob(
-          mux,
-          'ask-questions',
-          job.id,
-          Boolean(options.json),
-        )) as typeof job;
+        job = (await pollForRobotsJob(mux, 'ask-questions', job.id, {
+          json: wantsJson(options),
+        })) as typeof job;
       }
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify(job, null, 2));
       } else if (options.wait && job.outputs) {
         console.log('Outputs:');

--- a/src/commands/robots/cancel.ts
+++ b/src/commands/robots/cancel.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 
@@ -15,7 +16,7 @@ export const cancelCommand = new Command()
       const mux = await createAuthenticatedMuxClient();
       const job = await mux.robotsPreview.jobs.cancel(jobId);
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify(job, null, 2));
         return;
       }

--- a/src/commands/robots/find-key-moments.ts
+++ b/src/commands/robots/find-key-moments.ts
@@ -3,6 +3,7 @@ import type {
   FindKeyMomentCreateParams,
   FindKeyMomentsJobParameters,
 } from '@mux/mux-node/resources/robots-preview/jobs';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 import {
@@ -103,22 +104,19 @@ export const findKeyMomentsCommand: Command<any> = new Command()
       const mux = await createAuthenticatedMuxClient();
       let job = await mux.robotsPreview.jobs.findKeyMoments.create(body);
 
-      if (!options.json) {
+      if (!wantsJson(options)) {
         console.log('Find key moments job created');
         console.log(`  Job ID: ${job.id}`);
         console.log(`  Status: ${job.status}`);
       }
 
       if (options.wait) {
-        job = (await pollForRobotsJob(
-          mux,
-          'find-key-moments',
-          job.id,
-          Boolean(options.json),
-        )) as typeof job;
+        job = (await pollForRobotsJob(mux, 'find-key-moments', job.id, {
+          json: wantsJson(options),
+        })) as typeof job;
       }
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify(job, null, 2));
       } else if (options.wait && job.outputs) {
         console.log('Outputs:');

--- a/src/commands/robots/generate-chapters.ts
+++ b/src/commands/robots/generate-chapters.ts
@@ -3,6 +3,7 @@ import type {
   GenerateChapterCreateParams,
   GenerateChaptersJobParameters,
 } from '@mux/mux-node/resources/robots-preview/jobs';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 import {
@@ -101,22 +102,19 @@ export const generateChaptersCommand: Command<any> = new Command()
       const mux = await createAuthenticatedMuxClient();
       let job = await mux.robotsPreview.jobs.generateChapters.create(body);
 
-      if (!options.json) {
+      if (!wantsJson(options)) {
         console.log('Generate chapters job created');
         console.log(`  Job ID: ${job.id}`);
         console.log(`  Status: ${job.status}`);
       }
 
       if (options.wait) {
-        job = (await pollForRobotsJob(
-          mux,
-          'generate-chapters',
-          job.id,
-          Boolean(options.json),
-        )) as typeof job;
+        job = (await pollForRobotsJob(mux, 'generate-chapters', job.id, {
+          json: wantsJson(options),
+        })) as typeof job;
       }
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify(job, null, 2));
       } else if (options.wait && job.outputs) {
         console.log('Outputs:');

--- a/src/commands/robots/get.ts
+++ b/src/commands/robots/get.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { formatCreatedAt } from '@/lib/formatters.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
@@ -42,7 +43,7 @@ export const getCommand = new Command()
       const mux = await createAuthenticatedMuxClient();
       const job = await retrieveRobotsJob(mux, workflow, jobId);
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify(job, null, 2));
         return;
       }

--- a/src/commands/robots/list.ts
+++ b/src/commands/robots/list.ts
@@ -1,5 +1,6 @@
 import { Command } from '@cliffy/command';
 import type { JobListParams } from '@mux/mux-node/resources/robots-preview/jobs';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { formatCreatedAt } from '@/lib/formatters.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
@@ -46,7 +47,7 @@ export const listCommand = new Command()
       const response = await mux.robotsPreview.jobs.list(params);
       const data = response.data ?? [];
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify({ data }, null, 2));
         return;
       }

--- a/src/commands/robots/moderate.ts
+++ b/src/commands/robots/moderate.ts
@@ -3,6 +3,7 @@ import type {
   ModerateCreateParams,
   ModerateJobParameters,
 } from '@mux/mux-node/resources/robots-preview/jobs';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 import {
@@ -133,22 +134,19 @@ export const moderateCommand: Command<any> = new Command()
       const mux = await createAuthenticatedMuxClient();
       let job = await mux.robotsPreview.jobs.moderate.create(body);
 
-      if (!options.json) {
+      if (!wantsJson(options)) {
         console.log('Moderate job created');
         console.log(`  Job ID: ${job.id}`);
         console.log(`  Status: ${job.status}`);
       }
 
       if (options.wait) {
-        job = (await pollForRobotsJob(
-          mux,
-          'moderate',
-          job.id,
-          Boolean(options.json),
-        )) as typeof job;
+        job = (await pollForRobotsJob(mux, 'moderate', job.id, {
+          json: wantsJson(options),
+        })) as typeof job;
       }
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify(job, null, 2));
       } else if (options.wait && job.outputs) {
         console.log('Outputs:');

--- a/src/commands/robots/summarize.ts
+++ b/src/commands/robots/summarize.ts
@@ -3,6 +3,7 @@ import type {
   SummarizeCreateParams,
   SummarizeJobParameters,
 } from '@mux/mux-node/resources/robots-preview/jobs';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 import {
@@ -149,22 +150,19 @@ export const summarizeCommand: Command<any> = new Command()
       const mux = await createAuthenticatedMuxClient();
       let job = await mux.robotsPreview.jobs.summarize.create(body);
 
-      if (!options.json) {
+      if (!wantsJson(options)) {
         console.log('Summarize job created');
         console.log(`  Job ID: ${job.id}`);
         console.log(`  Status: ${job.status}`);
       }
 
       if (options.wait) {
-        job = (await pollForRobotsJob(
-          mux,
-          'summarize',
-          job.id,
-          Boolean(options.json),
-        )) as typeof job;
+        job = (await pollForRobotsJob(mux, 'summarize', job.id, {
+          json: wantsJson(options),
+        })) as typeof job;
       }
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify(job, null, 2));
       } else if (options.wait && job.outputs) {
         console.log('Outputs:');

--- a/src/commands/robots/translate-captions.ts
+++ b/src/commands/robots/translate-captions.ts
@@ -3,6 +3,7 @@ import type {
   TranslateCaptionCreateParams,
   TranslateCaptionsJobParameters,
 } from '@mux/mux-node/resources/robots-preview/jobs';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 import {
@@ -93,22 +94,19 @@ export const translateCaptionsCommand: Command<any> = new Command()
       const mux = await createAuthenticatedMuxClient();
       let job = await mux.robotsPreview.jobs.translateCaptions.create(body);
 
-      if (!options.json) {
+      if (!wantsJson(options)) {
         console.log('Translate captions job created');
         console.log(`  Job ID: ${job.id}`);
         console.log(`  Status: ${job.status}`);
       }
 
       if (options.wait) {
-        job = (await pollForRobotsJob(
-          mux,
-          'translate-captions',
-          job.id,
-          Boolean(options.json),
-        )) as typeof job;
+        job = (await pollForRobotsJob(mux, 'translate-captions', job.id, {
+          json: wantsJson(options),
+        })) as typeof job;
       }
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify(job, null, 2));
       } else if (options.wait && job.outputs) {
         console.log('Outputs:');

--- a/src/commands/sign.test.ts
+++ b/src/commands/sign.test.ts
@@ -7,10 +7,15 @@ import {
   spyOn,
   test,
 } from 'bun:test';
+import { generateKeyPairSync } from 'node:crypto';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { setEnvironment } from '@/lib/config.ts';
 import { signCommand } from './sign.ts';
 
-// Note: These tests focus on CLI flag parsing and basic command structure
-// They do NOT test the actual JWT signing logic
+// Note: Command execution tests sign real JWTs with a generated RSA key;
+// signing is local, so no network access is involved.
 
 describe('mux sign command', () => {
   let exitSpy: Mock<typeof process.exit>;
@@ -153,17 +158,191 @@ describe('mux sign command', () => {
   });
 
   describe('Command execution', () => {
-    test('fails when signing keys not configured', async () => {
-      // This will fail at the signing key check
-      // We're just verifying the command structure is correct
+    let testConfigDir: string;
+    let originalXdgConfigHome: string | undefined;
+    const originalEnvVars: Record<string, string | undefined> = {};
+    const ENV_KEYS = [
+      'MUX_TOKEN_ID',
+      'MUX_TOKEN_SECRET',
+      'MUX_SIGNING_KEY',
+      'MUX_PRIVATE_KEY',
+    ];
+
+    // A real RSA key so mux.jwt can sign locally (no network involved)
+    const { privateKey: privateKeyPem } = generateKeyPairSync('rsa', {
+      modulusLength: 2048,
+      publicKeyEncoding: { type: 'pkcs1', format: 'pem' },
+      privateKeyEncoding: { type: 'pkcs1', format: 'pem' },
+    });
+    const privateKeyBase64 = Buffer.from(privateKeyPem).toString('base64');
+
+    // The Mux SDK places the key id in the payload's kid claim
+    function decodeJwtPayload(token: string): { kid?: string } {
+      return JSON.parse(
+        Buffer.from(token.split('.')[1], 'base64url').toString(),
+      );
+    }
+
+    function tokenFromOutput(): string {
+      return String(consoleLogSpy.mock.calls.at(-1)?.[0]).trim();
+    }
+
+    beforeEach(async () => {
+      testConfigDir = await mkdtemp(join(tmpdir(), 'mux-cli-test-'));
+      originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
+      process.env.XDG_CONFIG_HOME = testConfigDir;
+      for (const key of ENV_KEYS) {
+        originalEnvVars[key] = process.env[key];
+        delete process.env[key];
+      }
+    });
+
+    afterEach(async () => {
+      if (originalXdgConfigHome === undefined) {
+        delete process.env.XDG_CONFIG_HOME;
+      } else {
+        process.env.XDG_CONFIG_HOME = originalXdgConfigHome;
+      }
+      for (const key of ENV_KEYS) {
+        if (originalEnvVars[key] === undefined) delete process.env[key];
+        else process.env[key] = originalEnvVars[key];
+      }
+      await rm(testConfigDir, { recursive: true, force: true });
+    });
+
+    test('error mentions env vars when signing keys are not configured anywhere', async () => {
+      await setEnvironment('default', {
+        tokenId: 'stored_id',
+        tokenSecret: 'stored_secret',
+      });
+
       try {
         await signCommand.parse(['test-playback-id']);
       } catch (_error) {
-        // Expected to fail
+        // Expected to fail via mocked process.exit
       }
 
-      // The command should fail during execution, not during parsing
-      expect(true).toBe(true);
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      const errorMessage = String(consoleErrorSpy.mock.calls[0][0]);
+      expect(errorMessage).toContain('mux signing-keys create');
+      expect(errorMessage).toContain('MUX_SIGNING_KEY');
+      expect(errorMessage).toContain('MUX_PRIVATE_KEY');
+    });
+
+    test('signs with MUX_SIGNING_KEY/MUX_PRIVATE_KEY env vars and no stored config', async () => {
+      process.env.MUX_TOKEN_ID = 'env_id';
+      process.env.MUX_TOKEN_SECRET = 'env_secret';
+      process.env.MUX_SIGNING_KEY = 'key_from_env';
+      process.env.MUX_PRIVATE_KEY = privateKeyBase64;
+
+      await signCommand.parse(['test-playback-id', '--token-only']);
+
+      const payload = decodeJwtPayload(tokenFromOutput());
+      expect(payload.kid).toBe('key_from_env');
+    });
+
+    test('env var signing keys take precedence over stored config keys', async () => {
+      await setEnvironment('default', {
+        tokenId: 'stored_id',
+        tokenSecret: 'stored_secret',
+        signingKeyId: 'key_from_config',
+        signingPrivateKey: privateKeyBase64,
+      });
+      process.env.MUX_SIGNING_KEY = 'key_from_env';
+      process.env.MUX_PRIVATE_KEY = privateKeyBase64;
+
+      await signCommand.parse(['test-playback-id', '--token-only']);
+
+      const payload = decodeJwtPayload(tokenFromOutput());
+      expect(payload.kid).toBe('key_from_env');
+    });
+
+    test('still signs with stored config keys when env vars are absent', async () => {
+      await setEnvironment('default', {
+        tokenId: 'stored_id',
+        tokenSecret: 'stored_secret',
+        signingKeyId: 'key_from_config',
+        signingPrivateKey: privateKeyBase64,
+      });
+
+      await signCommand.parse(['test-playback-id', '--token-only']);
+
+      const payload = decodeJwtPayload(tokenFromOutput());
+      expect(payload.kid).toBe('key_from_config');
+    });
+
+    test('uses stored signing keys when env credentials match the stored environment', async () => {
+      await setEnvironment('default', {
+        tokenId: 'stored_id',
+        tokenSecret: 'stored_secret',
+        environmentId: 'env_same_123',
+        signingKeyId: 'key_from_config',
+        signingPrivateKey: privateKeyBase64,
+      });
+      process.env.MUX_TOKEN_ID = 'env_id';
+      process.env.MUX_TOKEN_SECRET = 'env_secret';
+      const fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(
+        (async () =>
+          new Response(
+            JSON.stringify({ data: { environment_id: 'env_same_123' } }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } },
+          )) as unknown as typeof fetch,
+      );
+
+      try {
+        await signCommand.parse(['test-playback-id', '--token-only']);
+      } finally {
+        fetchSpy.mockRestore();
+      }
+
+      const payload = decodeJwtPayload(tokenFromOutput());
+      expect(payload.kid).toBe('key_from_config');
+    });
+
+    test('refuses stored signing keys when env credentials point at a different environment', async () => {
+      await setEnvironment('default', {
+        tokenId: 'stored_id',
+        tokenSecret: 'stored_secret',
+        environmentId: 'env_stored_123',
+        signingKeyId: 'key_from_config',
+        signingPrivateKey: privateKeyBase64,
+      });
+      process.env.MUX_TOKEN_ID = 'env_id';
+      process.env.MUX_TOKEN_SECRET = 'env_secret';
+      const fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(
+        (async () =>
+          new Response(
+            JSON.stringify({ data: { environment_id: 'env_other_456' } }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } },
+          )) as unknown as typeof fetch,
+      );
+
+      try {
+        await signCommand.parse(['test-playback-id', '--token-only']);
+      } catch (_error) {
+        // Expected to fail via mocked process.exit
+      } finally {
+        fetchSpy.mockRestore();
+      }
+
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      const errorMessage = String(consoleErrorSpy.mock.calls[0][0]);
+      expect(errorMessage).toContain('Signing keys not configured');
+    });
+
+    test('ignores env signing keys when only one of the pair is set', async () => {
+      await setEnvironment('default', {
+        tokenId: 'stored_id',
+        tokenSecret: 'stored_secret',
+        signingKeyId: 'key_from_config',
+        signingPrivateKey: privateKeyBase64,
+      });
+      process.env.MUX_SIGNING_KEY = 'key_from_env';
+
+      await signCommand.parse(['test-playback-id', '--token-only']);
+
+      const payload = decodeJwtPayload(tokenFromOutput());
+      expect(payload.kid).toBe('key_from_config');
     });
   });
 });

--- a/src/commands/sign.test.ts
+++ b/src/commands/sign.test.ts
@@ -330,7 +330,7 @@ describe('mux sign command', () => {
       expect(errorMessage).toContain('Signing keys not configured');
     });
 
-    test('ignores env signing keys when only one of the pair is set', async () => {
+    test('errors when MUX_SIGNING_KEY is set without MUX_PRIVATE_KEY', async () => {
       await setEnvironment('default', {
         tokenId: 'stored_id',
         tokenSecret: 'stored_secret',
@@ -339,8 +339,62 @@ describe('mux sign command', () => {
       });
       process.env.MUX_SIGNING_KEY = 'key_from_env';
 
-      await signCommand.parse(['test-playback-id', '--token-only']);
+      try {
+        await signCommand.parse(['test-playback-id', '--token-only']);
+      } catch (_error) {
+        // Expected to fail via mocked process.exit
+      }
 
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      const errorMessage = String(consoleErrorSpy.mock.calls[0][0]);
+      expect(errorMessage).toContain('MUX_SIGNING_KEY is set');
+      expect(errorMessage).toContain('MUX_PRIVATE_KEY');
+    });
+
+    test('errors when MUX_PRIVATE_KEY is set without MUX_SIGNING_KEY', async () => {
+      await setEnvironment('default', {
+        tokenId: 'stored_id',
+        tokenSecret: 'stored_secret',
+        signingKeyId: 'key_from_config',
+        signingPrivateKey: privateKeyBase64,
+      });
+      process.env.MUX_PRIVATE_KEY = privateKeyBase64;
+
+      try {
+        await signCommand.parse(['test-playback-id', '--token-only']);
+      } catch (_error) {
+        // Expected to fail via mocked process.exit
+      }
+
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      const errorMessage = String(consoleErrorSpy.mock.calls[0][0]);
+      expect(errorMessage).toContain('MUX_PRIVATE_KEY is set');
+      expect(errorMessage).toContain('MUX_SIGNING_KEY');
+    });
+
+    test('signs offline when env credentials byte-match the stored environment', async () => {
+      await setEnvironment('default', {
+        tokenId: 'same_id',
+        tokenSecret: 'same_secret',
+        environmentId: 'env_same_123',
+        signingKeyId: 'key_from_config',
+        signingPrivateKey: privateKeyBase64,
+      });
+      process.env.MUX_TOKEN_ID = 'same_id';
+      process.env.MUX_TOKEN_SECRET = 'same_secret';
+      const fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(
+        (async () => {
+          throw new Error('unexpected fetch');
+        }) as unknown as typeof fetch,
+      );
+
+      try {
+        await signCommand.parse(['test-playback-id', '--token-only']);
+      } finally {
+        fetchSpy.mockRestore();
+      }
+
+      expect(fetchSpy).not.toHaveBeenCalled();
       const payload = decodeJwtPayload(tokenFromOutput());
       expect(payload.kid).toBe('key_from_config');
     });

--- a/src/commands/sign.ts
+++ b/src/commands/sign.ts
@@ -149,7 +149,7 @@ export const signCommand = new Command()
             'To create and configure a signing key, run:\n' +
             '  mux signing-keys create\n\n' +
             'This creates a new signing key and saves it to your current environment.\n' +
-            'Alternatively, set the MUX_SIGNING_KEY and MUX_PRIVATE_KEY environment variables.',
+            'Alternatively, set the MUX_SIGNING_KEY and MUX_PRIVATE_KEY environment variables (API credentials are still required).',
         );
       }
 

--- a/src/commands/sign.ts
+++ b/src/commands/sign.ts
@@ -126,8 +126,9 @@ export const signCommand = new Command()
       // Resolve signing key material.
       // Priority: MUX_SIGNING_KEY/MUX_PRIVATE_KEY env vars > stored config
       // (consistent with how MUX_TOKEN_ID/MUX_TOKEN_SECRET take precedence).
-      // Env vars are only used when both are set and non-empty. Stored keys
-      // are only used when the stored environment matches the active
+      // A half-set pair is an error: falling back to a stored key would
+      // silently sign with a different environment's key. Stored keys are
+      // only used when the stored environment matches the active
       // credentials, so tokens for one environment cannot mint JWTs with
       // another environment's key.
       let keyId: string | undefined;
@@ -137,6 +138,13 @@ export const signCommand = new Command()
       if (envSigningKey && envPrivateKey) {
         keyId = envSigningKey;
         keySecret = envPrivateKey;
+      } else if (envSigningKey || envPrivateKey) {
+        const [set, missing] = envSigningKey
+          ? ['MUX_SIGNING_KEY', 'MUX_PRIVATE_KEY']
+          : ['MUX_PRIVATE_KEY', 'MUX_SIGNING_KEY'];
+        throw new Error(
+          `${set} is set but ${missing} is not. Set both to sign with that key pair, or unset ${set} to use the stored environment's signing keys.`,
+        );
       } else {
         const active = await resolveActiveEnvironment();
         keyId = active.stored?.environment.signingKeyId;

--- a/src/commands/sign.ts
+++ b/src/commands/sign.ts
@@ -1,6 +1,9 @@
 import { Command } from '@cliffy/command';
-import Mux from '@mux/mux-node';
-import { getCurrentEnvironment } from '../lib/config.ts';
+import { wantsJson } from '@/lib/context.ts';
+import {
+  createAuthenticatedMuxClient,
+  resolveActiveEnvironment,
+} from '../lib/mux.ts';
 import { getSignedUrl } from '../lib/urls.ts';
 
 interface SignOptions {
@@ -120,34 +123,39 @@ export const signCommand = new Command()
   )
   .action(async (options: SignOptions, playbackId: string) => {
     try {
-      // Get current environment to retrieve signing keys
-      const currentEnv = await getCurrentEnvironment();
-      if (!currentEnv) {
-        throw new Error(
-          'No environment configured.\n\n' +
-            'Signing requires an authenticated environment.\n' +
-            "Please run 'mux login' first.",
-        );
+      // Resolve signing key material.
+      // Priority: MUX_SIGNING_KEY/MUX_PRIVATE_KEY env vars > stored config
+      // (consistent with how MUX_TOKEN_ID/MUX_TOKEN_SECRET take precedence).
+      // Env vars are only used when both are set and non-empty. Stored keys
+      // are only used when the stored environment matches the active
+      // credentials, so tokens for one environment cannot mint JWTs with
+      // another environment's key.
+      let keyId: string | undefined;
+      let keySecret: string | undefined;
+      const envSigningKey = process.env.MUX_SIGNING_KEY;
+      const envPrivateKey = process.env.MUX_PRIVATE_KEY;
+      if (envSigningKey && envPrivateKey) {
+        keyId = envSigningKey;
+        keySecret = envPrivateKey;
+      } else {
+        const active = await resolveActiveEnvironment();
+        keyId = active.stored?.environment.signingKeyId;
+        keySecret = active.stored?.environment.signingPrivateKey;
       }
 
-      // Check if signing keys are configured
-      if (
-        !currentEnv.environment.signingKeyId ||
-        !currentEnv.environment.signingPrivateKey
-      ) {
+      if (!keyId || !keySecret) {
         throw new Error(
-          'Signing keys not configured for this environment.\n\n' +
+          'Signing keys not configured.\n\n' +
             'To create and configure a signing key, run:\n' +
             '  mux signing-keys create\n\n' +
-            'This will create a new signing key and automatically configure it for your current environment.',
+            'This creates a new signing key and saves it to your current environment.\n' +
+            'Alternatively, set the MUX_SIGNING_KEY and MUX_PRIVATE_KEY environment variables.',
         );
       }
 
-      // Create Mux client
-      const mux = new Mux({
-        tokenId: currentEnv.environment.tokenId,
-        tokenSecret: currentEnv.environment.tokenSecret,
-      });
+      // Create Mux client (signing is local; credentials resolve from env
+      // vars or stored config like every other command)
+      const mux = await createAuthenticatedMuxClient();
 
       const tokenType =
         options.type && isValidTokenType(options.type) ? options.type : 'video';
@@ -156,8 +164,8 @@ export const signCommand = new Command()
 
       // Build sign options, casting to work around SDK's strict Record<string, string> typing
       const signOptions = {
-        keyId: currentEnv.environment.signingKeyId,
-        keySecret: currentEnv.environment.signingPrivateKey,
+        keyId,
+        keySecret,
         type: tokenType,
         expiration: options.expiration || '7d',
         ...(params ? { params } : {}),
@@ -173,7 +181,7 @@ export const signCommand = new Command()
       // Output based on format options
       if (options.tokenOnly) {
         console.log(token);
-      } else if (options.json) {
+      } else if (wantsJson(options)) {
         console.log(
           JSON.stringify(
             {
@@ -195,7 +203,7 @@ export const signCommand = new Command()
       const errorMessage =
         error instanceof Error ? error.message : String(error);
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.error(JSON.stringify({ error: errorMessage }, null, 2));
       } else {
         console.error(`Error: ${errorMessage}`);

--- a/src/commands/signing-keys/create.test.ts
+++ b/src/commands/signing-keys/create.test.ts
@@ -4,13 +4,17 @@ import {
   describe,
   expect,
   type Mock,
+  mock,
   spyOn,
   test,
 } from 'bun:test';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import type Mux from '@mux/mux-node';
+import * as configModule from '@/lib/config.ts';
 import { getEnvironment, setEnvironment } from '@/lib/config.ts';
+import * as muxModule from '@/lib/mux.ts';
 import { createCommand } from './create.ts';
 
 describe('mux signing-keys create command', () => {
@@ -44,31 +48,23 @@ describe('mux signing-keys create command', () => {
     let errorSpy: Mock<typeof console.error>;
     let exitSpy: Mock<typeof process.exit>;
     let fetchSpy: Mock<typeof fetch>;
+    let muxClientSpy: Mock<typeof muxModule.createAuthenticatedMuxClient>;
 
+    // The whoami probe in resolveActiveEnvironment uses fetch directly; the
+    // signing key creation goes through the SDK client, which binds fetch
+    // internally and cannot be reliably intercepted via globalThis.fetch —
+    // so the client itself is mocked (same pattern as live/create.test.ts).
     function mockApi(whoamiEnvironmentId: string) {
       fetchSpy = spyOn(globalThis, 'fetch').mockImplementation((async (
         input: string | URL | Request,
       ) => {
         const url = String(input instanceof Request ? input.url : input);
-        const jsonHeaders = { 'Content-Type': 'application/json' };
         if (url.includes('/system/v1/whoami')) {
           return new Response(
             JSON.stringify({
               data: { environment_id: whoamiEnvironmentId },
             }),
-            { status: 200, headers: jsonHeaders },
-          );
-        }
-        if (url.includes('signing-keys')) {
-          return new Response(
-            JSON.stringify({
-              data: {
-                id: 'key_new_123',
-                private_key: 'cHJpdmF0ZS1rZXktcGVt',
-                created_at: '1721500000',
-              },
-            }),
-            { status: 200, headers: jsonHeaders },
+            { status: 200, headers: { 'Content-Type': 'application/json' } },
           );
         }
         throw new Error(`Unexpected fetch in test: ${url}`);
@@ -94,6 +90,25 @@ describe('mux signing-keys create command', () => {
       exitSpy = spyOn(process, 'exit').mockImplementation((() => {
         throw new Error('process.exit called');
       }) as never);
+      muxClientSpy = spyOn(
+        muxModule,
+        'createAuthenticatedMuxClient',
+      ).mockImplementation(
+        async () =>
+          ({
+            system: {
+              signingKeys: {
+                create: mock(() =>
+                  Promise.resolve({
+                    id: 'key_new_123',
+                    private_key: 'cHJpdmF0ZS1rZXktcGVt',
+                    created_at: '1721500000',
+                  }),
+                ),
+              },
+            },
+          }) as unknown as Mux,
+      );
     });
 
     afterEach(async () => {
@@ -111,6 +126,7 @@ describe('mux signing-keys create command', () => {
       errorSpy?.mockRestore();
       exitSpy?.mockRestore();
       fetchSpy?.mockRestore();
+      muxClientSpy?.mockRestore();
       await rm(testConfigDir, { recursive: true, force: true });
     });
 
@@ -254,6 +270,34 @@ describe('mux signing-keys create command', () => {
       expect(saved?.signingKeyId).toBe('key_new_123');
       const parsed = jsonOutput();
       expect(parsed.saved).toBe(true);
+    });
+
+    test('emits the private key once when saving to config fails', async () => {
+      await setEnvironment('default', {
+        tokenId: 'stored_id',
+        tokenSecret: 'stored_secret',
+        environmentId: 'env_stored_123',
+      });
+      mockApi('env_stored_123');
+      const updateSpy = spyOn(
+        configModule,
+        'updateEnvironment',
+      ).mockImplementation(() => Promise.reject(new Error('disk full')));
+
+      try {
+        await createCommand.parse(['--json']);
+      } finally {
+        updateSpy.mockRestore();
+      }
+
+      expect(exitSpy).not.toHaveBeenCalled();
+      const parsed = jsonOutput();
+      expect(parsed.saved).toBe(false);
+      expect(parsed.private_key).toBe('cHJpdmF0ZS1rZXktcGVt');
+      expect(String(parsed.note)).toContain('failed');
+      const stderr = errorSpy.mock.calls.map((c) => String(c[0])).join('\n');
+      expect(stderr).toContain('Failed to save signing key');
+      expect(stderr).not.toContain('cHJpdmF0ZS1rZXktcGVt');
     });
 
     test('prints the private key with guidance in pretty mode when not saved', async () => {

--- a/src/commands/signing-keys/create.test.ts
+++ b/src/commands/signing-keys/create.test.ts
@@ -1,10 +1,17 @@
-import { describe, expect, test } from 'bun:test';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  type Mock,
+  spyOn,
+  test,
+} from 'bun:test';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { getEnvironment, setEnvironment } from '@/lib/config.ts';
 import { createCommand } from './create.ts';
-
-// Note: These tests focus on CLI flag parsing and basic command structure
-// They do NOT test the actual Mux API integration or config file writes
-// Execution tests are omitted because the command uses interactive prompts
-// that depend on local config state
 
 describe('mux signing-keys create command', () => {
   describe('Command metadata', () => {
@@ -25,6 +32,200 @@ describe('mux signing-keys create command', () => {
     test('has no required arguments', () => {
       const args = createCommand.getArguments();
       expect(args.length).toBe(0);
+    });
+  });
+
+  describe('Action', () => {
+    let testConfigDir: string;
+    let originalXdgConfigHome: string | undefined;
+    let originalTokenId: string | undefined;
+    let originalTokenSecret: string | undefined;
+    let logSpy: Mock<typeof console.log>;
+    let errorSpy: Mock<typeof console.error>;
+    let exitSpy: Mock<typeof process.exit>;
+    let fetchSpy: Mock<typeof fetch>;
+
+    function mockApi(whoamiEnvironmentId: string) {
+      fetchSpy = spyOn(globalThis, 'fetch').mockImplementation((async (
+        input: string | URL | Request,
+      ) => {
+        const url = String(input instanceof Request ? input.url : input);
+        const jsonHeaders = { 'Content-Type': 'application/json' };
+        if (url.includes('/system/v1/whoami')) {
+          return new Response(
+            JSON.stringify({
+              data: { environment_id: whoamiEnvironmentId },
+            }),
+            { status: 200, headers: jsonHeaders },
+          );
+        }
+        if (url.includes('signing-keys')) {
+          return new Response(
+            JSON.stringify({
+              data: {
+                id: 'key_new_123',
+                private_key: 'cHJpdmF0ZS1rZXktcGVt',
+                created_at: '1721500000',
+              },
+            }),
+            { status: 200, headers: jsonHeaders },
+          );
+        }
+        throw new Error(`Unexpected fetch in test: ${url}`);
+      }) as unknown as typeof fetch);
+    }
+
+    function jsonOutput(): Record<string, unknown> {
+      const output = logSpy.mock.calls.map((c) => String(c[0])).join('\n');
+      return JSON.parse(output);
+    }
+
+    beforeEach(async () => {
+      testConfigDir = await mkdtemp(join(tmpdir(), 'mux-cli-test-'));
+      originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
+      originalTokenId = process.env.MUX_TOKEN_ID;
+      originalTokenSecret = process.env.MUX_TOKEN_SECRET;
+      process.env.XDG_CONFIG_HOME = testConfigDir;
+      delete process.env.MUX_TOKEN_ID;
+      delete process.env.MUX_TOKEN_SECRET;
+
+      logSpy = spyOn(console, 'log').mockImplementation(() => {});
+      errorSpy = spyOn(console, 'error').mockImplementation(() => {});
+      exitSpy = spyOn(process, 'exit').mockImplementation((() => {
+        throw new Error('process.exit called');
+      }) as never);
+    });
+
+    afterEach(async () => {
+      if (originalXdgConfigHome === undefined) {
+        delete process.env.XDG_CONFIG_HOME;
+      } else {
+        process.env.XDG_CONFIG_HOME = originalXdgConfigHome;
+      }
+      if (originalTokenId === undefined) delete process.env.MUX_TOKEN_ID;
+      else process.env.MUX_TOKEN_ID = originalTokenId;
+      if (originalTokenSecret === undefined)
+        delete process.env.MUX_TOKEN_SECRET;
+      else process.env.MUX_TOKEN_SECRET = originalTokenSecret;
+      logSpy?.mockRestore();
+      errorSpy?.mockRestore();
+      exitSpy?.mockRestore();
+      fetchSpy?.mockRestore();
+      await rm(testConfigDir, { recursive: true, force: true });
+    });
+
+    test('saves the key to the stored environment when credentials come from config', async () => {
+      await setEnvironment('default', {
+        tokenId: 'stored_id',
+        tokenSecret: 'stored_secret',
+        environmentId: 'env_stored_123',
+      });
+      mockApi('env_stored_123');
+
+      await createCommand.parse(['--json']);
+
+      const saved = await getEnvironment('default');
+      expect(saved?.signingKeyId).toBe('key_new_123');
+      expect(saved?.signingPrivateKey).toBe('cHJpdmF0ZS1rZXktcGVt');
+      const parsed = jsonOutput();
+      expect(parsed.id).toBe('key_new_123');
+      expect(parsed.saved).toBe(true);
+      expect(parsed.private_key).toBeUndefined();
+    });
+
+    test('emits the private key once with saved: false when only env vars are set', async () => {
+      process.env.MUX_TOKEN_ID = 'env_id';
+      process.env.MUX_TOKEN_SECRET = 'env_secret';
+      mockApi('env_from_vars');
+
+      await createCommand.parse(['--json']);
+
+      const parsed = jsonOutput();
+      expect(parsed.id).toBe('key_new_123');
+      expect(parsed.saved).toBe(false);
+      expect(parsed.private_key).toBe('cHJpdmF0ZS1rZXktcGVt');
+      expect(String(parsed.note)).toContain('MUX_SIGNING_KEY');
+    });
+
+    test('does not save to a stored environment that env var credentials do not match', async () => {
+      await setEnvironment('default', {
+        tokenId: 'stored_id',
+        tokenSecret: 'stored_secret',
+        environmentId: 'env_stored_123',
+        signingKeyId: 'key_existing',
+        signingPrivateKey: 'existing_private_key',
+      });
+      process.env.MUX_TOKEN_ID = 'env_id';
+      process.env.MUX_TOKEN_SECRET = 'env_secret';
+      mockApi('env_other_456');
+
+      await createCommand.parse(['--json']);
+
+      const saved = await getEnvironment('default');
+      expect(saved?.signingKeyId).toBe('key_existing');
+      expect(saved?.signingPrivateKey).toBe('existing_private_key');
+      const parsed = jsonOutput();
+      expect(parsed.saved).toBe(false);
+      expect(parsed.private_key).toBe('cHJpdmF0ZS1rZXktcGVt');
+    });
+
+    test('saves to a non-default stored environment when env var credentials match it', async () => {
+      await setEnvironment('production', {
+        tokenId: 'prod_id',
+        tokenSecret: 'prod_secret',
+        environmentId: 'env_prod_123',
+      });
+      await setEnvironment('staging', {
+        tokenId: 'staging_id',
+        tokenSecret: 'staging_secret',
+        environmentId: 'env_staging_456',
+      });
+      process.env.MUX_TOKEN_ID = 'env_id';
+      process.env.MUX_TOKEN_SECRET = 'env_secret';
+      mockApi('env_staging_456');
+
+      await createCommand.parse(['--json']);
+
+      const staging = await getEnvironment('staging');
+      expect(staging?.signingKeyId).toBe('key_new_123');
+      const production = await getEnvironment('production');
+      expect(production?.signingKeyId).toBeUndefined();
+      const parsed = jsonOutput();
+      expect(parsed.saved).toBe(true);
+      expect(parsed.environment).toBe('staging');
+    });
+
+    test('saves to the stored environment when env var credentials match it', async () => {
+      await setEnvironment('default', {
+        tokenId: 'stored_id',
+        tokenSecret: 'stored_secret',
+        environmentId: 'env_same_123',
+      });
+      process.env.MUX_TOKEN_ID = 'env_id';
+      process.env.MUX_TOKEN_SECRET = 'env_secret';
+      mockApi('env_same_123');
+
+      await createCommand.parse(['--json']);
+
+      const saved = await getEnvironment('default');
+      expect(saved?.signingKeyId).toBe('key_new_123');
+      const parsed = jsonOutput();
+      expect(parsed.saved).toBe(true);
+    });
+
+    test('prints the private key with guidance in pretty mode when not saved', async () => {
+      process.env.MUX_TOKEN_ID = 'env_id';
+      process.env.MUX_TOKEN_SECRET = 'env_secret';
+      mockApi('env_from_vars');
+
+      await createCommand.parse([]);
+
+      const output = logSpy.mock.calls.map((c) => String(c[0])).join('\n');
+      expect(output).toContain('key_new_123');
+      expect(output).toContain('cHJpdmF0ZS1rZXktcGVt');
+      expect(output).toContain('MUX_SIGNING_KEY');
+      expect(output).toContain('MUX_PRIVATE_KEY');
+      expect(output).toContain('not saved');
     });
   });
 });

--- a/src/commands/signing-keys/create.test.ts
+++ b/src/commands/signing-keys/create.test.ts
@@ -213,6 +213,49 @@ describe('mux signing-keys create command', () => {
       expect(parsed.saved).toBe(true);
     });
 
+    test('fails fast in JSON mode when a signing key exists and --force is omitted', async () => {
+      await setEnvironment('default', {
+        tokenId: 'stored_id',
+        tokenSecret: 'stored_secret',
+        environmentId: 'env_stored_123',
+        signingKeyId: 'key_existing',
+        signingPrivateKey: 'existing_private_key',
+      });
+      mockApi('env_stored_123');
+
+      try {
+        await createCommand.parse(['--json']);
+      } catch (_error) {
+        // Expected to throw via mocked process.exit
+      }
+
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      const parsed = JSON.parse(String(errorSpy.mock.calls[0][0]));
+      expect(parsed.error).toContain('--force');
+      expect(parsed.error).toContain('key_existing');
+      const saved = await getEnvironment('default');
+      expect(saved?.signingKeyId).toBe('key_existing');
+      expect(saved?.signingPrivateKey).toBe('existing_private_key');
+    });
+
+    test('replaces an existing signing key in JSON mode with --force', async () => {
+      await setEnvironment('default', {
+        tokenId: 'stored_id',
+        tokenSecret: 'stored_secret',
+        environmentId: 'env_stored_123',
+        signingKeyId: 'key_existing',
+        signingPrivateKey: 'existing_private_key',
+      });
+      mockApi('env_stored_123');
+
+      await createCommand.parse(['--json', '--force']);
+
+      const saved = await getEnvironment('default');
+      expect(saved?.signingKeyId).toBe('key_new_123');
+      const parsed = jsonOutput();
+      expect(parsed.saved).toBe(true);
+    });
+
     test('prints the private key with guidance in pretty mode when not saved', async () => {
       process.env.MUX_TOKEN_ID = 'env_id';
       process.env.MUX_TOKEN_SECRET = 'env_secret';

--- a/src/commands/signing-keys/create.ts
+++ b/src/commands/signing-keys/create.ts
@@ -1,12 +1,19 @@
 import { Command } from '@cliffy/command';
-import { getCurrentEnvironment, setEnvironment } from '@/lib/config.ts';
+import { setEnvironment } from '@/lib/config.ts';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
-import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
+import {
+  createAuthenticatedMuxClient,
+  resolveActiveEnvironment,
+} from '@/lib/mux.ts';
 import { confirmPrompt } from '@/lib/prompt.ts';
 
 interface CreateOptions {
   json?: boolean;
 }
+
+const NOT_SAVED_NOTE =
+  'No stored environment matches the active credentials, so the private key was not saved. Set MUX_SIGNING_KEY and MUX_PRIVATE_KEY to sign URLs with it.';
 
 export const createCommand = new Command()
   .description(
@@ -18,18 +25,16 @@ export const createCommand = new Command()
       // Initialize authenticated Mux client
       const mux = await createAuthenticatedMuxClient();
 
-      // Get current environment
-      const currentEnv = await getCurrentEnvironment();
-      if (!currentEnv) {
-        throw new Error(
-          "No environment configured. Please run 'mux login' first.",
-        );
-      }
+      // The key is only saved when the stored environment matches the active
+      // credentials; otherwise it would desync from the environment the key
+      // was actually created in.
+      const active = await resolveActiveEnvironment();
+      const target = active.stored;
 
       // Check if a signing key already exists
-      if (currentEnv.environment.signingKeyId && !options.json) {
+      if (target?.environment.signingKeyId && !wantsJson(options)) {
         const confirmed = await confirmPrompt({
-          message: `Environment '${currentEnv.name}' already has a signing key (${currentEnv.environment.signingKeyId}). Replace it?`,
+          message: `Environment '${target.name}' already has a signing key (${target.environment.signingKeyId}). Replace it?`,
           default: false,
         });
 
@@ -47,37 +52,67 @@ export const createCommand = new Command()
       const privateKey = signingKey.private_key;
       const createdAt = signingKey.created_at;
 
-      // Store the signing key in the current environment config
-      // Wrap in try-catch to prevent privateKey from leaking in error messages
-      try {
-        await setEnvironment(currentEnv.name, {
-          ...currentEnv.environment,
-          signingKeyId: keyId,
-          signingPrivateKey: privateKey,
-        });
-      } catch (err) {
-        throw new Error(
-          `Failed to save signing key to config: ${err instanceof Error ? err.message : 'Unknown error'}`,
-        );
+      if (target) {
+        // Store the signing key in the matching environment config
+        // Wrap in try-catch to prevent privateKey from leaking in error messages
+        try {
+          await setEnvironment(target.name, {
+            ...target.environment,
+            signingKeyId: keyId,
+            signingPrivateKey: privateKey,
+          });
+        } catch (err) {
+          throw new Error(
+            `Failed to save signing key to config: ${err instanceof Error ? err.message : 'Unknown error'}`,
+          );
+        }
+
+        if (wantsJson(options)) {
+          console.log(
+            JSON.stringify(
+              {
+                id: keyId,
+                created_at: createdAt,
+                environment: target.name,
+                saved: true,
+              },
+              null,
+              2,
+            ),
+          );
+        } else {
+          console.log(
+            `Signing key created and saved to environment: ${target.name}`,
+          );
+          console.log(`Key ID: ${keyId}`);
+        }
+        return;
       }
 
-      if (options.json) {
+      // No matching stored environment: emit the private key once instead of
+      // persisting it. The API only returns it at creation time.
+      if (wantsJson(options)) {
         console.log(
           JSON.stringify(
             {
               id: keyId,
               created_at: createdAt,
-              environment: currentEnv.name,
+              private_key: privateKey,
+              saved: false,
+              note: NOT_SAVED_NOTE,
             },
             null,
             2,
           ),
         );
       } else {
-        console.log(
-          `Signing key created and saved to environment: ${currentEnv.name}`,
-        );
-        console.log(`Key ID: ${keyId}`);
+        console.log(`Signing key created: ${keyId}`);
+        console.log('Private key (base64, shown once, not saved):');
+        console.log(privateKey);
+        console.log();
+        console.log(NOT_SAVED_NOTE);
+        console.log(`  export MUX_SIGNING_KEY=${keyId}`);
+        console.log('  export MUX_PRIVATE_KEY=<private key above>');
       }
     } catch (error) {
       await handleCommandError(error, 'signing-keys', 'create', options);

--- a/src/commands/signing-keys/create.ts
+++ b/src/commands/signing-keys/create.ts
@@ -1,5 +1,5 @@
 import { Command } from '@cliffy/command';
-import { setEnvironment } from '@/lib/config.ts';
+import { updateEnvironment } from '@/lib/config.ts';
 import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import {
@@ -15,6 +15,9 @@ interface CreateOptions {
 
 const NOT_SAVED_NOTE =
   'No stored environment matches the active credentials, so the private key was not saved. Set MUX_SIGNING_KEY and MUX_PRIVATE_KEY to sign URLs with it.';
+
+const SAVE_FAILED_NOTE =
+  'Saving to the environment config failed, so the private key is shown here instead — this is the only time it is available. Set MUX_SIGNING_KEY and MUX_PRIVATE_KEY to sign URLs with it.';
 
 export const createCommand = new Command()
   .description(
@@ -61,45 +64,54 @@ export const createCommand = new Command()
       const privateKey = signingKey.private_key;
       const createdAt = signingKey.created_at;
 
+      let saveFailed = false;
       if (target) {
-        // Store the signing key in the matching environment config
-        // Wrap in try-catch to prevent privateKey from leaking in error messages
+        // Persist only the two signing fields. updateEnvironment re-reads
+        // the config before merging, so fields another command wrote while
+        // the API calls above were in flight (e.g. a forwardUrl saved by a
+        // long-running `webhooks listen`) are not clobbered.
         try {
-          await setEnvironment(target.name, {
-            ...target.environment,
+          await updateEnvironment(target.name, {
             signingKeyId: keyId,
             signingPrivateKey: privateKey,
           });
+
+          if (wantsJson(options)) {
+            console.log(
+              JSON.stringify(
+                {
+                  id: keyId,
+                  created_at: createdAt,
+                  environment: target.name,
+                  saved: true,
+                },
+                null,
+                2,
+              ),
+            );
+          } else {
+            console.log(
+              `Signing key created and saved to environment: ${target.name}`,
+            );
+            console.log(`Key ID: ${keyId}`);
+          }
+          return;
         } catch (err) {
-          throw new Error(
+          // The key already exists server-side and the API only returns the
+          // private key at creation time — swallowing it here would lose it
+          // forever. Report the save failure on stderr and fall through to
+          // the emit-once output below.
+          console.error(
             `Failed to save signing key to config: ${err instanceof Error ? err.message : 'Unknown error'}`,
           );
+          saveFailed = true;
         }
-
-        if (wantsJson(options)) {
-          console.log(
-            JSON.stringify(
-              {
-                id: keyId,
-                created_at: createdAt,
-                environment: target.name,
-                saved: true,
-              },
-              null,
-              2,
-            ),
-          );
-        } else {
-          console.log(
-            `Signing key created and saved to environment: ${target.name}`,
-          );
-          console.log(`Key ID: ${keyId}`);
-        }
-        return;
       }
 
-      // No matching stored environment: emit the private key once instead of
-      // persisting it. The API only returns it at creation time.
+      // No matching stored environment (or the save failed): emit the
+      // private key once instead of persisting it. The API only returns it
+      // at creation time.
+      const note = saveFailed ? SAVE_FAILED_NOTE : NOT_SAVED_NOTE;
       if (wantsJson(options)) {
         console.log(
           JSON.stringify(
@@ -108,7 +120,7 @@ export const createCommand = new Command()
               created_at: createdAt,
               private_key: privateKey,
               saved: false,
-              note: NOT_SAVED_NOTE,
+              note,
             },
             null,
             2,
@@ -119,7 +131,7 @@ export const createCommand = new Command()
         console.log('Private key (base64, shown once, not saved):');
         console.log(privateKey);
         console.log();
-        console.log(NOT_SAVED_NOTE);
+        console.log(note);
         console.log(`  export MUX_SIGNING_KEY=${keyId}`);
         console.log('  export MUX_PRIVATE_KEY=<private key above>');
       }

--- a/src/commands/signing-keys/create.ts
+++ b/src/commands/signing-keys/create.ts
@@ -10,6 +10,7 @@ import { confirmPrompt } from '@/lib/prompt.ts';
 
 interface CreateOptions {
   json?: boolean;
+  force?: boolean;
 }
 
 const NOT_SAVED_NOTE =
@@ -20,6 +21,7 @@ export const createCommand = new Command()
     'Create a signing key and save to current environment (private key only available at creation)',
   )
   .option('--json', 'Output JSON instead of pretty format')
+  .option('-f, --force', 'Replace an existing signing key without confirmation')
   .action(async (options: CreateOptions) => {
     try {
       // Initialize authenticated Mux client
@@ -31,8 +33,15 @@ export const createCommand = new Command()
       const active = await resolveActiveEnvironment();
       const target = active.stored;
 
-      // Check if a signing key already exists
-      if (target?.environment.signingKeyId && !wantsJson(options)) {
+      // Replacing an existing key is destructive: the saved private key is
+      // overwritten and cannot be retrieved again. Confirm unless --force.
+      if (target?.environment.signingKeyId && !options.force) {
+        if (wantsJson(options)) {
+          throw new Error(
+            `Environment '${target.name}' already has a signing key (${target.environment.signingKeyId}). Replacing it requires the --force flag with --json or in agent mode.`,
+          );
+        }
+
         const confirmed = await confirmPrompt({
           message: `Environment '${target.name}' already has a signing key (${target.environment.signingKeyId}). Replace it?`,
           default: false,

--- a/src/commands/signing-keys/delete.ts
+++ b/src/commands/signing-keys/delete.ts
@@ -1,5 +1,6 @@
 import { Command } from '@cliffy/command';
 import { readConfig, setEnvironment } from '@/lib/config.ts';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 import { confirmPrompt } from '@/lib/prompt.ts';
@@ -32,7 +33,7 @@ export const deleteCommand = new Command()
       }
 
       // Show warning if key is in use
-      if (affectedEnvironments.length > 0 && !options.json) {
+      if (affectedEnvironments.length > 0 && !wantsJson(options)) {
         console.log(
           `WARNING: This signing key is currently configured in environment${affectedEnvironments.length > 1 ? 's' : ''}: ${affectedEnvironments.join(', ')}`,
         );
@@ -45,9 +46,9 @@ export const deleteCommand = new Command()
       // Confirm deletion unless --force flag is provided
       if (!options.force) {
         // For JSON mode, require explicit --force flag for safety
-        if (options.json) {
+        if (wantsJson(options)) {
           throw new Error(
-            'Deletion requires --force flag when using --json output',
+            'Deletion requires the --force flag with --json or in agent mode',
           );
         }
 
@@ -57,7 +58,7 @@ export const deleteCommand = new Command()
         });
 
         if (!confirmed) {
-          if (options.json) {
+          if (wantsJson(options)) {
             console.log(JSON.stringify({ cancelled: true }, null, 2));
           } else {
             console.log('Deletion cancelled.');
@@ -81,7 +82,7 @@ export const deleteCommand = new Command()
         }
       }
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(
           JSON.stringify(
             {

--- a/src/commands/signing-keys/get.ts
+++ b/src/commands/signing-keys/get.ts
@@ -1,5 +1,6 @@
 import { Command } from '@cliffy/command';
 import { readConfig } from '@/lib/config.ts';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 
@@ -31,7 +32,7 @@ export const getCommand = new Command()
         }
       }
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(
           JSON.stringify(
             {

--- a/src/commands/signing-keys/list.ts
+++ b/src/commands/signing-keys/list.ts
@@ -1,5 +1,6 @@
 import { Command } from '@cliffy/command';
 import { readConfig } from '@/lib/config.ts';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 
@@ -35,7 +36,7 @@ export const listCommand = new Command()
         }
       }
 
-      if (options.json) {
+      if (wantsJson(options)) {
         const data = [];
         for await (const key of signingKeys) {
           const envs = activeKeys.get(key.id);

--- a/src/commands/transcription-vocabularies/create.ts
+++ b/src/commands/transcription-vocabularies/create.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 
@@ -44,7 +45,7 @@ export const createCommand = new Command()
       const vocabulary =
         await mux.video.transcriptionVocabularies.create(params);
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify(vocabulary, null, 2));
       } else {
         console.log('Transcription vocabulary created successfully');

--- a/src/commands/transcription-vocabularies/delete.ts
+++ b/src/commands/transcription-vocabularies/delete.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 import { confirmPrompt } from '@/lib/prompt.ts';
@@ -20,9 +21,9 @@ export const deleteCommand = new Command()
       const mux = await createAuthenticatedMuxClient();
 
       if (!options.force) {
-        if (options.json) {
+        if (wantsJson(options)) {
           throw new Error(
-            'Deletion requires --force flag when using --json output',
+            'Deletion requires the --force flag with --json or in agent mode',
           );
         }
 
@@ -39,7 +40,7 @@ export const deleteCommand = new Command()
 
       await mux.video.transcriptionVocabularies.delete(vocabularyId);
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify({ success: true, vocabularyId }, null, 2));
       } else {
         console.log(

--- a/src/commands/transcription-vocabularies/get.ts
+++ b/src/commands/transcription-vocabularies/get.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 
@@ -17,7 +18,7 @@ export const getCommand = new Command()
       const vocabulary =
         await mux.video.transcriptionVocabularies.retrieve(vocabularyId);
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify(vocabulary, null, 2));
       } else {
         console.log(`Vocabulary ID: ${vocabulary.id}`);

--- a/src/commands/transcription-vocabularies/list.ts
+++ b/src/commands/transcription-vocabularies/list.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 
@@ -26,7 +27,7 @@ export const listCommand = new Command()
         page: options.page,
       });
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify(vocabularies, null, 2));
         return;
       }

--- a/src/commands/transcription-vocabularies/update.ts
+++ b/src/commands/transcription-vocabularies/update.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 
@@ -47,7 +48,7 @@ export const updateCommand = new Command()
         params,
       );
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify(vocabulary, null, 2));
       } else {
         console.log('Transcription vocabulary updated successfully');

--- a/src/commands/uploads/cancel.ts
+++ b/src/commands/uploads/cancel.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 import { confirmPrompt } from '@/lib/prompt.ts';
@@ -18,9 +19,9 @@ export const cancelCommand = new Command()
       const mux = await createAuthenticatedMuxClient();
 
       if (!options.force) {
-        if (options.json) {
+        if (wantsJson(options)) {
           throw new Error(
-            'Cancellation requires --force flag when using --json output',
+            'Cancellation requires the --force flag with --json or in agent mode',
           );
         }
 
@@ -37,7 +38,7 @@ export const cancelCommand = new Command()
 
       const upload = await mux.video.uploads.cancel(uploadId);
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify(upload, null, 2));
       } else {
         console.log(`Upload ${uploadId} cancelled successfully`);

--- a/src/commands/uploads/create.ts
+++ b/src/commands/uploads/create.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 
@@ -64,7 +65,7 @@ export const createCommand = new Command()
 
       const upload = await mux.video.uploads.create(params as never);
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify(upload, null, 2));
       } else {
         console.log(`Upload created successfully`);

--- a/src/commands/uploads/get.ts
+++ b/src/commands/uploads/get.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 
@@ -16,7 +17,7 @@ export const getCommand = new Command()
 
       const upload = await mux.video.uploads.retrieve(uploadId);
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify(upload, null, 2));
       } else {
         console.log(`Upload ID: ${upload.id}`);

--- a/src/commands/uploads/list.ts
+++ b/src/commands/uploads/list.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 
@@ -26,7 +27,7 @@ export const listCommand = new Command()
         page: options.page,
       });
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify(uploads, null, 2));
         return;
       }

--- a/src/commands/video-views/get.ts
+++ b/src/commands/video-views/get.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 
@@ -16,7 +17,7 @@ export const getCommand = new Command()
 
       const view = await mux.data.videoViews.retrieve(viewId);
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify(view, null, 2));
         return;
       }

--- a/src/commands/video-views/list.ts
+++ b/src/commands/video-views/list.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { buildDataFilterParams } from '@/lib/data-filters.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
@@ -77,7 +78,7 @@ export const listCommand = new Command()
 
       const response = await mux.data.videoViews.list(params as never);
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify(response, null, 2));
         return;
       }

--- a/src/commands/webhooks/events/EventsBrowserApp.tsx
+++ b/src/commands/webhooks/events/EventsBrowserApp.tsx
@@ -14,15 +14,14 @@ import {
   SelectList,
   type SelectListItem,
 } from '@/lib/tui/index.ts';
-import {
-  buildSignedHeaders,
-  getSigningSecretForCurrentEnv,
-} from '@/lib/webhook-signing.ts';
+import { buildSignedHeaders, getSigningSecret } from '@/lib/webhook-signing.ts';
 
 type View = 'list' | 'detail' | 'filter-type' | 'message';
 
 interface EventsBrowserAppProps {
   environmentId: string;
+  /** Key for the local webhook signing secret (environment name or id). */
+  signingSecretKey: string;
   forwardTo?: string;
 }
 
@@ -35,6 +34,7 @@ function formatEventLabel(event: StoredEvent): string {
 
 export function EventsBrowserApp({
   environmentId,
+  signingSecretKey,
   forwardTo,
 }: EventsBrowserAppProps) {
   const renderer = useRenderer();
@@ -73,7 +73,7 @@ export function EventsBrowserApp({
     async (event: StoredEvent) => {
       if (!forwardTo) return;
       try {
-        const signingSecret = await getSigningSecretForCurrentEnv();
+        const signingSecret = await getSigningSecret(signingSecretKey);
         const body = JSON.stringify(event.payload);
         const response = await fetch(forwardTo, {
           method: 'POST',
@@ -97,7 +97,7 @@ export function EventsBrowserApp({
         );
       }
     },
-    [forwardTo, showMessage],
+    [forwardTo, signingSecretKey, showMessage],
   );
 
   useKeyboard((key) => {

--- a/src/commands/webhooks/events/browse.ts
+++ b/src/commands/webhooks/events/browse.ts
@@ -1,5 +1,6 @@
 import { Command } from '@cliffy/command';
-import { getCurrentEnvironment, updateEnvironment } from '@/lib/config.ts';
+import { updateEnvironment } from '@/lib/config.ts';
+import { resolveActiveEnvironment } from '@/lib/mux.ts';
 
 export const browseCommand = new Command()
   .description('Interactively browse, filter, and replay stored webhook events')
@@ -17,23 +18,21 @@ export const browseCommand = new Command()
         process.exit(1);
       }
 
-      const env = await getCurrentEnvironment();
-      if (!env) {
-        console.error("Not logged in. Please run 'mux login' to authenticate.");
-        process.exit(1);
-      }
-
-      const environmentId = env.environment.environmentId ?? env.name;
+      const active = await resolveActiveEnvironment();
+      const environmentId = active.environmentId;
 
       // Use provided --forward-to, or fall back to the saved URL
-      const forwardTo = options.forwardTo ?? env.environment.forwardUrl;
+      const forwardTo =
+        options.forwardTo ?? active.stored?.environment.forwardUrl;
 
-      // Save the forward URL if a new one was provided
+      // Save the forward URL if a new one was provided. Only persisted when
+      // the stored environment matches the active credentials.
       if (
         options.forwardTo &&
-        options.forwardTo !== env.environment.forwardUrl
+        active.stored &&
+        options.forwardTo !== active.stored.environment.forwardUrl
       ) {
-        await updateEnvironment(env.name, {
+        await updateEnvironment(active.stored.name, {
           forwardUrl: options.forwardTo,
         });
       }
@@ -49,6 +48,7 @@ export const browseCommand = new Command()
       root.render(
         React.createElement(EventsBrowserApp, {
           environmentId,
+          signingSecretKey: active.stored?.name ?? active.environmentId,
           forwardTo,
         }),
       );

--- a/src/commands/webhooks/events/list.test.ts
+++ b/src/commands/webhooks/events/list.test.ts
@@ -1,0 +1,152 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  type Mock,
+  spyOn,
+  test,
+} from 'bun:test';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { setEnvironment } from '@/lib/config.ts';
+import { appendEvent, closeDb } from '@/lib/events-store.ts';
+import { listCommand } from './list.ts';
+
+function makeEvent(id: string, environmentId: string) {
+  return {
+    id,
+    type: 'video.asset.ready',
+    timestamp: new Date().toISOString(),
+    environmentId,
+    payload: { id },
+  };
+}
+
+describe('mux webhooks events list command', () => {
+  let testDir: string;
+  let originalXdgConfigHome: string | undefined;
+  let originalXdgDataHome: string | undefined;
+  let originalTokenId: string | undefined;
+  let originalTokenSecret: string | undefined;
+  let logSpy: Mock<typeof console.log>;
+  let errorSpy: Mock<typeof console.error>;
+  let exitSpy: Mock<typeof process.exit>;
+  let fetchSpy: Mock<typeof fetch> | undefined;
+
+  function mockWhoami(environmentId: string) {
+    fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(
+      (async () =>
+        new Response(
+          JSON.stringify({ data: { environment_id: environmentId } }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        )) as unknown as typeof fetch,
+    );
+  }
+
+  beforeEach(async () => {
+    testDir = await mkdtemp(join(tmpdir(), 'mux-cli-test-'));
+    originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
+    originalXdgDataHome = process.env.XDG_DATA_HOME;
+    originalTokenId = process.env.MUX_TOKEN_ID;
+    originalTokenSecret = process.env.MUX_TOKEN_SECRET;
+    process.env.XDG_CONFIG_HOME = testDir;
+    process.env.XDG_DATA_HOME = testDir;
+    delete process.env.MUX_TOKEN_ID;
+    delete process.env.MUX_TOKEN_SECRET;
+    closeDb();
+
+    logSpy = spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = spyOn(console, 'error').mockImplementation(() => {});
+    exitSpy = spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit called');
+    }) as never);
+  });
+
+  afterEach(async () => {
+    if (originalXdgConfigHome === undefined) {
+      delete process.env.XDG_CONFIG_HOME;
+    } else {
+      process.env.XDG_CONFIG_HOME = originalXdgConfigHome;
+    }
+    if (originalXdgDataHome === undefined) {
+      delete process.env.XDG_DATA_HOME;
+    } else {
+      process.env.XDG_DATA_HOME = originalXdgDataHome;
+    }
+    if (originalTokenId === undefined) delete process.env.MUX_TOKEN_ID;
+    else process.env.MUX_TOKEN_ID = originalTokenId;
+    if (originalTokenSecret === undefined) delete process.env.MUX_TOKEN_SECRET;
+    else process.env.MUX_TOKEN_SECRET = originalTokenSecret;
+    logSpy?.mockRestore();
+    errorSpy?.mockRestore();
+    exitSpy?.mockRestore();
+    fetchSpy?.mockRestore();
+    fetchSpy = undefined;
+    closeDb();
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  function jsonOutput(): Array<{ id: string }> {
+    const output = logSpy.mock.calls.map((c) => String(c[0])).join('\n');
+    return JSON.parse(output);
+  }
+
+  test('lists events for the stored environment id when logged in', async () => {
+    await setEnvironment('default', {
+      tokenId: 'stored_id',
+      tokenSecret: 'stored_secret',
+      environmentId: 'env_stored_123',
+    });
+    appendEvent(makeEvent('evt_stored', 'env_stored_123'));
+    appendEvent(makeEvent('evt_other', 'env_other_456'));
+
+    await listCommand.parse(['--json']);
+
+    const events = jsonOutput();
+    expect(events.map((e) => e.id)).toEqual(['evt_stored']);
+  });
+
+  test('lists events for the env var credentials environment, not the stored one', async () => {
+    await setEnvironment('default', {
+      tokenId: 'stored_id',
+      tokenSecret: 'stored_secret',
+      environmentId: 'env_stored_123',
+    });
+    appendEvent(makeEvent('evt_stored', 'env_stored_123'));
+    appendEvent(makeEvent('evt_other', 'env_other_456'));
+    process.env.MUX_TOKEN_ID = 'env_id';
+    process.env.MUX_TOKEN_SECRET = 'env_secret';
+    mockWhoami('env_other_456');
+
+    await listCommand.parse(['--json']);
+
+    const events = jsonOutput();
+    expect(events.map((e) => e.id)).toEqual(['evt_other']);
+  });
+
+  test('works with env var credentials and no stored config', async () => {
+    appendEvent(makeEvent('evt_env_only', 'env_from_vars'));
+    process.env.MUX_TOKEN_ID = 'env_id';
+    process.env.MUX_TOKEN_SECRET = 'env_secret';
+    mockWhoami('env_from_vars');
+
+    await listCommand.parse(['--json']);
+
+    const events = jsonOutput();
+    expect(events.map((e) => e.id)).toEqual(['evt_env_only']);
+  });
+
+  test('emits a JSON error when no credentials are available', async () => {
+    try {
+      await listCommand.parse(['--json']);
+    } catch (_error) {
+      // Expected to throw via mocked process.exit
+    }
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const parsed = JSON.parse(String(errorSpy.mock.calls[0][0]));
+    expect(parsed.error).toMatch(/MUX_TOKEN_ID/);
+  });
+});

--- a/src/commands/webhooks/events/list.ts
+++ b/src/commands/webhooks/events/list.ts
@@ -1,6 +1,7 @@
 import { Command } from '@cliffy/command';
-import { getCurrentEnvironment } from '@/lib/config.ts';
+import { wantsJson } from '@/lib/context.ts';
 import { listEvents } from '@/lib/events-store.ts';
+import { resolveActiveEnvironment } from '@/lib/mux.ts';
 
 interface ListOptions {
   limit?: number;
@@ -15,16 +16,11 @@ export const listCommand = new Command()
   .option('--json', 'Output JSON instead of pretty format')
   .action(async (options: ListOptions) => {
     try {
-      const env = await getCurrentEnvironment();
-      if (!env) {
-        console.error("Not logged in. Please run 'mux login' to authenticate.");
-        process.exit(1);
-      }
-      const environmentId = env.environment.environmentId ?? env.name;
-      const events = listEvents(environmentId, options.limit);
+      const active = await resolveActiveEnvironment();
+      const events = listEvents(active.environmentId, options.limit);
 
       if (events.length === 0) {
-        if (options.json) {
+        if (wantsJson(options)) {
           console.log(JSON.stringify([], null, 2));
         } else {
           console.log(
@@ -34,7 +30,7 @@ export const listCommand = new Command()
         return;
       }
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify(events, null, 2));
         return;
       }
@@ -46,7 +42,7 @@ export const listCommand = new Command()
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message : String(error);
-      if (options.json) {
+      if (wantsJson(options)) {
         console.error(JSON.stringify({ error: errorMessage }, null, 2));
       } else {
         console.error(`Error: ${errorMessage}`);

--- a/src/commands/webhooks/events/replay.test.ts
+++ b/src/commands/webhooks/events/replay.test.ts
@@ -11,6 +11,7 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { setEnvironment } from '@/lib/config.ts';
+import { closeDb } from '@/lib/events-store.ts';
 import { replayCommand } from './replay.ts';
 
 describe('mux webhooks events replay command', () => {
@@ -27,6 +28,9 @@ describe('mux webhooks events replay command', () => {
     originalXdgDataHome = process.env.XDG_DATA_HOME;
     process.env.XDG_CONFIG_HOME = join(testConfigDir, 'cfg');
     process.env.XDG_DATA_HOME = join(testConfigDir, 'data');
+    // The events store caches its sqlite handle module-wide; drop any handle
+    // another test file opened against its own (possibly deleted) temp dir.
+    closeDb();
 
     logSpy = spyOn(console, 'log').mockImplementation(() => {});
     errorSpy = spyOn(console, 'error').mockImplementation(() => {});
@@ -49,6 +53,7 @@ describe('mux webhooks events replay command', () => {
     logSpy?.mockRestore();
     errorSpy?.mockRestore();
     exitSpy?.mockRestore();
+    closeDb();
     await rm(testConfigDir, { recursive: true, force: true });
   });
 
@@ -82,7 +87,7 @@ describe('mux webhooks events replay command', () => {
     await setEnvironment('default', {
       tokenId: 'stored_id',
       tokenSecret: 'stored_secret',
-      environmentId: 'env_stored_123',
+      environmentId: 'env_replay_qa_isolated',
     });
 
     try {
@@ -99,7 +104,7 @@ describe('mux webhooks events replay command', () => {
     await setEnvironment('default', {
       tokenId: 'stored_id',
       tokenSecret: 'stored_secret',
-      environmentId: 'env_stored_123',
+      environmentId: 'env_replay_qa_isolated',
     });
 
     await replayCommand.parse(['--count', '5', '--json']);

--- a/src/commands/webhooks/events/replay.test.ts
+++ b/src/commands/webhooks/events/replay.test.ts
@@ -1,0 +1,111 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  type Mock,
+  spyOn,
+  test,
+} from 'bun:test';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { setEnvironment } from '@/lib/config.ts';
+import { replayCommand } from './replay.ts';
+
+describe('mux webhooks events replay command', () => {
+  let testConfigDir: string;
+  let originalXdgConfigHome: string | undefined;
+  let originalXdgDataHome: string | undefined;
+  let logSpy: Mock<typeof console.log>;
+  let errorSpy: Mock<typeof console.error>;
+  let exitSpy: Mock<typeof process.exit>;
+
+  beforeEach(async () => {
+    testConfigDir = await mkdtemp(join(tmpdir(), 'mux-cli-test-'));
+    originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
+    originalXdgDataHome = process.env.XDG_DATA_HOME;
+    process.env.XDG_CONFIG_HOME = join(testConfigDir, 'cfg');
+    process.env.XDG_DATA_HOME = join(testConfigDir, 'data');
+
+    logSpy = spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = spyOn(console, 'error').mockImplementation(() => {});
+    exitSpy = spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit called');
+    }) as never);
+  });
+
+  afterEach(async () => {
+    if (originalXdgConfigHome === undefined) {
+      delete process.env.XDG_CONFIG_HOME;
+    } else {
+      process.env.XDG_CONFIG_HOME = originalXdgConfigHome;
+    }
+    if (originalXdgDataHome === undefined) {
+      delete process.env.XDG_DATA_HOME;
+    } else {
+      process.env.XDG_DATA_HOME = originalXdgDataHome;
+    }
+    logSpy?.mockRestore();
+    errorSpy?.mockRestore();
+    exitSpy?.mockRestore();
+    await rm(testConfigDir, { recursive: true, force: true });
+  });
+
+  function stderrJson(): Record<string, unknown> {
+    return JSON.parse(String(errorSpy.mock.calls[0][0]));
+  }
+
+  test('missing event ID and --count is a JSON error in JSON mode', async () => {
+    try {
+      await replayCommand.parse(['--json']);
+    } catch (_error) {
+      // Expected to throw via mocked process.exit
+    }
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(String(stderrJson().error)).toContain('--count');
+  });
+
+  test('event ID combined with --count is a JSON error in JSON mode', async () => {
+    try {
+      await replayCommand.parse(['evt_1', '--count', '2', '--json']);
+    } catch (_error) {
+      // Expected to throw via mocked process.exit
+    }
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(String(stderrJson().error)).toContain('Cannot use both');
+  });
+
+  test('unknown event ID is a JSON error in JSON mode', async () => {
+    await setEnvironment('default', {
+      tokenId: 'stored_id',
+      tokenSecret: 'stored_secret',
+      environmentId: 'env_stored_123',
+    });
+
+    try {
+      await replayCommand.parse(['evt_does_not_exist', '--json']);
+    } catch (_error) {
+      // Expected to throw via mocked process.exit
+    }
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(String(stderrJson().error)).toContain('Event not found');
+  });
+
+  test('empty replay set emits JSON in JSON mode', async () => {
+    await setEnvironment('default', {
+      tokenId: 'stored_id',
+      tokenSecret: 'stored_secret',
+      environmentId: 'env_stored_123',
+    });
+
+    await replayCommand.parse(['--count', '5', '--json']);
+
+    expect(exitSpy).not.toHaveBeenCalled();
+    const output = logSpy.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(JSON.parse(output)).toEqual([]);
+  });
+});

--- a/src/commands/webhooks/events/replay.ts
+++ b/src/commands/webhooks/events/replay.ts
@@ -34,16 +34,15 @@ export const replayCommand = new Command()
   .option('--json', 'Output JSON instead of pretty format')
   .action(async (options: ReplayOptions, eventId?: string) => {
     try {
+      // Thrown (not printed) so the catch below formats them per wantsJson.
       if (!eventId && !options.count) {
-        console.error(
+        throw new Error(
           'Provide an event ID or use --count <n> to replay the last N events.',
         );
-        process.exit(1);
       }
 
       if (eventId && options.count) {
-        console.error('Cannot use both an event ID and --count.');
-        process.exit(1);
+        throw new Error('Cannot use both an event ID and --count.');
       }
 
       const active = await resolveActiveEnvironment();
@@ -71,8 +70,7 @@ export const replayCommand = new Command()
       if (eventId) {
         const event = getEventById(eventId, environmentId);
         if (!event) {
-          console.error(`Event not found: ${eventId}`);
-          process.exit(1);
+          throw new Error(`Event not found: ${eventId}`);
         }
 
         if (!options.forwardTo) {
@@ -104,7 +102,15 @@ export const replayCommand = new Command()
       const count = options.count as number;
       const events = getRecentEvents(environmentId, count);
       if (events.length === 0) {
-        console.log('No stored events to replay.');
+        if (wantsJson(options)) {
+          console.log(
+            options.forwardTo
+              ? JSON.stringify({ forwarded: 0, failed: 0 }, null, 2)
+              : JSON.stringify([], null, 2),
+          );
+        } else {
+          console.log('No stored events to replay.');
+        }
         return;
       }
 

--- a/src/commands/webhooks/events/replay.ts
+++ b/src/commands/webhooks/events/replay.ts
@@ -1,11 +1,10 @@
 import { colors } from '@cliffy/ansi/colors';
 import { Command } from '@cliffy/command';
-import { getCurrentEnvironment, updateEnvironment } from '@/lib/config.ts';
+import { updateEnvironment } from '@/lib/config.ts';
+import { wantsJson } from '@/lib/context.ts';
 import { getEventById, getRecentEvents } from '@/lib/events-store.ts';
-import {
-  buildSignedHeaders,
-  getSigningSecretForCurrentEnv,
-} from '@/lib/webhook-signing.ts';
+import { resolveActiveEnvironment } from '@/lib/mux.ts';
+import { buildSignedHeaders, getSigningSecret } from '@/lib/webhook-signing.ts';
 
 interface ReplayOptions {
   forwardTo?: string;
@@ -47,24 +46,23 @@ export const replayCommand = new Command()
         process.exit(1);
       }
 
-      const env = await getCurrentEnvironment();
-      if (!env) {
-        console.error("Not logged in. Please run 'mux login' to authenticate.");
-        process.exit(1);
-      }
-      const environmentId = env.environment.environmentId ?? env.name;
+      const active = await resolveActiveEnvironment();
+      const environmentId = active.environmentId;
+      const signingSecretKey = active.stored?.name ?? active.environmentId;
 
       // Use provided --forward-to, or fall back to the saved URL
-      if (!options.forwardTo && env.environment.forwardUrl) {
-        options.forwardTo = env.environment.forwardUrl;
+      if (!options.forwardTo && active.stored?.environment.forwardUrl) {
+        options.forwardTo = active.stored.environment.forwardUrl;
       }
 
-      // Save the forward URL if a new one was provided
+      // Save the forward URL if a new one was provided. Only persisted when
+      // the stored environment matches the active credentials.
       if (
         options.forwardTo &&
-        options.forwardTo !== env.environment.forwardUrl
+        active.stored &&
+        options.forwardTo !== active.stored.environment.forwardUrl
       ) {
-        await updateEnvironment(env.name, {
+        await updateEnvironment(active.stored.name, {
           forwardUrl: options.forwardTo,
         });
       }
@@ -82,13 +80,13 @@ export const replayCommand = new Command()
           return;
         }
 
-        const signingSecret = await getSigningSecretForCurrentEnv();
+        const signingSecret = await getSigningSecret(signingSecretKey);
         const { status } = await forwardEvent(
           options.forwardTo,
           event.payload,
           signingSecret,
         );
-        if (options.json) {
+        if (wantsJson(options)) {
           console.log(JSON.stringify({ status, eventId: event.id }, null, 2));
         } else if (status >= 200 && status < 300) {
           console.log(
@@ -111,7 +109,7 @@ export const replayCommand = new Command()
       }
 
       if (!options.forwardTo) {
-        if (options.json) {
+        if (wantsJson(options)) {
           console.log(JSON.stringify(events, null, 2));
         } else {
           for (const event of events) {
@@ -121,7 +119,7 @@ export const replayCommand = new Command()
         return;
       }
 
-      const signingSecret = await getSigningSecretForCurrentEnv();
+      const signingSecret = await getSigningSecret(signingSecretKey);
 
       let forwarded = 0;
       let failed = 0;
@@ -134,14 +132,14 @@ export const replayCommand = new Command()
           );
           if (status >= 200 && status < 300) {
             forwarded++;
-            if (!options.json) {
+            if (!wantsJson(options)) {
               console.log(
                 `${colors.green(`[${status}]`)}  ${event.type.padEnd(30)}  ${event.id}`,
               );
             }
           } else {
             failed++;
-            if (!options.json) {
+            if (!wantsJson(options)) {
               console.log(
                 `${colors.red(`[${status}]`)}  ${event.type.padEnd(30)}  ${event.id}`,
               );
@@ -149,7 +147,7 @@ export const replayCommand = new Command()
           }
         } catch {
           failed++;
-          if (!options.json) {
+          if (!wantsJson(options)) {
             console.log(
               `${colors.red('[ERR]')}  ${event.type.padEnd(30)}  ${event.id}`,
             );
@@ -157,7 +155,7 @@ export const replayCommand = new Command()
         }
       }
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify({ forwarded, failed }, null, 2));
       } else {
         console.log(
@@ -167,7 +165,7 @@ export const replayCommand = new Command()
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message : String(error);
-      if (options.json) {
+      if (wantsJson(options)) {
         console.error(JSON.stringify({ error: errorMessage }, null, 2));
       } else {
         console.error(`Error: ${errorMessage}`);

--- a/src/commands/webhooks/listen.ts
+++ b/src/commands/webhooks/listen.ts
@@ -1,9 +1,10 @@
 import { colors } from '@cliffy/ansi/colors';
 import { Command } from '@cliffy/command';
-import { getCurrentEnvironment, updateEnvironment } from '@/lib/config.ts';
+import { updateEnvironment } from '@/lib/config.ts';
+import { wantsJson } from '@/lib/context.ts';
 import { checkFetchPermissionError } from '@/lib/errors.ts';
 import { appendEvent, type StoredEvent } from '@/lib/events-store.ts';
-import { getAuthHeaders, getMuxBaseUrl } from '@/lib/mux.ts';
+import { getAuthHeaders, resolveActiveEnvironment } from '@/lib/mux.ts';
 import { parseSSEStream } from '@/lib/sse.ts';
 import { buildSignedHeaders, getSigningSecret } from '@/lib/webhook-signing.ts';
 
@@ -32,7 +33,7 @@ export const listenCommand = new Command()
     let backoffMs = INITIAL_BACKOFF_MS;
 
     function printSummary() {
-      if (options.json) return;
+      if (wantsJson(options)) return;
       console.log(`\n${eventCount} event(s) received.`);
       if (options.forwardTo) {
         console.log(
@@ -47,29 +48,42 @@ export const listenCommand = new Command()
       process.exit(0);
     });
 
-    const env = await getCurrentEnvironment();
-    if (!env) {
-      console.error("Not logged in. Please run 'mux login' to authenticate.");
+    let active: Awaited<ReturnType<typeof resolveActiveEnvironment>>;
+    try {
+      active = await resolveActiveEnvironment();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (wantsJson(options)) {
+        console.error(JSON.stringify({ error: message }, null, 2));
+      } else {
+        console.error(`Error: ${message}`);
+      }
       process.exit(1);
     }
 
-    // Save the forward URL for use by replay/browse
-    if (options.forwardTo && options.forwardTo !== env.environment.forwardUrl) {
-      await updateEnvironment(env.name, {
+    // Save the forward URL for use by replay/browse. Only persisted when the
+    // stored environment matches the active credentials.
+    if (
+      options.forwardTo &&
+      active.stored &&
+      options.forwardTo !== active.stored.environment.forwardUrl
+    ) {
+      await updateEnvironment(active.stored.name, {
         forwardUrl: options.forwardTo,
       });
     }
 
     const authHeaders = await getAuthHeaders();
-    const baseUrl = getMuxBaseUrl(env);
-    const url = `${baseUrl}/system/v1/webhook-events/stream`;
+    const url = `${active.baseUrl}/system/v1/webhook-events/stream`;
 
     let signingSecret: string | undefined;
     if (options.forwardTo) {
-      signingSecret = await getSigningSecret(env.name);
+      signingSecret = await getSigningSecret(
+        active.stored?.name ?? active.environmentId,
+      );
     }
 
-    if (!options.json) {
+    if (!wantsJson(options)) {
       console.log(`Connecting...`);
       if (options.forwardTo) {
         console.log(`Forwarding events to ${options.forwardTo}`);
@@ -101,7 +115,7 @@ export const listenCommand = new Command()
           // Permission errors are not transient and should not be retried.
           const permError = await checkFetchPermissionError(response);
           if (permError) {
-            if (options.json) {
+            if (wantsJson(options)) {
               console.error(JSON.stringify({ error: permError }));
             } else {
               console.error(`Error: ${permError}`);
@@ -123,7 +137,7 @@ export const listenCommand = new Command()
         )) {
           if (sseEvent.event === 'connected') {
             backoffMs = INITIAL_BACKOFF_MS;
-            if (!options.json) {
+            if (!wantsJson(options)) {
               console.log(colors.dim('Connected to event stream.\n'));
             }
             continue;
@@ -144,7 +158,7 @@ export const listenCommand = new Command()
             id: eventId,
             type: eventType,
             timestamp,
-            environmentId: env.environment.environmentId ?? env.name,
+            environmentId: active.environmentId,
             payload: parsed,
           };
 
@@ -174,7 +188,7 @@ export const listenCommand = new Command()
             }
           }
 
-          if (options.json) {
+          if (wantsJson(options)) {
             console.log(JSON.stringify(parsed));
           } else {
             const time = new Date().toLocaleTimeString();
@@ -195,7 +209,7 @@ export const listenCommand = new Command()
         }
 
         // Stream ended naturally (server closed connection) — reconnect
-        if (!options.json) {
+        if (!wantsJson(options)) {
           console.log(colors.dim('\nStream ended.'));
         }
       } catch (error) {
@@ -210,13 +224,13 @@ export const listenCommand = new Command()
           errorMessage.includes('getaddrinfo')
         ) {
           console.error(
-            `Error: Could not resolve hostname for ${baseUrl}\n` +
+            `Error: Could not resolve hostname for ${active.baseUrl}\n` +
               'Check that MUX_BASE_URL is set correctly and the host is reachable.',
           );
           process.exit(1);
         }
 
-        if (!options.json) {
+        if (!wantsJson(options)) {
           if (
             errorMessage.includes('ECONNREFUSED') ||
             errorMessage.includes('ECONNRESET') ||
@@ -233,7 +247,7 @@ export const listenCommand = new Command()
 
       // Backoff before reconnecting
       if (!controller.signal.aborted) {
-        if (!options.json) {
+        if (!wantsJson(options)) {
           console.log(colors.dim(`Reconnecting in ${backoffMs / 1000}s...`));
         }
         await new Promise<void>((resolve) => {

--- a/src/commands/webhooks/listen.ts
+++ b/src/commands/webhooks/listen.ts
@@ -223,10 +223,14 @@ export const listenCommand = new Command()
           errorMessage.includes('ENOTFOUND') ||
           errorMessage.includes('getaddrinfo')
         ) {
-          console.error(
-            `Error: Could not resolve hostname for ${active.baseUrl}\n` +
-              'Check that MUX_BASE_URL is set correctly and the host is reachable.',
-          );
+          const message =
+            `Could not resolve hostname for ${active.baseUrl}. ` +
+            'Check that MUX_BASE_URL is set correctly and the host is reachable.';
+          if (wantsJson(options)) {
+            console.error(JSON.stringify({ error: message }, null, 2));
+          } else {
+            console.error(`Error: ${message}`);
+          }
           process.exit(1);
         }
 

--- a/src/commands/webhooks/trigger.ts
+++ b/src/commands/webhooks/trigger.ts
@@ -1,11 +1,12 @@
 import { colors } from '@cliffy/ansi/colors';
 import { Command } from '@cliffy/command';
-import { getCurrentEnvironment } from '@/lib/config.ts';
+import { wantsJson } from '@/lib/context.ts';
 import {
   generateExampleWebhook,
   WEBHOOK_EVENT_TYPES,
   type WebhookEventType,
 } from '@/lib/example-webhooks.ts';
+import { resolveActiveEnvironment } from '@/lib/mux.ts';
 import { buildSignedHeaders, getSigningSecret } from '@/lib/webhook-signing.ts';
 
 interface TriggerOptions {
@@ -35,20 +36,19 @@ export const triggerCommand = new Command()
         process.exit(1);
       }
 
-      const env = await getCurrentEnvironment();
-      if (!env) {
-        console.error("Not logged in. Please run 'mux login' to authenticate.");
-        process.exit(1);
-      }
+      const active = await resolveActiveEnvironment();
+      const envLabel = active.stored?.name ?? active.environmentId;
+      const tokenId =
+        active.stored?.environment.tokenId ?? process.env.MUX_TOKEN_ID ?? '';
 
       const payload = generateExampleWebhook(
         eventType as WebhookEventType,
-        env.name,
-        env.environment.tokenId.slice(0, 6),
+        envLabel,
+        tokenId.slice(0, 6),
       );
 
       const body = JSON.stringify(payload);
-      const signingSecret = await getSigningSecret(env.name);
+      const signingSecret = await getSigningSecret(envLabel);
 
       const response = await fetch(options.forwardTo, {
         method: 'POST',
@@ -58,7 +58,7 @@ export const triggerCommand = new Command()
 
       const status = response.status;
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify({ status, eventType, payload }, null, 2));
       } else if (status >= 200 && status < 300) {
         console.log(
@@ -72,7 +72,7 @@ export const triggerCommand = new Command()
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message : String(error);
-      if (options.json) {
+      if (wantsJson(options)) {
         console.error(JSON.stringify({ error: errorMessage }, null, 2));
       } else {
         console.error(`Error: ${errorMessage}`);

--- a/src/commands/whoami.ts
+++ b/src/commands/whoami.ts
@@ -1,4 +1,5 @@
 import { Command } from '@cliffy/command';
+import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
 import { DEFAULT_BASE_URL, getAuthContext } from '../lib/mux.ts';
 
@@ -21,7 +22,7 @@ export const whoamiCommand = new Command()
       const body = (await response.json()) as { data: Record<string, unknown> };
       const data = body.data;
 
-      if (options.json) {
+      if (wantsJson(options)) {
         console.log(JSON.stringify(data, null, 2));
         return;
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,30 +27,10 @@ import { uploadsCommand } from './commands/uploads/index.ts';
 import { videoViewsCommand } from './commands/video-views/index.ts';
 import { webhooksCommand } from './commands/webhooks/index.ts';
 import { whoamiCommand } from './commands/whoami.ts';
-import { setAgentMode } from './lib/context.ts';
+import { isAgentMode, preprocessArgs } from './lib/context.ts';
 import { checkForUpdate, refreshUpdateCache } from './lib/update-notifier.ts';
 
 const VERSION = pkg.version;
-
-/**
- * Preprocess argv to handle --agent flag before Cliffy parses it.
- * Strips --agent from args, enables agent mode, and injects --json.
- */
-function preprocessArgs(argv: string[]): string[] {
-  const agentIndex = argv.indexOf('--agent');
-  if (agentIndex === -1) {
-    return argv;
-  }
-
-  setAgentMode(true);
-  const args = argv.filter((_, i) => i !== agentIndex);
-
-  if (!args.includes('--json')) {
-    args.push('--json');
-  }
-
-  return args;
-}
 
 // Main CLI command
 const cli = new Command()
@@ -108,10 +88,15 @@ if (import.meta.main) {
   try {
     await cli.parse(preprocessArgs(Bun.argv.slice(2)));
   } catch (error) {
-    if (error instanceof Error) {
-      console.error(`Error: ${error.message}`);
+    const message =
+      error instanceof Error ? error.message : 'An unknown error occurred';
+    // Commands format their own errors via handleCommandError; this is the
+    // fallback for errors that escape them, so it must stay machine-readable
+    // for agent and --json callers.
+    if (isAgentMode() || Bun.argv.includes('--json')) {
+      console.error(JSON.stringify({ error: message }, null, 2));
     } else {
-      console.error('An unknown error occurred');
+      console.error(`Error: ${message}`);
     }
     process.exit(1);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ import { uploadsCommand } from './commands/uploads/index.ts';
 import { videoViewsCommand } from './commands/video-views/index.ts';
 import { webhooksCommand } from './commands/webhooks/index.ts';
 import { whoamiCommand } from './commands/whoami.ts';
-import { isAgentMode, preprocessArgs } from './lib/context.ts';
+import { hasJsonFlag, isAgentMode, preprocessArgs } from './lib/context.ts';
 import { checkForUpdate, refreshUpdateCache } from './lib/update-notifier.ts';
 
 const VERSION = pkg.version;
@@ -82,7 +82,12 @@ if (import.meta.main) {
   refreshUpdateCache().catch(() => {});
 
   process.on('exit', () => {
-    if (updateNotice) console.error(updateNotice);
+    // Suppressed in agent/--json runs: stderr carries machine-readable
+    // errors there and must not mix in prose (same rule as the env
+    // credential shadow notice).
+    if (updateNotice && !isAgentMode() && !hasJsonFlag()) {
+      console.error(updateNotice);
+    }
   });
 
   try {

--- a/src/lib/context.test.ts
+++ b/src/lib/context.test.ts
@@ -1,8 +1,10 @@
 import { afterEach, describe, expect, it } from 'bun:test';
 import {
+  hasJsonFlag,
   isAgentMode,
   preprocessArgs,
   setAgentMode,
+  setJsonFlag,
   wantsJson,
 } from './context.ts';
 
@@ -34,6 +36,7 @@ describe('wantsJson', () => {
 describe('preprocessArgs', () => {
   afterEach(() => {
     setAgentMode(false);
+    setJsonFlag(false);
   });
 
   it('passes args through unchanged when --agent is absent', () => {
@@ -63,5 +66,16 @@ describe('preprocessArgs', () => {
     const result = preprocessArgs(['--agent', 'whoami']);
     expect(result).toEqual(['whoami']);
     expect(isAgentMode()).toBe(true);
+  });
+
+  it('records --json without stripping it', () => {
+    const result = preprocessArgs(['assets', 'list', '--json']);
+    expect(result).toEqual(['assets', 'list', '--json']);
+    expect(hasJsonFlag()).toBe(true);
+  });
+
+  it('does not record the json flag when --json is absent', () => {
+    preprocessArgs(['assets', 'list']);
+    expect(hasJsonFlag()).toBe(false);
   });
 });

--- a/src/lib/context.test.ts
+++ b/src/lib/context.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import {
+  isAgentMode,
+  preprocessArgs,
+  setAgentMode,
+  wantsJson,
+} from './context.ts';
+
+describe('wantsJson', () => {
+  afterEach(() => {
+    setAgentMode(false);
+  });
+
+  it('returns false when --json is not set and agent mode is off', () => {
+    expect(wantsJson({})).toBe(false);
+    expect(wantsJson({ json: undefined })).toBe(false);
+  });
+
+  it('returns true when --json is set', () => {
+    expect(wantsJson({ json: true })).toBe(true);
+  });
+
+  it('returns true in agent mode even without --json', () => {
+    setAgentMode(true);
+    expect(wantsJson({})).toBe(true);
+  });
+
+  it('returns true when both --json and agent mode are set', () => {
+    setAgentMode(true);
+    expect(wantsJson({ json: true })).toBe(true);
+  });
+});
+
+describe('preprocessArgs', () => {
+  afterEach(() => {
+    setAgentMode(false);
+  });
+
+  it('passes args through unchanged when --agent is absent', () => {
+    const args = ['assets', 'list', '--json'];
+    expect(preprocessArgs(args)).toEqual(['assets', 'list', '--json']);
+    expect(isAgentMode()).toBe(false);
+  });
+
+  it('strips --agent and enables agent mode', () => {
+    const args = ['assets', 'list', '--agent'];
+    expect(preprocessArgs(args)).toEqual(['assets', 'list']);
+    expect(isAgentMode()).toBe(true);
+  });
+
+  it('does NOT inject --json (commands consult agent mode instead)', () => {
+    const result = preprocessArgs(['login', '--agent']);
+    expect(result).toEqual(['login']);
+    expect(result).not.toContain('--json');
+  });
+
+  it('leaves an explicit --json in place alongside --agent', () => {
+    const result = preprocessArgs(['assets', 'list', '--agent', '--json']);
+    expect(result).toEqual(['assets', 'list', '--json']);
+  });
+
+  it('strips --agent regardless of position', () => {
+    const result = preprocessArgs(['--agent', 'whoami']);
+    expect(result).toEqual(['whoami']);
+    expect(isAgentMode()).toBe(true);
+  });
+});

--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -7,3 +7,27 @@ export function setAgentMode(value: boolean) {
 export function isAgentMode(): boolean {
   return agentMode;
 }
+
+/**
+ * Whether a command should produce machine-readable JSON output.
+ * True when the command was invoked with --json or when agent mode is active.
+ */
+export function wantsJson(options: { json?: boolean }): boolean {
+  return Boolean(options.json) || agentMode;
+}
+
+/**
+ * Preprocess argv to handle the --agent flag before Cliffy parses it.
+ * Strips --agent from args and enables agent mode. Commands consult
+ * agent mode via wantsJson()/isAgentMode() to decide output format, so
+ * no --json flag is injected and commands without one still work.
+ */
+export function preprocessArgs(argv: string[]): string[] {
+  const agentIndex = argv.indexOf('--agent');
+  if (agentIndex === -1) {
+    return argv;
+  }
+
+  setAgentMode(true);
+  return argv.filter((_, i) => i !== agentIndex);
+}

--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -1,4 +1,5 @@
 let agentMode = false;
+let jsonFlag = false;
 
 export function setAgentMode(value: boolean) {
   agentMode = value;
@@ -6,6 +7,19 @@ export function setAgentMode(value: boolean) {
 
 export function isAgentMode(): boolean {
   return agentMode;
+}
+
+export function setJsonFlag(value: boolean) {
+  jsonFlag = value;
+}
+
+/**
+ * Whether --json appeared anywhere in argv. Lets process-wide notices that
+ * cannot see per-command options (e.g. the env credential shadow warning)
+ * stay off stderr when output is meant to be machine-readable.
+ */
+export function hasJsonFlag(): boolean {
+  return jsonFlag;
 }
 
 /**
@@ -23,6 +37,10 @@ export function wantsJson(options: { json?: boolean }): boolean {
  * no --json flag is injected and commands without one still work.
  */
 export function preprocessArgs(argv: string[]): string[] {
+  if (argv.includes('--json')) {
+    setJsonFlag(true);
+  }
+
   const agentIndex = argv.indexOf('--agent');
   if (agentIndex === -1) {
     return argv;

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,4 +1,5 @@
 import { AuthenticationError, NotFoundError } from '@mux/mux-node';
+import { wantsJson } from '@/lib/context.ts';
 import { getAuthContext } from './mux.ts';
 
 /**
@@ -74,11 +75,13 @@ export async function handleCommandError(
   _action: string,
   options: { json?: boolean },
 ): Promise<never> {
+  const json = wantsJson(options);
+
   // 401: invalid/expired credentials
   if (error instanceof AuthenticationError) {
     const message =
       "Authentication failed. Please run 'mux login' to re-authenticate.";
-    if (options.json) {
+    if (json) {
       console.error(JSON.stringify({ error: message }, null, 2));
     } else {
       console.error(`Error: ${message}`);
@@ -96,7 +99,7 @@ export async function handleCommandError(
         tokenInfo.tokenName,
         error.error,
       );
-      if (options.json) {
+      if (json) {
         console.error(
           JSON.stringify(
             {
@@ -119,7 +122,7 @@ export async function handleCommandError(
   // Default: generic error formatting
   const errorMessage = error instanceof Error ? error.message : String(error);
 
-  if (options.json) {
+  if (json) {
     console.error(JSON.stringify({ error: errorMessage }, null, 2));
   } else {
     console.error(`Error: ${errorMessage}`);

--- a/src/lib/mux.test.ts
+++ b/src/lib/mux.test.ts
@@ -1,9 +1,25 @@
-import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type Mock,
+  spyOn,
+} from 'bun:test';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { getCurrentEnvironment, setEnvironment } from './config.ts';
-import { DEFAULT_BASE_URL, getMuxBaseUrl } from './mux.ts';
+import { setAgentMode } from './context.ts';
+import {
+  createAuthenticatedMuxClient,
+  DEFAULT_BASE_URL,
+  getAuthContext,
+  getMuxBaseUrl,
+  resetEnvCredentialNotice,
+  resolveActiveEnvironment,
+} from './mux.ts';
 
 describe('getMuxBaseUrl', () => {
   let testConfigDir: string;
@@ -68,5 +84,394 @@ describe('getMuxBaseUrl', () => {
 
     const env = await getCurrentEnvironment();
     expect(getMuxBaseUrl(env)).toBe(DEFAULT_BASE_URL);
+  });
+});
+
+describe('auth fallback to environment variables', () => {
+  let testConfigDir: string;
+  let originalXdgConfigHome: string | undefined;
+  let originalTokenId: string | undefined;
+  let originalTokenSecret: string | undefined;
+
+  beforeEach(async () => {
+    testConfigDir = await mkdtemp(join(tmpdir(), 'mux-cli-test-'));
+    originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
+    originalTokenId = process.env.MUX_TOKEN_ID;
+    originalTokenSecret = process.env.MUX_TOKEN_SECRET;
+    process.env.XDG_CONFIG_HOME = testConfigDir;
+    delete process.env.MUX_TOKEN_ID;
+    delete process.env.MUX_TOKEN_SECRET;
+    resetEnvCredentialNotice();
+  });
+
+  afterEach(async () => {
+    if (originalXdgConfigHome === undefined) {
+      delete process.env.XDG_CONFIG_HOME;
+    } else {
+      process.env.XDG_CONFIG_HOME = originalXdgConfigHome;
+    }
+    if (originalTokenId === undefined) {
+      delete process.env.MUX_TOKEN_ID;
+    } else {
+      process.env.MUX_TOKEN_ID = originalTokenId;
+    }
+    if (originalTokenSecret === undefined) {
+      delete process.env.MUX_TOKEN_SECRET;
+    } else {
+      process.env.MUX_TOKEN_SECRET = originalTokenSecret;
+    }
+    setAgentMode(false);
+    await rm(testConfigDir, { recursive: true, force: true });
+  });
+
+  describe('getAuthContext', () => {
+    it('uses MUX_TOKEN_ID/MUX_TOKEN_SECRET env vars when not logged in', async () => {
+      process.env.MUX_TOKEN_ID = 'env_token_id';
+      process.env.MUX_TOKEN_SECRET = 'env_token_secret';
+
+      const { headers } = await getAuthContext();
+      expect(headers.Authorization).toBe(
+        `Basic ${btoa('env_token_id:env_token_secret')}`,
+      );
+    });
+
+    it('prefers env vars over stored config (consistent with MUX_BASE_URL)', async () => {
+      await setEnvironment('default', {
+        tokenId: 'stored_id',
+        tokenSecret: 'stored_secret',
+      });
+      process.env.MUX_TOKEN_ID = 'env_token_id';
+      process.env.MUX_TOKEN_SECRET = 'env_token_secret';
+
+      const { headers } = await getAuthContext();
+      expect(headers.Authorization).toBe(
+        `Basic ${btoa('env_token_id:env_token_secret')}`,
+      );
+    });
+
+    it('uses stored config when env vars are absent', async () => {
+      await setEnvironment('default', {
+        tokenId: 'stored_id',
+        tokenSecret: 'stored_secret',
+      });
+
+      const { headers } = await getAuthContext();
+      expect(headers.Authorization).toBe(
+        `Basic ${btoa('stored_id:stored_secret')}`,
+      );
+    });
+
+    it('prints a one-time stderr notice when env vars shadow a stored login', async () => {
+      await setEnvironment('default', {
+        tokenId: 'stored_id',
+        tokenSecret: 'stored_secret',
+      });
+      process.env.MUX_TOKEN_ID = 'env_token_id';
+      process.env.MUX_TOKEN_SECRET = 'env_token_secret';
+      const errorSpy = spyOn(console, 'error').mockImplementation(() => {});
+      let notices: string[];
+
+      try {
+        await getAuthContext();
+        await getAuthContext();
+        notices = errorSpy.mock.calls
+          .map((c) => String(c[0]))
+          .filter((m) => m.includes('MUX_TOKEN_ID'));
+      } finally {
+        errorSpy.mockRestore();
+      }
+
+      expect(notices).toHaveLength(1);
+      expect(notices[0]).toContain('stored login');
+    });
+
+    it('suppresses the notice in agent mode', async () => {
+      await setEnvironment('default', {
+        tokenId: 'stored_id',
+        tokenSecret: 'stored_secret',
+      });
+      process.env.MUX_TOKEN_ID = 'env_token_id';
+      process.env.MUX_TOKEN_SECRET = 'env_token_secret';
+      setAgentMode(true);
+      const errorSpy = spyOn(console, 'error').mockImplementation(() => {});
+      let callCount: number;
+
+      try {
+        await getAuthContext();
+        callCount = errorSpy.mock.calls.length;
+      } finally {
+        errorSpy.mockRestore();
+      }
+
+      expect(callCount).toBe(0);
+    });
+
+    it('prints no notice when there is no stored login to shadow', async () => {
+      process.env.MUX_TOKEN_ID = 'env_token_id';
+      process.env.MUX_TOKEN_SECRET = 'env_token_secret';
+      const errorSpy = spyOn(console, 'error').mockImplementation(() => {});
+      let callCount: number;
+
+      try {
+        await getAuthContext();
+        callCount = errorSpy.mock.calls.length;
+      } finally {
+        errorSpy.mockRestore();
+      }
+
+      expect(callCount).toBe(0);
+    });
+
+    it('does not inherit the stored config baseUrl when credentials come from env vars', async () => {
+      await setEnvironment('default', {
+        tokenId: 'stored_id',
+        tokenSecret: 'stored_secret',
+        baseUrl: 'https://stored.example.com',
+      });
+      process.env.MUX_TOKEN_ID = 'env_token_id';
+      process.env.MUX_TOKEN_SECRET = 'env_token_secret';
+
+      const { baseUrl } = await getAuthContext();
+      expect(baseUrl).toBe(DEFAULT_BASE_URL);
+    });
+
+    it('uses the stored config baseUrl when credentials come from config', async () => {
+      await setEnvironment('default', {
+        tokenId: 'stored_id',
+        tokenSecret: 'stored_secret',
+        baseUrl: 'https://stored.example.com',
+      });
+
+      const { baseUrl } = await getAuthContext();
+      expect(baseUrl).toBe('https://stored.example.com');
+    });
+
+    it('ignores env vars when only one of the pair is set', async () => {
+      process.env.MUX_TOKEN_ID = 'env_token_id';
+
+      expect(getAuthContext()).rejects.toThrow(/not logged in/i);
+    });
+
+    it('error message mentions both env vars and mux login', async () => {
+      try {
+        await getAuthContext();
+        expect.unreachable('should have thrown');
+      } catch (error) {
+        const message = (error as Error).message;
+        expect(message).toContain('MUX_TOKEN_ID');
+        expect(message).toContain('MUX_TOKEN_SECRET');
+        expect(message).toContain('mux login');
+      }
+    });
+  });
+
+  describe('createAuthenticatedMuxClient', () => {
+    it('creates a client from env vars when not logged in', async () => {
+      process.env.MUX_TOKEN_ID = 'env_token_id';
+      process.env.MUX_TOKEN_SECRET = 'env_token_secret';
+
+      const client = await createAuthenticatedMuxClient();
+      expect(client.tokenId).toBe('env_token_id');
+      expect(client.tokenSecret).toBe('env_token_secret');
+    });
+
+    it('throws the updated error when no credentials anywhere', async () => {
+      expect(createAuthenticatedMuxClient()).rejects.toThrow(/MUX_TOKEN_ID/);
+    });
+  });
+
+  describe('resolveActiveEnvironment', () => {
+    let fetchSpy: Mock<typeof fetch>;
+
+    function mockWhoami(environmentId: string | undefined, status = 200) {
+      fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(
+        (async () =>
+          new Response(
+            JSON.stringify({ data: { environment_id: environmentId } }),
+            { status },
+          )) as unknown as typeof fetch,
+      );
+    }
+
+    afterEach(() => {
+      fetchSpy?.mockRestore();
+    });
+
+    it('uses the stored environment without calling the API when env vars are absent', async () => {
+      await setEnvironment('default', {
+        tokenId: 'stored_id',
+        tokenSecret: 'stored_secret',
+        environmentId: 'env_stored_123',
+      });
+      fetchSpy = spyOn(globalThis, 'fetch').mockImplementation((async () => {
+        throw new Error('unexpected fetch');
+      }) as unknown as typeof fetch);
+
+      const active = await resolveActiveEnvironment();
+
+      expect(active.source).toBe('config');
+      expect(active.environmentId).toBe('env_stored_123');
+      expect(active.stored?.name).toBe('default');
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('falls back to the environment name when stored config has no environmentId', async () => {
+      await setEnvironment('legacy', {
+        tokenId: 'stored_id',
+        tokenSecret: 'stored_secret',
+      });
+
+      const active = await resolveActiveEnvironment();
+
+      expect(active.source).toBe('config');
+      expect(active.environmentId).toBe('legacy');
+      expect(active.stored?.name).toBe('legacy');
+    });
+
+    it('resolves the environment id via whoami when only env vars are set', async () => {
+      process.env.MUX_TOKEN_ID = 'env_token_id';
+      process.env.MUX_TOKEN_SECRET = 'env_token_secret';
+      mockWhoami('env_from_whoami');
+
+      const active = await resolveActiveEnvironment();
+
+      expect(active.source).toBe('env');
+      expect(active.environmentId).toBe('env_from_whoami');
+      expect(active.stored).toBeNull();
+    });
+
+    it('returns the stored environment when env var credentials match it', async () => {
+      await setEnvironment('default', {
+        tokenId: 'stored_id',
+        tokenSecret: 'stored_secret',
+        environmentId: 'env_same_123',
+      });
+      process.env.MUX_TOKEN_ID = 'env_token_id';
+      process.env.MUX_TOKEN_SECRET = 'env_token_secret';
+      mockWhoami('env_same_123');
+
+      const active = await resolveActiveEnvironment();
+
+      expect(active.source).toBe('env');
+      expect(active.environmentId).toBe('env_same_123');
+      expect(active.stored?.name).toBe('default');
+    });
+
+    it('matches env var credentials against non-default stored environments', async () => {
+      await setEnvironment('production', {
+        tokenId: 'prod_id',
+        tokenSecret: 'prod_secret',
+        environmentId: 'env_prod_123',
+      });
+      await setEnvironment('staging', {
+        tokenId: 'staging_id',
+        tokenSecret: 'staging_secret',
+        environmentId: 'env_staging_456',
+      });
+      process.env.MUX_TOKEN_ID = 'env_token_id';
+      process.env.MUX_TOKEN_SECRET = 'env_token_secret';
+      mockWhoami('env_staging_456');
+
+      const active = await resolveActiveEnvironment();
+
+      expect(active.source).toBe('env');
+      expect(active.environmentId).toBe('env_staging_456');
+      expect(active.stored?.name).toBe('staging');
+    });
+
+    it('prefers the current environment when multiple stored environments match', async () => {
+      await setEnvironment('prod-copy', {
+        tokenId: 'a_id',
+        tokenSecret: 'a_secret',
+        environmentId: 'env_same_123',
+      });
+      await setEnvironment('prod', {
+        tokenId: 'b_id',
+        tokenSecret: 'b_secret',
+        environmentId: 'env_same_123',
+      });
+      // prod-copy was added first, so it is the default/current environment
+      process.env.MUX_TOKEN_ID = 'env_token_id';
+      process.env.MUX_TOKEN_SECRET = 'env_token_secret';
+      mockWhoami('env_same_123');
+
+      const active = await resolveActiveEnvironment();
+
+      expect(active.stored?.name).toBe('prod-copy');
+    });
+
+    it('drops the stored environment when env var credentials point elsewhere', async () => {
+      await setEnvironment('default', {
+        tokenId: 'stored_id',
+        tokenSecret: 'stored_secret',
+        environmentId: 'env_stored_123',
+      });
+      process.env.MUX_TOKEN_ID = 'env_token_id';
+      process.env.MUX_TOKEN_SECRET = 'env_token_secret';
+      mockWhoami('env_other_456');
+
+      const active = await resolveActiveEnvironment();
+
+      expect(active.source).toBe('env');
+      expect(active.environmentId).toBe('env_other_456');
+      expect(active.stored).toBeNull();
+    });
+
+    it('drops the stored environment when it has no environmentId to compare', async () => {
+      await setEnvironment('default', {
+        tokenId: 'stored_id',
+        tokenSecret: 'stored_secret',
+      });
+      process.env.MUX_TOKEN_ID = 'env_token_id';
+      process.env.MUX_TOKEN_SECRET = 'env_token_secret';
+      mockWhoami('env_other_456');
+
+      const active = await resolveActiveEnvironment();
+
+      expect(active.stored).toBeNull();
+    });
+
+    it('resolves the base URL from the credential source, not the stored config', async () => {
+      await setEnvironment('default', {
+        tokenId: 'stored_id',
+        tokenSecret: 'stored_secret',
+        environmentId: 'env_stored_123',
+        baseUrl: 'https://stored.example.com',
+      });
+      process.env.MUX_TOKEN_ID = 'env_token_id';
+      process.env.MUX_TOKEN_SECRET = 'env_token_secret';
+      mockWhoami('env_other_456');
+
+      const active = await resolveActiveEnvironment();
+
+      expect(active.baseUrl).toBe(DEFAULT_BASE_URL);
+      const whoamiUrl = String(fetchSpy.mock.calls[0][0]);
+      expect(whoamiUrl.startsWith(DEFAULT_BASE_URL)).toBe(true);
+    });
+
+    it('returns the stored baseUrl when credentials come from config', async () => {
+      await setEnvironment('default', {
+        tokenId: 'stored_id',
+        tokenSecret: 'stored_secret',
+        environmentId: 'env_stored_123',
+        baseUrl: 'https://stored.example.com',
+      });
+
+      const active = await resolveActiveEnvironment();
+
+      expect(active.baseUrl).toBe('https://stored.example.com');
+    });
+
+    it('throws when whoami rejects the env var credentials', async () => {
+      process.env.MUX_TOKEN_ID = 'env_token_id';
+      process.env.MUX_TOKEN_SECRET = 'bad_secret';
+      mockWhoami(undefined, 401);
+
+      expect(resolveActiveEnvironment()).rejects.toThrow(/credentials/i);
+    });
+
+    it('throws when no credentials are available anywhere', async () => {
+      expect(resolveActiveEnvironment()).rejects.toThrow(/MUX_TOKEN_ID/);
+    });
   });
 });

--- a/src/lib/mux.test.ts
+++ b/src/lib/mux.test.ts
@@ -11,7 +11,7 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { getCurrentEnvironment, setEnvironment } from './config.ts';
-import { setAgentMode } from './context.ts';
+import { setAgentMode, setJsonFlag } from './context.ts';
 import {
   createAuthenticatedMuxClient,
   DEFAULT_BASE_URL,
@@ -121,6 +121,7 @@ describe('auth fallback to environment variables', () => {
       process.env.MUX_TOKEN_SECRET = originalTokenSecret;
     }
     setAgentMode(false);
+    setJsonFlag(false);
     await rm(testConfigDir, { recursive: true, force: true });
   });
 
@@ -193,6 +194,27 @@ describe('auth fallback to environment variables', () => {
       process.env.MUX_TOKEN_ID = 'env_token_id';
       process.env.MUX_TOKEN_SECRET = 'env_token_secret';
       setAgentMode(true);
+      const errorSpy = spyOn(console, 'error').mockImplementation(() => {});
+      let callCount: number;
+
+      try {
+        await getAuthContext();
+        callCount = errorSpy.mock.calls.length;
+      } finally {
+        errorSpy.mockRestore();
+      }
+
+      expect(callCount).toBe(0);
+    });
+
+    it('suppresses the notice when --json was passed', async () => {
+      await setEnvironment('default', {
+        tokenId: 'stored_id',
+        tokenSecret: 'stored_secret',
+      });
+      process.env.MUX_TOKEN_ID = 'env_token_id';
+      process.env.MUX_TOKEN_SECRET = 'env_token_secret';
+      setJsonFlag(true);
       const errorSpy = spyOn(console, 'error').mockImplementation(() => {});
       let callCount: number;
 
@@ -501,6 +523,90 @@ describe('auth fallback to environment variables', () => {
       const active = await resolveActiveEnvironment();
 
       expect(active.baseUrl).toBe('https://stored.example.com');
+    });
+
+    it('skips whoami when env credentials byte-match a stored environment', async () => {
+      await setEnvironment('default', {
+        tokenId: 'same_id',
+        tokenSecret: 'same_secret',
+        environmentId: 'env_same_123',
+      });
+      process.env.MUX_TOKEN_ID = 'same_id';
+      process.env.MUX_TOKEN_SECRET = 'same_secret';
+      fetchSpy = spyOn(globalThis, 'fetch').mockImplementation((async () => {
+        throw new Error('unexpected fetch');
+      }) as unknown as typeof fetch);
+
+      const active = await resolveActiveEnvironment();
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(active.source).toBe('env');
+      expect(active.environmentId).toBe('env_same_123');
+      expect(active.stored?.name).toBe('default');
+    });
+
+    it('skips whoami when env credentials byte-match a non-default stored environment', async () => {
+      await setEnvironment('production', {
+        tokenId: 'prod_id',
+        tokenSecret: 'prod_secret',
+        environmentId: 'env_prod_123',
+      });
+      await setEnvironment('staging', {
+        tokenId: 'staging_id',
+        tokenSecret: 'staging_secret',
+        environmentId: 'env_staging_456',
+      });
+      process.env.MUX_TOKEN_ID = 'staging_id';
+      process.env.MUX_TOKEN_SECRET = 'staging_secret';
+      fetchSpy = spyOn(globalThis, 'fetch').mockImplementation((async () => {
+        throw new Error('unexpected fetch');
+      }) as unknown as typeof fetch);
+
+      const active = await resolveActiveEnvironment();
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(active.environmentId).toBe('env_staging_456');
+      expect(active.stored?.name).toBe('staging');
+    });
+
+    it('still calls whoami when the byte-matching environment has no environmentId', async () => {
+      await setEnvironment('legacy', {
+        tokenId: 'same_id',
+        tokenSecret: 'same_secret',
+      });
+      process.env.MUX_TOKEN_ID = 'same_id';
+      process.env.MUX_TOKEN_SECRET = 'same_secret';
+      mockWhoami('env_from_whoami');
+
+      const active = await resolveActiveEnvironment();
+
+      expect(fetchSpy).toHaveBeenCalled();
+      expect(active.environmentId).toBe('env_from_whoami');
+    });
+
+    it('wraps whoami network failures in an actionable error', async () => {
+      process.env.MUX_TOKEN_ID = 'env_token_id';
+      process.env.MUX_TOKEN_SECRET = 'env_token_secret';
+      fetchSpy = spyOn(globalThis, 'fetch').mockImplementation((async () => {
+        throw new TypeError('fetch failed');
+      }) as unknown as typeof fetch);
+
+      expect(resolveActiveEnvironment()).rejects.toThrow(
+        /failed to reach.*network/is,
+      );
+    });
+
+    it('wraps non-JSON whoami responses in an actionable error', async () => {
+      process.env.MUX_TOKEN_ID = 'env_token_id';
+      process.env.MUX_TOKEN_SECRET = 'env_token_secret';
+      fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(
+        (async () =>
+          new Response('<html>proxy</html>', {
+            status: 200,
+          })) as unknown as typeof fetch,
+      );
+
+      expect(resolveActiveEnvironment()).rejects.toThrow(/non-JSON response/);
     });
 
     it('throws when whoami rejects the env var credentials', async () => {

--- a/src/lib/mux.test.ts
+++ b/src/lib/mux.test.ts
@@ -569,7 +569,7 @@ describe('auth fallback to environment variables', () => {
       expect(active.stored?.name).toBe('staging');
     });
 
-    it('still calls whoami when the byte-matching environment has no environmentId', async () => {
+    it('verifies a legacy byte-matching environment via whoami and still binds it', async () => {
       await setEnvironment('legacy', {
         tokenId: 'same_id',
         tokenSecret: 'same_secret',
@@ -582,6 +582,9 @@ describe('auth fallback to environment variables', () => {
 
       expect(fetchSpy).toHaveBeenCalled();
       expect(active.environmentId).toBe('env_from_whoami');
+      // Identical credentials mean the legacy entry IS this environment,
+      // even though it has no environmentId to match by id.
+      expect(active.stored?.name).toBe('legacy');
     });
 
     it('wraps whoami network failures in an actionable error', async () => {

--- a/src/lib/mux.test.ts
+++ b/src/lib/mux.test.ts
@@ -431,6 +431,47 @@ describe('auth fallback to environment variables', () => {
       expect(active.stored).toBeNull();
     });
 
+    it('prints the shadow notice when env vars redirect away from a stored login', async () => {
+      await setEnvironment('default', {
+        tokenId: 'stored_id',
+        tokenSecret: 'stored_secret',
+        environmentId: 'env_stored_123',
+      });
+      process.env.MUX_TOKEN_ID = 'env_token_id';
+      process.env.MUX_TOKEN_SECRET = 'env_token_secret';
+      mockWhoami('env_other_456');
+      const errorSpy = spyOn(console, 'error').mockImplementation(() => {});
+      let notices: string[];
+
+      try {
+        await resolveActiveEnvironment();
+        notices = errorSpy.mock.calls
+          .map((c) => String(c[0]))
+          .filter((m) => m.includes('MUX_TOKEN_ID'));
+      } finally {
+        errorSpy.mockRestore();
+      }
+
+      expect(notices).toHaveLength(1);
+    });
+
+    it('prints no notice when only env credentials exist', async () => {
+      process.env.MUX_TOKEN_ID = 'env_token_id';
+      process.env.MUX_TOKEN_SECRET = 'env_token_secret';
+      mockWhoami('env_from_whoami');
+      const errorSpy = spyOn(console, 'error').mockImplementation(() => {});
+      let callCount: number;
+
+      try {
+        await resolveActiveEnvironment();
+        callCount = errorSpy.mock.calls.length;
+      } finally {
+        errorSpy.mockRestore();
+      }
+
+      expect(callCount).toBe(0);
+    });
+
     it('resolves the base URL from the credential source, not the stored config', async () => {
       await setEnvironment('default', {
         tokenId: 'stored_id',

--- a/src/lib/mux.ts
+++ b/src/lib/mux.ts
@@ -5,7 +5,7 @@ import {
   getCurrentEnvironment,
   readConfig,
 } from './config.ts';
-import { isAgentMode } from './context.ts';
+import { hasJsonFlag, isAgentMode } from './context.ts';
 
 export const DEFAULT_BASE_URL = 'https://api.mux.com';
 
@@ -40,10 +40,11 @@ export function resetEnvCredentialNotice(): void {
 /**
  * Warn once per process when env var credentials shadow a stored login, so
  * a forgotten shell variable does not silently switch accounts. Suppressed
- * in agent mode, where output must stay machine-readable.
+ * in agent mode and when --json was passed, where output (including stderr
+ * errors) must stay machine-readable.
  */
 function noticeEnvCredentialsShadowStoredLogin(): void {
-  if (envCredentialNoticeShown || isAgentMode()) return;
+  if (envCredentialNoticeShown || isAgentMode() || hasJsonFlag()) return;
   envCredentialNoticeShown = true;
   console.error(
     'Using MUX_TOKEN_ID/MUX_TOKEN_SECRET from environment variables; they take precedence over the stored login.',
@@ -133,6 +134,37 @@ async function findStoredEnvironmentById(
 }
 
 /**
+ * Find the stored environment holding exactly these credentials, checking
+ * every named environment. Prefers the current environment when it matches.
+ * Byte-identical credentials cannot belong to a different environment than
+ * the stored entry that holds them, so a match lets callers skip the
+ * /whoami round-trip.
+ */
+async function findStoredEnvironmentByCredentials(
+  tokenId: string,
+  tokenSecret: string,
+  current: { name: string; environment: Environment } | null,
+): Promise<{ name: string; environment: Environment } | null> {
+  const matches = (environment: Environment) =>
+    environment.tokenId === tokenId && environment.tokenSecret === tokenSecret;
+
+  if (current && matches(current.environment)) {
+    return current;
+  }
+
+  const config = await readConfig();
+  if (!config) return null;
+
+  for (const [name, environment] of Object.entries(config.environments)) {
+    if (matches(environment)) {
+      return { name, environment };
+    }
+  }
+
+  return null;
+}
+
+/**
  * Resolve the identity of the environment the active credentials operate on.
  * When credentials come from env vars, the environment id is confirmed via
  * /whoami; a stored config environment is returned only when one matches.
@@ -161,12 +193,38 @@ export async function resolveActiveEnvironment(): Promise<ActiveEnvironment> {
   // The base URL follows the credential source: env var credentials never
   // inherit a stored environment's host (MUX_BASE_URL or default).
   const baseUrl = getMuxBaseUrl(null);
-  const response = await fetch(`${baseUrl}/system/v1/whoami`, {
-    headers: {
-      Authorization: `Basic ${btoa(`${envTokenId}:${envTokenSecret}`)}`,
-      'User-Agent': getUserAgent(),
-    },
-  });
+
+  // When the env vars hold the same credentials as a stored environment,
+  // that environment's identity is already known — skip the /whoami
+  // round-trip so local-only commands (sign, webhooks events list) keep
+  // working offline.
+  const sameCredentials = await findStoredEnvironmentByCredentials(
+    envTokenId,
+    envTokenSecret,
+    stored,
+  );
+  if (sameCredentials?.environment.environmentId) {
+    return {
+      environmentId: sameCredentials.environment.environmentId,
+      source: 'env',
+      baseUrl,
+      stored: sameCredentials,
+    };
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(`${baseUrl}/system/v1/whoami`, {
+      headers: {
+        Authorization: `Basic ${btoa(`${envTokenId}:${envTokenSecret}`)}`,
+        'User-Agent': getUserAgent(),
+      },
+    });
+  } catch (error) {
+    throw new Error(
+      `Could not verify MUX_TOKEN_ID/MUX_TOKEN_SECRET credentials: failed to reach ${baseUrl} (${error instanceof Error ? error.message : String(error)}). Check your network connection and MUX_BASE_URL.`,
+    );
+  }
 
   if (!response.ok) {
     throw new Error(
@@ -174,10 +232,15 @@ export async function resolveActiveEnvironment(): Promise<ActiveEnvironment> {
     );
   }
 
-  const body = (await response.json()) as {
-    data: { environment_id?: string };
-  };
-  const environmentId = body.data.environment_id;
+  let body: { data?: { environment_id?: string } };
+  try {
+    body = (await response.json()) as { data?: { environment_id?: string } };
+  } catch {
+    throw new Error(
+      `Could not verify MUX_TOKEN_ID/MUX_TOKEN_SECRET credentials: ${baseUrl} returned a non-JSON response. Check MUX_BASE_URL.`,
+    );
+  }
+  const environmentId = body?.data?.environment_id;
   if (!environmentId) {
     throw new Error(
       'Could not determine the environment for the MUX_TOKEN_ID/MUX_TOKEN_SECRET credentials.',

--- a/src/lib/mux.ts
+++ b/src/lib/mux.ts
@@ -154,6 +154,10 @@ export async function resolveActiveEnvironment(): Promise<ActiveEnvironment> {
     };
   }
 
+  if (stored) {
+    noticeEnvCredentialsShadowStoredLogin();
+  }
+
   // The base URL follows the credential source: env var credentials never
   // inherit a stored environment's host (MUX_BASE_URL or default).
   const baseUrl = getMuxBaseUrl(null);

--- a/src/lib/mux.ts
+++ b/src/lib/mux.ts
@@ -1,6 +1,10 @@
 import Mux from '@mux/mux-node';
 import pkg from '../../package.json';
-import { getCurrentEnvironment } from './config.ts';
+import {
+  type Environment,
+  getCurrentEnvironment,
+  readConfig,
+} from './config.ts';
 import { isAgentMode } from './context.ts';
 
 export const DEFAULT_BASE_URL = 'https://api.mux.com';
@@ -23,6 +27,167 @@ export function getMuxBaseUrl(
   );
 }
 
+export const NOT_LOGGED_IN_MESSAGE =
+  "Not logged in. Set MUX_TOKEN_ID and MUX_TOKEN_SECRET environment variables, or run 'mux login' to authenticate.";
+
+let envCredentialNoticeShown = false;
+
+/** Reset the one-time env credential notice. Intended for tests. */
+export function resetEnvCredentialNotice(): void {
+  envCredentialNoticeShown = false;
+}
+
+/**
+ * Warn once per process when env var credentials shadow a stored login, so
+ * a forgotten shell variable does not silently switch accounts. Suppressed
+ * in agent mode, where output must stay machine-readable.
+ */
+function noticeEnvCredentialsShadowStoredLogin(): void {
+  if (envCredentialNoticeShown || isAgentMode()) return;
+  envCredentialNoticeShown = true;
+  console.error(
+    'Using MUX_TOKEN_ID/MUX_TOKEN_SECRET from environment variables; they take precedence over the stored login.',
+  );
+}
+
+/**
+ * Resolve API credentials.
+ * Priority: MUX_TOKEN_ID/MUX_TOKEN_SECRET env vars > stored config
+ * (consistent with how MUX_BASE_URL takes precedence over config).
+ * Env vars are only used when both are set and non-empty.
+ */
+async function resolveCredentials(): Promise<{
+  tokenId: string;
+  tokenSecret: string;
+  baseUrl: string;
+}> {
+  const env = await getCurrentEnvironment();
+
+  const envTokenId = process.env.MUX_TOKEN_ID;
+  const envTokenSecret = process.env.MUX_TOKEN_SECRET;
+  if (envTokenId && envTokenSecret) {
+    if (env) {
+      noticeEnvCredentialsShadowStoredLogin();
+    }
+    return {
+      tokenId: envTokenId,
+      tokenSecret: envTokenSecret,
+      // The base URL follows the credential source: env var credentials
+      // never inherit a stored environment's host (MUX_BASE_URL or default).
+      baseUrl: getMuxBaseUrl(null),
+    };
+  }
+
+  if (!env) {
+    throw new Error(NOT_LOGGED_IN_MESSAGE);
+  }
+
+  return {
+    tokenId: env.environment.tokenId,
+    tokenSecret: env.environment.tokenSecret,
+    baseUrl: getMuxBaseUrl(env),
+  };
+}
+
+export interface ActiveEnvironment {
+  /** Identifier that keys locally stored data (webhook events, signing secrets). */
+  environmentId: string;
+  /** Where the active credentials came from. */
+  source: 'env' | 'config';
+  /** API host, resolved from the same source as the credentials. */
+  baseUrl: string;
+  /**
+   * The stored config environment, only when it matches the active
+   * credentials. Null when credentials come from env vars that point to a
+   * different environment (or no environment is stored) — persisting API
+   * results to the stored config would desync it from the environment the
+   * credentials actually operate on.
+   */
+  stored: { name: string; environment: Environment } | null;
+}
+
+/**
+ * Find the stored environment matching an environment id, checking every
+ * named environment, not just the current one. Prefers the current
+ * environment when it matches, since the same environment can be saved
+ * under multiple names.
+ */
+async function findStoredEnvironmentById(
+  environmentId: string,
+  current: { name: string; environment: Environment } | null,
+): Promise<{ name: string; environment: Environment } | null> {
+  if (current?.environment.environmentId === environmentId) {
+    return current;
+  }
+
+  const config = await readConfig();
+  if (!config) return null;
+
+  for (const [name, environment] of Object.entries(config.environments)) {
+    if (environment.environmentId === environmentId) {
+      return { name, environment };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Resolve the identity of the environment the active credentials operate on.
+ * When credentials come from env vars, the environment id is confirmed via
+ * /whoami; a stored config environment is returned only when one matches.
+ */
+export async function resolveActiveEnvironment(): Promise<ActiveEnvironment> {
+  const stored = await getCurrentEnvironment();
+
+  const envTokenId = process.env.MUX_TOKEN_ID;
+  const envTokenSecret = process.env.MUX_TOKEN_SECRET;
+  if (!(envTokenId && envTokenSecret)) {
+    if (!stored) {
+      throw new Error(NOT_LOGGED_IN_MESSAGE);
+    }
+    return {
+      environmentId: stored.environment.environmentId ?? stored.name,
+      source: 'config',
+      baseUrl: getMuxBaseUrl(stored),
+      stored,
+    };
+  }
+
+  // The base URL follows the credential source: env var credentials never
+  // inherit a stored environment's host (MUX_BASE_URL or default).
+  const baseUrl = getMuxBaseUrl(null);
+  const response = await fetch(`${baseUrl}/system/v1/whoami`, {
+    headers: {
+      Authorization: `Basic ${btoa(`${envTokenId}:${envTokenSecret}`)}`,
+      'User-Agent': getUserAgent(),
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Could not verify MUX_TOKEN_ID/MUX_TOKEN_SECRET credentials: ${response.status} ${response.statusText}. Check the values or run 'mux login'.`,
+    );
+  }
+
+  const body = (await response.json()) as {
+    data: { environment_id?: string };
+  };
+  const environmentId = body.data.environment_id;
+  if (!environmentId) {
+    throw new Error(
+      'Could not determine the environment for the MUX_TOKEN_ID/MUX_TOKEN_SECRET credentials.',
+    );
+  }
+
+  return {
+    environmentId,
+    source: 'env',
+    baseUrl,
+    stored: await findStoredEnvironmentById(environmentId, stored),
+  };
+}
+
 /**
  * Get auth headers and base URL in a single config read.
  */
@@ -30,20 +195,15 @@ export async function getAuthContext(): Promise<{
   headers: Record<string, string>;
   baseUrl: string;
 }> {
-  const env = await getCurrentEnvironment();
-  if (!env) {
-    throw new Error("Not logged in. Please run 'mux login' to authenticate.");
-  }
+  const { tokenId, tokenSecret, baseUrl } = await resolveCredentials();
 
-  const credentials = btoa(
-    `${env.environment.tokenId}:${env.environment.tokenSecret}`,
-  );
+  const credentials = btoa(`${tokenId}:${tokenSecret}`);
   return {
     headers: {
       Authorization: `Basic ${credentials}`,
       'User-Agent': getUserAgent(),
     },
-    baseUrl: getMuxBaseUrl(env),
+    baseUrl,
   };
 }
 
@@ -55,21 +215,16 @@ export async function getAuthHeaders(): Promise<Record<string, string>> {
 }
 
 /**
- * Create an authenticated Mux client using stored credentials
- * Throws an error if not logged in
+ * Create an authenticated Mux client from env vars or stored credentials.
+ * Throws an error when no credentials are available.
  */
 export async function createAuthenticatedMuxClient(): Promise<Mux> {
-  const env = await getCurrentEnvironment();
-  if (!env) {
-    throw new Error("Not logged in. Please run 'mux login' to authenticate.");
-  }
-
-  const baseURL = getMuxBaseUrl(env);
+  const { tokenId, tokenSecret, baseUrl } = await resolveCredentials();
 
   return new Mux({
-    tokenId: env.environment.tokenId,
-    tokenSecret: env.environment.tokenSecret,
-    ...(baseURL !== DEFAULT_BASE_URL && { baseURL }),
+    tokenId,
+    tokenSecret,
+    ...(baseUrl !== DEFAULT_BASE_URL && { baseURL: baseUrl }),
     defaultHeaders: { 'User-Agent': getUserAgent() },
   });
 }

--- a/src/lib/mux.ts
+++ b/src/lib/mux.ts
@@ -247,11 +247,17 @@ export async function resolveActiveEnvironment(): Promise<ActiveEnvironment> {
     );
   }
 
+  // A stored entry holding these exact credentials IS this environment,
+  // even when the entry predates environmentId stamping (legacy config):
+  // whoami just resolved which environment those credentials belong to.
+  const storedMatch =
+    (await findStoredEnvironmentById(environmentId, stored)) ?? sameCredentials;
+
   return {
     environmentId,
     source: 'env',
     baseUrl,
-    stored: await findStoredEnvironmentById(environmentId, stored),
+    stored: storedMatch,
   };
 }
 

--- a/src/lib/prompt.ts
+++ b/src/lib/prompt.ts
@@ -1,5 +1,8 @@
 import { createInterface } from 'node:readline';
 
+export const STDIN_CLOSED_MESSAGE =
+  'Interactive input required but stdin is closed. Provide the value via flags or environment variables (e.g. --force, -y), or run in an interactive terminal.';
+
 function createReadlineInterface() {
   return createInterface({
     input: process.stdin,
@@ -14,10 +17,17 @@ export async function inputPrompt(options: {
   const rl = createReadlineInterface();
   const defaultSuffix = options.default ? ` (${options.default})` : '';
 
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
+    let answered = false;
     rl.question(`${options.message}${defaultSuffix} `, (answer) => {
+      answered = true;
       rl.close();
       resolve(answer.trim() || options.default || '');
+    });
+    // EOF (piped or closed stdin) fires 'close' without an answer; without
+    // this handler the promise never settles and the process hangs.
+    rl.on('close', () => {
+      if (!answered) reject(new Error(STDIN_CLOSED_MESSAGE));
     });
   });
 }
@@ -34,7 +44,7 @@ export async function secretPrompt(options: {
     stdin.setRawMode(true);
   }
 
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     let input = '';
     process.stderr.write(`${options.message} `);
 
@@ -47,6 +57,7 @@ export async function secretPrompt(options: {
           stdin.setRawMode(wasRaw ?? false);
         }
         stdin.removeListener('data', onData);
+        stdin.removeListener('end', onEnd);
         process.stderr.write('\n');
         rl.close();
         resolve(input);
@@ -68,7 +79,19 @@ export async function secretPrompt(options: {
       }
     };
 
+    // EOF without any input (piped or closed stdin) must fail loudly
+    // rather than leave the promise unsettled and the process hung.
+    const onEnd = () => {
+      if (stdin.isTTY) {
+        stdin.setRawMode(wasRaw ?? false);
+      }
+      stdin.removeListener('data', onData);
+      rl.close();
+      reject(new Error(STDIN_CLOSED_MESSAGE));
+    };
+
     stdin.on('data', onData);
+    stdin.once('end', onEnd);
   });
 }
 
@@ -80,8 +103,10 @@ export async function confirmPrompt(options: {
   const defaultValue = options.default ?? false;
   const hint = defaultValue ? '(Y/n)' : '(y/N)';
 
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
+    let answered = false;
     rl.question(`${options.message} ${hint} `, (answer) => {
+      answered = true;
       rl.close();
       const trimmed = answer.trim().toLowerCase();
       if (trimmed === '') {
@@ -89,6 +114,11 @@ export async function confirmPrompt(options: {
       } else {
         resolve(trimmed === 'y' || trimmed === 'yes');
       }
+    });
+    // EOF must fail loudly rather than hang (or silently decline): a script
+    // that meant to confirm should learn to pass --force / -y.
+    rl.on('close', () => {
+      if (!answered) reject(new Error(STDIN_CLOSED_MESSAGE));
     });
   });
 }

--- a/src/lib/webhook-signing.ts
+++ b/src/lib/webhook-signing.ts
@@ -2,7 +2,6 @@ import { createHmac, randomBytes } from 'node:crypto';
 import { existsSync } from 'node:fs';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
-import { getCurrentEnvironment } from './config.ts';
 import { getDataDir } from './xdg.ts';
 
 function getSigningSecretPath(envName: string): string {
@@ -27,18 +26,6 @@ export async function getSigningSecret(envName: string): Promise<string> {
   await mkdir(dir, { recursive: true });
   await writeFile(path, secret, { mode: 0o600 });
   return secret;
-}
-
-/**
- * Get the signing secret for the default (logged-in) environment.
- * Throws if not logged in.
- */
-export async function getSigningSecretForCurrentEnv(): Promise<string> {
-  const env = await getCurrentEnvironment();
-  if (!env) {
-    throw new Error("Not logged in. Please run 'mux login' to authenticate.");
-  }
-  return getSigningSecret(env.name);
 }
 
 /**


### PR DESCRIPTION
## Summary

Makes the Mux CLI work well for agents and CI: credentials can come from `MUX_TOKEN_ID`/`MUX_TOKEN_SECRET` environment variables without a stored login, a global `--agent` flag implies JSON output everywhere, errors are machine-readable, and nothing ever blocks on stdin in non-interactive use.

Credential precedence follows the convention of the GitHub, Stripe, Vercel, AWS, and Fly CLIs: **environment variables beat the stored login**, and all values in a credential bundle (tokens, base URL, signing keys) come from the same source — the CLI never mixes sources.

## Commits

Each commit is a reviewable theme; the branch history was rebuilt so features arrive with their safety behavior included.

1. **`test: restore Mux client spy in live create tests`** — an unrestored module mock leaked into every test file that ran after it in the same process. Independent fix, surfaced while testing this branch.
2. **`feat: agent mode with machine-readable output across commands`** — global `--agent` flag (implies JSON, sets an agent User-Agent). Commands consult `wantsJson()` instead of reading `options.json`; errors route through a JSON-aware `handleCommandError`; destructive commands require `--force` instead of prompting, with an error that names agent mode. Bulk of the diff — ~90 files of mechanical `options.json` → `wantsJson()` conversion live here.
3. **`feat: env-var credential fallback with single-source resolution`** — `resolveCredentials` prefers `MUX_TOKEN_ID`/`MUX_TOKEN_SECRET` (both required, lone variables ignored). Env credentials use `MUX_BASE_URL` or the default host, never a stored environment's custom host. `resolveActiveEnvironment()` determines which environment the active credentials operate on (one `/whoami` call, matched against every stored environment). A one-time stderr notice warns when env vars shadow a stored login (suppressed in agent mode).
4. **`feat: login works with env credentials and fails fast in agent mode`** — login reads env vars when no `--env-file` is given, fails fast with a structured error instead of prompting in JSON/agent mode, and saves `MUX_SIGNING_KEY`/`MUX_PRIVATE_KEY` when both are present (the `--env-file` help text always claimed this; now it is true).
5. **`fix: assets create fails fast on upload confirmation in agent mode`** — multi-file uploads confirmed via prompt; in JSON/agent mode this blocked on stdin. Now fails before authentication with guidance to pass `-y`.
6. **`fix: bind signing keys and webhook state to the active environment`** — env-var credentials introduce a hazard this PR must handle: commands that persist local state can no longer assume the credentials belong to the logged-in environment. Before touching config, these commands verify the active environment. Credentials matching a saved environment (default or not) persist there. Credentials for an unknown environment never write to config: `signing-keys create` emits the private key once with `saved: false`, `sign` uses `MUX_SIGNING_KEY`/`MUX_PRIVATE_KEY`, and webhook events are stored under the real environment id from `/whoami`.
7. **`docs: document credential sources and precedence`** — README section covering the resolution order, both-or-neither pairing, and the single-source rule.

## QA

**Agent mode & errors**
```bash
mux assets list --agent                          # JSON array, no prose
mux assets delete some-id --agent                # JSON error naming --force and agent mode, exit 1
env -u MUX_TOKEN_ID -u MUX_TOKEN_SECRET mux login --agent   # structured error, no prompt, no hang
```

**Env-var credentials**
```bash
env -u MUX_TOKEN_ID -u MUX_TOKEN_SECRET mux whoami          # stored login unchanged
MUX_TOKEN_ID=<id> MUX_TOKEN_SECRET=<secret> mux whoami      # env creds win; one-line notice on stderr if a login is stored
MUX_TOKEN_ID=<id> mux whoami                                # lone variable ignored; falls back to stored login
```

**Login**
```bash
MUX_TOKEN_ID=<id> MUX_TOKEN_SECRET=<secret> mux login --json    # {"success":true,...,"source":"env"}
mux login --env-file .env                                       # saves signing keys too when the file has both
```

**Uploads**
```bash
mux assets create --upload a.mp4 --upload b.mp4 --agent     # JSON error telling you to pass -y; exits immediately
mux assets create --upload a.mp4 --upload b.mp4 --agent -y  # proceeds
```

**Environment-state safety** (use tokens for an environment that is NOT in your config)
```bash
MUX_TOKEN_ID=<B> MUX_TOKEN_SECRET=<B> mux signing-keys create --json
# → private_key in output, saved: false, config untouched
MUX_TOKEN_ID=<B> MUX_TOKEN_SECRET=<B> MUX_SIGNING_KEY=<key-id> MUX_PRIVATE_KEY=<base64> mux sign <playback-id>
# → signs without any stored login (API credentials are still required; signing keys supplement them)
MUX_TOKEN_ID=<B> MUX_TOKEN_SECRET=<B> mux webhooks listen
# → works; events stored under B's environment id, not the logged-in one
```
Then repeat `signing-keys create` with tokens for an environment that IS in your config (default or not): the key saves to that environment's entry.

**Regression suite**: 898 tests pass (`bun test`), typecheck and biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication, credential resolution, and signing-key persistence across many commands; behavior changes are intentional but wide-reaching for scripts and CI.
> 
> **Overview**
> Improves **agent and CI** use: a global **`--agent`** flag turns on machine-readable behavior (via `wantsJson()`), JSON errors, and no stdin prompts. Destructive actions need **`--force`** with `--json` or in agent mode; multi-file uploads need **`-y`** in the same cases.
> 
> **Credentials** now prefer **`MUX_TOKEN_ID` / `MUX_TOKEN_SECRET`** (both required) over stored `mux login`, with a single-source rule for base URL and signing keys. **`mux login`** can use env or `--env-file`, supports **`--json`**, saves signing key pairs when both vars are present, and preserves environment-bound state only when `/whoami` matches the same environment.
> 
> **`mux sign`** and **`signing-keys create`** resolve keys from env or stored config only when active credentials match that stored environment; otherwise keys are shown once with `saved: false` instead of writing the wrong config.
> 
> README documents precedence and pairing rules. Broad mechanical swap from `options.json` to `wantsJson()` across commands, plus focused tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f871139ca5ad525e776fe8ebf58bfe5fdb4df17c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

