### PR TITLE
fix: emit only the API response body in --json output for paginated commands

### DIFF
--- a/src/commands/annotations/list.ts
+++ b/src/commands/annotations/list.ts
@@ -1,6 +1,7 @@
 import { Command } from '@cliffy/command';
 import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
+import { formatJson } from '@/lib/json-output.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 
 interface ListOptions {
@@ -58,7 +59,7 @@ export const listCommand = new Command()
       const response = await mux.data.annotations.list(params as never);
 
       if (wantsJson(options)) {
-        console.log(JSON.stringify(response, null, 2));
+        console.log(formatJson(response));
         return;
       }
 

--- a/src/commands/assets/list.ts
+++ b/src/commands/assets/list.ts
@@ -7,6 +7,7 @@ import {
   formatCreatedAt,
   formatDuration,
 } from '@/lib/formatters.ts';
+import { formatJson } from '@/lib/json-output.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 
 interface ListOptions {
@@ -61,7 +62,7 @@ export const listCommand = new Command()
       const response = await mux.video.assets.list(params);
 
       if (wantsJson(options)) {
-        console.log(JSON.stringify(response, null, 2));
+        console.log(formatJson(response));
       } else if (options.compact) {
         // Compact output - one line per asset, grep-friendly
         if (!response.data || response.data.length === 0) {

--- a/src/commands/delivery-usage/list.ts
+++ b/src/commands/delivery-usage/list.ts
@@ -1,6 +1,7 @@
 import { Command } from '@cliffy/command';
 import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
+import { formatJson } from '@/lib/json-output.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 
 interface ListOptions {
@@ -50,7 +51,7 @@ export const listCommand = new Command()
       const reports = await mux.video.deliveryUsage.list(params as never);
 
       if (wantsJson(options)) {
-        console.log(JSON.stringify(reports, null, 2));
+        console.log(formatJson(reports));
         return;
       }
 

--- a/src/commands/dimensions/values.ts
+++ b/src/commands/dimensions/values.ts
@@ -2,6 +2,7 @@ import { Command } from '@cliffy/command';
 import { wantsJson } from '@/lib/context.ts';
 import { buildDataFilterParams } from '@/lib/data-filters.ts';
 import { handleCommandError } from '@/lib/errors.ts';
+import { formatJson } from '@/lib/json-output.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 
 interface ValuesOptions {
@@ -55,7 +56,7 @@ export const valuesCommand = new Command()
       );
 
       if (wantsJson(options)) {
-        console.log(JSON.stringify(response, null, 2));
+        console.log(formatJson(response));
         return;
       }
 

--- a/src/commands/drm-configurations/list.ts
+++ b/src/commands/drm-configurations/list.ts
@@ -1,6 +1,7 @@
 import { Command } from '@cliffy/command';
 import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
+import { formatJson } from '@/lib/json-output.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 
 interface ListOptions {
@@ -28,7 +29,7 @@ export const listCommand = new Command()
       });
 
       if (wantsJson(options)) {
-        console.log(JSON.stringify(configurations, null, 2));
+        console.log(formatJson(configurations));
         return;
       }
 

--- a/src/commands/incidents/list.ts
+++ b/src/commands/incidents/list.ts
@@ -1,6 +1,7 @@
 import { Command } from '@cliffy/command';
 import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
+import { formatJson } from '@/lib/json-output.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 
 interface ListOptions {
@@ -90,7 +91,7 @@ export const listCommand = new Command()
       const response = await mux.data.incidents.list(params as never);
 
       if (wantsJson(options)) {
-        console.log(JSON.stringify(response, null, 2));
+        console.log(formatJson(response));
         return;
       }
 

--- a/src/commands/incidents/related.ts
+++ b/src/commands/incidents/related.ts
@@ -1,6 +1,7 @@
 import { Command } from '@cliffy/command';
 import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
+import { formatJson } from '@/lib/json-output.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 
 interface RelatedOptions {
@@ -58,7 +59,7 @@ export const relatedCommand = new Command()
       );
 
       if (wantsJson(options)) {
-        console.log(JSON.stringify(response, null, 2));
+        console.log(formatJson(response));
         return;
       }
 

--- a/src/commands/live/list.ts
+++ b/src/commands/live/list.ts
@@ -8,6 +8,7 @@ import {
   formatSeconds,
   truncateMiddle,
 } from '@/lib/formatters.ts';
+import { formatJson } from '@/lib/json-output.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 
 interface ListOptions {
@@ -45,7 +46,7 @@ export const listCommand = new Command()
       const response = await mux.video.liveStreams.list(params);
 
       if (wantsJson(options)) {
-        console.log(JSON.stringify(response, null, 2));
+        console.log(formatJson(response));
       } else if (options.compact) {
         // Compact output - one line per stream, grep-friendly
         if (!response.data || response.data.length === 0) {

--- a/src/commands/metrics/breakdown.ts
+++ b/src/commands/metrics/breakdown.ts
@@ -2,6 +2,7 @@ import { Command } from '@cliffy/command';
 import { wantsJson } from '@/lib/context.ts';
 import { buildDataFilterParams } from '@/lib/data-filters.ts';
 import { handleCommandError } from '@/lib/errors.ts';
+import { formatJson } from '@/lib/json-output.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 
 interface BreakdownOptions {
@@ -102,7 +103,7 @@ export const breakdownCommand = new Command()
       );
 
       if (wantsJson(options)) {
-        console.log(JSON.stringify(response, null, 2));
+        console.log(formatJson(response));
         return;
       }
 

--- a/src/commands/playback-restrictions/list.ts
+++ b/src/commands/playback-restrictions/list.ts
@@ -1,6 +1,7 @@
 import { Command } from '@cliffy/command';
 import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
+import { formatJson } from '@/lib/json-output.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 
 interface ListOptions {
@@ -28,7 +29,7 @@ export const listCommand = new Command()
       });
 
       if (wantsJson(options)) {
-        console.log(JSON.stringify(restrictions, null, 2));
+        console.log(formatJson(restrictions));
         return;
       }
 

--- a/src/commands/transcription-vocabularies/list.ts
+++ b/src/commands/transcription-vocabularies/list.ts
@@ -1,6 +1,7 @@
 import { Command } from '@cliffy/command';
 import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
+import { formatJson } from '@/lib/json-output.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 
 interface ListOptions {
@@ -28,7 +29,7 @@ export const listCommand = new Command()
       });
 
       if (wantsJson(options)) {
-        console.log(JSON.stringify(vocabularies, null, 2));
+        console.log(formatJson(vocabularies));
         return;
       }
 

--- a/src/commands/uploads/list.ts
+++ b/src/commands/uploads/list.ts
@@ -1,6 +1,7 @@
 import { Command } from '@cliffy/command';
 import { wantsJson } from '@/lib/context.ts';
 import { handleCommandError } from '@/lib/errors.ts';
+import { formatJson } from '@/lib/json-output.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 
 interface ListOptions {
@@ -28,7 +29,7 @@ export const listCommand = new Command()
       });
 
       if (wantsJson(options)) {
-        console.log(JSON.stringify(uploads, null, 2));
+        console.log(formatJson(uploads));
         return;
       }
 

--- a/src/commands/video-views/list.ts
+++ b/src/commands/video-views/list.ts
@@ -2,6 +2,7 @@ import { Command } from '@cliffy/command';
 import { wantsJson } from '@/lib/context.ts';
 import { buildDataFilterParams } from '@/lib/data-filters.ts';
 import { handleCommandError } from '@/lib/errors.ts';
+import { formatJson } from '@/lib/json-output.ts';
 import { createAuthenticatedMuxClient } from '@/lib/mux.ts';
 
 interface ListOptions {
@@ -79,7 +80,7 @@ export const listCommand = new Command()
       const response = await mux.data.videoViews.list(params as never);
 
       if (wantsJson(options)) {
-        console.log(JSON.stringify(response, null, 2));
+        console.log(formatJson(response));
         return;
       }
 

--- a/src/lib/json-output.test.ts
+++ b/src/lib/json-output.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'bun:test';
+import { AbstractPage } from '@mux/mux-node/core/pagination';
+import { formatJson, unwrapPage } from './json-output.ts';
+
+/**
+ * Build an object that is a real AbstractPage instance (via prototype) with
+ * the same enumerable own properties the SDK assigns in its constructor.
+ */
+function makePage(body: unknown): AbstractPage<unknown> {
+  const page = Object.create(AbstractPage.prototype);
+  page.options = {
+    method: 'get',
+    path: '/video/v1/assets',
+    query: { limit: 25, page: 1 },
+  };
+  page.response = {};
+  page.body = body;
+  // Page subclasses mirror body fields onto the instance
+  if (body && typeof body === 'object') {
+    Object.assign(page, body);
+  }
+  return page;
+}
+
+describe('unwrapPage', () => {
+  it('returns the raw API response body for SDK page objects', () => {
+    const body = { data: [{ id: 'abc' }], next_cursor: 'cursor123' };
+    expect(unwrapPage(makePage(body))).toBe(body);
+  });
+
+  it('preserves non-cursor pagination fields carried in the body', () => {
+    const body = {
+      data: [{ value: 1 }],
+      total_row_count: 1,
+      timeframe: [100, 200],
+      limit: 25,
+    };
+    expect(unwrapPage(makePage(body))).toBe(body);
+  });
+
+  it('returns plain objects unchanged', () => {
+    const plain = { data: [], timeframe: [1, 2], total_row_count: 0 };
+    expect(unwrapPage(plain)).toBe(plain);
+  });
+
+  it('returns arrays unchanged', () => {
+    const arr = [{ id: 'a' }];
+    expect(unwrapPage(arr)).toBe(arr);
+  });
+
+  it('returns null and undefined unchanged', () => {
+    expect(unwrapPage(null)).toBe(null);
+    expect(unwrapPage(undefined)).toBe(undefined);
+  });
+});
+
+describe('formatJson', () => {
+  it('serializes only the body of a page, excluding SDK internals', () => {
+    const body = { data: [{ id: 'abc' }], next_cursor: null };
+    const parsed = JSON.parse(formatJson(makePage(body)));
+    expect(parsed).toEqual(body);
+    expect(Object.keys(parsed).sort()).toEqual(['data', 'next_cursor']);
+  });
+
+  it('serializes plain responses as-is with 2-space indentation', () => {
+    const plain = { data: [1, 2] };
+    expect(formatJson(plain)).toBe(JSON.stringify(plain, null, 2));
+  });
+});

--- a/src/lib/json-output.ts
+++ b/src/lib/json-output.ts
@@ -1,0 +1,20 @@
+import { AbstractPage } from '@mux/mux-node/core/pagination';
+
+/**
+ * SDK page objects carry internal request state (options, response, body)
+ * as enumerable properties, so stringifying one leaks those fields and
+ * duplicates the payload. Unwrap to the raw API response body instead.
+ */
+export function unwrapPage(value: unknown): unknown {
+  if (value instanceof AbstractPage) {
+    return (value as unknown as { body: unknown }).body;
+  }
+  return value;
+}
+
+/**
+ * Serialize an API response for --json output.
+ */
+export function formatJson(value: unknown): string {
+  return JSON.stringify(unwrapPage(value), null, 2);
+}


### PR DESCRIPTION
## Problem

Commands backed by paginated SDK methods serialize the SDK page object directly, so `--json` output includes internal request state alongside the payload:

```json
{
  "options": { "method": "get", "path": "/video/v1/assets", ... },
  "response": {},
  "body": { "data": [...], "next_cursor": "..." },
  "data": [...],
  "next_cursor": "..."
}
```

`options` echoes the request, `response` is always empty, and `body` duplicates the top-level fields. This has shipped since the original asset commands (present in 1.3.2), but 2.0 is the last chance to fix the shape without breaking within a major version.

## Fix

New `formatJson` helper unwraps `AbstractPage` instances to their raw API response body and passes everything else through unchanged. Applied to the 13 commands backed by paginated SDK methods: `assets`/`live`/`uploads`/`playback-restrictions`/`transcription-vocabularies`/`drm-configurations`/`delivery-usage`/`annotations`/`video-views`/`incidents list`, `incidents related`, `metrics breakdown`, and `dimensions values`.

Output is now exactly the API response body, e.g. `{ "data": [...], "next_cursor": "..." }`. Unwrapping also surfaces body fields the page accessors hid (`meta` on `metrics breakdown`, `page` on `delivery-usage`).

## Compatibility

Consumers reading top-level fields (`data`, `next_cursor`, `timeframe`, `total_row_count`) are unaffected. Only the `options`/`response`/`body` keys are removed, and they contained no unique information. Non-paginated commands are untouched.

## Testing

- Unit tests for `formatJson`/`unwrapPage` (`src/lib/json-output.test.ts`)
- Full suite passes (930 tests), `biome check` and `tsc` clean
- Verified against the live API: all 13 commands now emit only body fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `--json` shape for 13 commands (removes SDK-only keys); intentional breaking cleanup for 2.0, but scripts that depended on `options`/`body` will need updates.
> 
> **Overview**
> **`--json` on paginated list commands** no longer serializes the Mux SDK page object. Output is now the raw API body (e.g. `data`, `next_cursor`, `timeframe`) instead of leaking `options`, `response`, and a duplicate `body` wrapper.
> 
> A shared **`formatJson` / `unwrapPage`** helper in `src/lib/json-output.ts` detects `AbstractPage` instances and stringifies only `.body`; other values behave like before (2-space indent). Thirteen list-style commands were switched from `JSON.stringify` to `formatJson` (assets, live, uploads, playback-restrictions, transcription vocabularies, DRM configs, delivery usage, annotations, video views, incidents list/related, metrics breakdown, dimensions values). Non-paginated commands are unchanged.
> 
> Unit tests in `src/lib/json-output.test.ts` cover page unwrapping and plain-object serialization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 076bc8b9e4fb68a2e93c4aa1f2a8e4fa00bffab6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->