### PR TITLE
feat(auth)!: OAuth login as the default for `mux login`

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git log *)"
+    ]
+  }
+}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,7 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(git log *)"
-    ]
-  }
-}

--- a/README.md
+++ b/README.md
@@ -116,30 +116,63 @@ After saving the file, restart your shell or source it (e.g. `source ~/.zshrc`) 
 
 ### Authentication
 
-Before using the Mux CLI, you need to authenticate with your Mux API credentials. You can obtain these from the [Mux Dashboard](https://dashboard.mux.com/settings/access-tokens).
+The CLI supports two ways to sign in, and both are fully supported:
+
+- **Browser sign-in (default).** `mux login` opens the Mux Dashboard, where you pick an organization and environment. The CLI receives the result on a local loopback address and manages token refresh for you. Best for local development.
+- **Mux API access token.** A Token ID and Secret from the [Mux Dashboard](https://dashboard.mux.com/settings/access-tokens). Best for CI, service accounts, and scripting, where no browser is available.
 
 ```bash
-# Interactive login (prompts for Token ID and Secret)
+# Browser sign-in: pick an organization and environment in the dashboard
 mux login
 
-# Login with .env file (expects MUX_TOKEN_ID and MUX_TOKEN_SECRET)
+# Sign in to more environments by running it again — each one is saved separately
+mux login
+
+# Mux API access token, entered manually
+mux login --interactive
+
+# Access token from a .env file (expects MUX_TOKEN_ID and MUX_TOKEN_SECRET)
 mux login --env-file .env
+
+# Save the MUX_TOKEN_ID / MUX_TOKEN_SECRET already set in this shell
+mux login --from-env
 
 # Named environments for multi-environment workflows
 mux login --name production
 mux login --name staging --env-file .env.staging
 ```
 
-The first environment you add becomes the default. See [Authentication & Environment Management](#authentication--environment-management) for more details.
+> [!IMPORTANT]
+> When `MUX_TOKEN_ID` and `MUX_TOKEN_SECRET` are set in your shell, `mux login` with no
+> flags stops and asks which method you meant, rather than silently saving them. Those
+> variables already work on their own — no login needed — and they take precedence over
+> any saved login, so a config entry written from them has no effect until they are unset.
+> Pass `--from-env` to save them deliberately, or `--oauth` for a browser sign-in.
+
+Browser sign-in names each environment after the organization and environment you selected (for example `acme-inc-production`); pass `--name` to choose your own. Signing in again to the *same* environment refreshes its credentials in place and keeps its signing keys and forward URL; signing in to a *different* environment adds a new entry and never overwrites an existing one.
+
+The first environment you add becomes the default, and a new browser sign-in becomes the active environment unless you pass `--keep-current`. Run `mux auth status` at any time to see every credential the CLI can find and which one is active. See [Authentication & Environment Management](#authentication--environment-management) for more details.
 
 #### Credential sources and precedence
 
 The CLI resolves credentials from two sources, in order:
 
 1. **Environment variables** — `MUX_TOKEN_ID` and `MUX_TOKEN_SECRET`. Used only when both are set and non-empty; a lone variable is ignored.
-2. **Stored login** — the environment saved by `mux login`.
+2. **Stored login** — the active environment saved by `mux login`, whether it holds a browser sign-in or an access token pair.
 
-Environment variables take precedence over the stored login, matching the convention of tools like the GitHub, Stripe, and Vercel CLIs. When they shadow a stored login, the CLI prints a one-line notice on stderr (suppressed in agent mode).
+Environment variables take precedence over the stored login, matching the convention of tools like the GitHub, Stripe, and Vercel CLIs. When they shadow a stored login, the CLI prints a one-line notice on stderr naming the shadowed environment (suppressed in agent mode). `mux auth status` lays out every source and marks the active one.
+
+Because environment variables win, `mux login` with `MUX_TOKEN_ID` and `MUX_TOKEN_SECRET` already set refuses to guess: it prints the four explicit methods and exits without writing anything. Pass `--from-env` to save the shell credentials, or `--oauth` for a browser sign-in. If a login is saved while those variables are set, the CLI says so — the saved login will not take effect until they are unset.
+
+#### One environment, two ways in
+
+A single environment can hold both credential kinds at once: an access token pair saved for CI and a browser sign-in saved by `mux login`. Both are kept, and **OAuth is preferred when present** — OAuth credentials go stale unless they are exercised and refreshed, so the CLI does not quietly live on the token pair.
+
+If an OAuth login stops working for good (its refresh token was revoked or expired), the CLI records the failure on that credential, surfaces it in `mux auth status` and `mux env list`, and falls back to the access token pair on the same environment if there is one. Nothing is deleted automatically: run `mux login` to replace the dead login, or `mux logout <name>` to remove the environment entirely.
+
+The CLI discovers the authorization server's endpoints at runtime (RFC 8414 / OIDC discovery, cached for a day in `~/.cache/mux/`), so Mux can move them without breaking installed versions. Discovery is never required: if it is unreachable the CLI falls back to built-in defaults, and `MUX_OAUTH_AUTHORIZE_URL` / `MUX_OAUTH_TOKEN_URL` / `MUX_OAUTH_REVOKE_URL` always win when set. It is consulted only on login and refresh, never on ordinary commands.
+
+Requests carry `Authorization: Basic` for access token credentials and `Authorization: Bearer` for browser sign-ins. Access tokens for a browser sign-in are refreshed automatically: shortly before they expire, and once on an unexpected `401` before the request is retried. Concurrent `mux` processes coordinate through a lock file so a refresh token is never spent twice. When a refresh token is finally rejected, the CLI names the environment and tells you to run `mux login` again.
 
 All values in a credential bundle come from the same source — the CLI never mixes sources:
 
@@ -1051,41 +1084,98 @@ mux exports list                                       # list video view export 
 
 #### `mux login`
 
-Authenticate with Mux and save credentials.
+Sign in to Mux and save credentials. With no flags, opens your browser to select an organization and environment; the CLI then manages token refresh for you.
+
+The four authentication methods are mutually exclusive; passing more than one is an error.
 
 **Options:**
+- `--oauth` - Sign in with a browser (the default when no shell credentials are set)
+- `--interactive` - Enter a Mux API access token (Token ID and Secret) manually
 - `-f, --env-file <path>` - Path to .env file containing `MUX_TOKEN_ID` and `MUX_TOKEN_SECRET`, and optionally `MUX_SIGNING_KEY` and `MUX_PRIVATE_KEY` (saved for `mux sign` when both are present)
-- `-n, --name <name>` - Name for this environment (default: `default`)
+- `--from-env` - Save the `MUX_TOKEN_ID` and `MUX_TOKEN_SECRET` already set in this shell
+- `-n, --name <name>` - Name for this environment (default: derived from the organization and environment for browser sign-in, or `default` otherwise)
+- `--print-url` - Print the authorization URL instead of opening a browser
+- `--port <port>` - Local port to receive the login redirect on
+- `--keep-current` - Save the login without making it the active environment
 
 ```bash
-mux login                                        # interactive
+mux login                                         # browser sign-in
+mux login --interactive                           # prompts for Token ID and Secret
 mux login --env-file .env                         # from .env file
+mux login --from-env                              # save this shell's credentials
 mux login --name production --env-file .env.prod  # named environment
+mux login --print-url                             # no browser available
 ```
 
-#### `mux logout <name>`
+`--oauth` and `--interactive` both need a real terminal: they fail immediately with instructions under `--json`, in agent mode, or when stdin is not a TTY (CI, piped input), rather than hanging. Use `--env-file`, `--from-env`, or the environment variables for automation.
 
-Remove credentials for a specific environment. When you remove the default environment, the CLI automatically selects another as the new default.
+**Signing in from a remote or SSH session:** the redirect goes to a loopback address on the machine running the CLI, which your browser cannot reach from elsewhere. Either forward the port (`ssh -L 51372:127.0.0.1:51372 …`, then `mux login --port 51372`) or use `mux login --interactive`.
+
+#### `mux auth status`
+
+Show every credential source the CLI can find, which one is active, and how to change it. Reads only local state — no network calls — and never prints token material.
+
+**Options:**
+- `--json` - Output JSON instead of pretty format
+
+```bash
+mux auth status
+```
+
+```
+Active: MUX_TOKEN_ID / MUX_TOKEN_SECRET (environment variables)
+  Environment variables take precedence over the stored login "acme-inc-production".
+  Unset them to use the stored selection below.
+
+Stored logins (2): currently shadowed
+* acme-inc-production  oauth  Acme Inc / Production   expires in 47m
+  ci-token             token  env_01H9...
+
+* = selected stored environment. Change it with 'mux env switch <name>'.
+```
+
+`mux auth login` and `mux auth logout` are aliases of the top-level commands.
+
+#### `mux logout [name]`
+
+Remove credentials for a specific environment. When you remove the default environment, the CLI automatically selects another as the new default. For a browser sign-in, the refresh token is also revoked server-side; if that call fails, the local credentials are still removed and a warning is printed.
+
+**Options:**
+- `--all` - Remove stored credentials for every environment
 
 ```bash
 mux logout default
 mux logout staging
+mux logout --all
 ```
 
 #### `mux env list`
 
-Display all configured environments.
+Display all configured environments, with the credential kind, the organization and environment they point at, and access token expiry for browser sign-ins.
+
+**Options:**
+- `--json` - Output JSON instead of pretty format
 
 ```bash
 mux env list
 ```
 
-#### `mux env switch <name>`
+```
+Configured environments:
 
-Change the default environment.
+* acme-inc-production (current)  oauth  Acme Inc / Production  expires in 47m
+  ci-token                       token  env_01H9...
+
+2 environments total
+```
+
+#### `mux env switch [name]`
+
+Change the default environment. Works for both credential kinds. Run it without a name in an interactive terminal to pick from a list.
 
 ```bash
 mux env switch staging
+mux env switch            # interactive picker
 ```
 
 </details>
@@ -1094,23 +1184,39 @@ mux env switch staging
 
 Credentials are stored securely in `~/.config/mux/config.json` with restrictive file permissions (readable/writable only by the owner).
 
-The configuration file structure:
+Each environment holds its identity and settings, plus one or both credential blocks. Entries written by earlier versions are flat (`tokenId` / `tokenSecret` at the top level) and are read as a `token` block automatically — there is no migration step and no config version to track.
 
 ```json
 {
   "environments": {
-    "production": {
-      "tokenId": "your_token_id",
-      "tokenSecret": "your_token_secret"
+    "acme-inc-production": {
+      "environmentId": "env_…",
+      "environmentName": "Production",
+      "organizationId": "org_…",
+      "organizationName": "Acme Inc",
+      "oauth": {
+        "accessToken": "…",
+        "refreshToken": "…",
+        "expiresAt": 1799999999,
+        "scope": "video:read video:write"
+      },
+      "token": {
+        "tokenId": "your_token_id",
+        "tokenSecret": "your_token_secret"
+      }
     },
     "staging": {
       "tokenId": "your_staging_token_id",
       "tokenSecret": "your_staging_token_secret"
     }
   },
-  "defaultEnvironment": "production"
+  "defaultEnvironment": "acme-inc-production"
 }
 ```
+
+`acme-inc-production` above is reachable both ways; requests use the `oauth` block. `staging` is a flat entry from an older version, read as an access token login. A credential that has failed terminally gains a `lastError` field, which is what `mux auth status` reports.
+
+Writes are atomic (written to a temporary file in the same directory, then renamed), so a config read during a token refresh never sees a partial file.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -1216,6 +1216,15 @@ Each environment holds its identity and settings, plus one or both credential bl
 
 `acme-inc-production` above is reachable both ways; requests use the `oauth` block. `staging` is a flat entry from an older version, read as an access token login. A credential that has failed terminally gains a `lastError` field, which is what `mux auth status` reports.
 
+### Upgrading from 2.x
+
+Nothing to do beyond signing in again. Two things are worth knowing:
+
+- **Run `mux login` after upgrading.** The first command that writes the config converts every entry to the layout above, including entries it wasn't asked about. Version 2.x looks for `tokenId` at the top level, so if you go back to it afterwards it will report that you are not logged in.
+- **Your access token secret is not lost.** It is still in `~/.config/mux/config.json`, just nested under `token`. Mux only displays a token secret once, at creation, so don't mint a replacement — signing in again, or moving the two fields back up a level, restores it.
+
+In CI, `mux login` now fails when `MUX_TOKEN_ID` and `MUX_TOKEN_SECRET` are set, because those variables already work without a login and take precedence over anything saved. Use `mux login --from-env` if you specifically want them written to the config.
+
 Writes are atomic (written to a temporary file in the same directory, then renamed), so a config read during a token refresh never sees a partial file.
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ A single environment can hold both credential kinds at once: an access token pai
 
 If an OAuth login stops working for good (its refresh token was revoked or expired), the CLI records the failure on that credential, surfaces it in `mux auth status` and `mux env list`, and falls back to the access token pair on the same environment if there is one. Nothing is deleted automatically: run `mux login` to replace the dead login, or `mux logout <name>` to remove the environment entirely.
 
-The CLI discovers the authorization server's endpoints at runtime (RFC 8414 / OIDC discovery, cached for a day in `~/.cache/mux/`), so Mux can move them without breaking installed versions. Discovery is never required: if it is unreachable the CLI falls back to built-in defaults, and `MUX_OAUTH_AUTHORIZE_URL` / `MUX_OAUTH_TOKEN_URL` / `MUX_OAUTH_REVOKE_URL` always win when set. It is consulted only on login and refresh, never on ordinary commands.
+All OAuth endpoints live on the Mux API host, so they are derived from one base — `MUX_BASE_URL` moves the API calls, discovery, and the sign-in flow together, and the token endpoint can never end up on a different host than the authorization endpoint. On top of that, the CLI discovers the authorization server's endpoints at runtime (RFC 8414 / OIDC discovery, cached for a day in `~/.cache/mux/`), so Mux can move them without breaking installed versions. Discovery is never required: if it is unreachable the CLI falls back to built-in defaults, and `MUX_OAUTH_AUTHORIZE_URL` / `MUX_OAUTH_TOKEN_URL` / `MUX_OAUTH_REVOKE_URL` always win when set. It is consulted only on login and refresh, never on ordinary commands.
 
 Requests carry `Authorization: Basic` for access token credentials and `Authorization: Bearer` for browser sign-ins. Access tokens for a browser sign-in are refreshed automatically: shortly before they expire, and once on an unexpected `401` before the request is retried. Concurrent `mux` processes coordinate through a lock file so a refresh token is never spent twice. When a refresh token is finally rejected, the CLI names the environment and tells you to run `mux login` again.
 
@@ -179,8 +179,11 @@ All values in a credential bundle come from the same source — the CLI never mi
 | Variable | Purpose |
 |----------|---------|
 | `MUX_TOKEN_ID` / `MUX_TOKEN_SECRET` | API credentials (both required to take effect) |
-| `MUX_BASE_URL` | API host override (applies to either source) |
+| `MUX_BASE_URL` | API host override (applies to either source). Also moves the OAuth endpoints and endpoint discovery, so one variable points the whole CLI at another environment |
 | `MUX_SIGNING_KEY` / `MUX_PRIVATE_KEY` | Signing key pair for `mux sign` (setting only one of the pair is an error; used alongside API credentials, not instead of them) |
+| `MUX_OAUTH_CLIENT_ID` | OAuth client identifier. Needed when pointing at a non-production authorization server |
+| `MUX_OAUTH_SCOPES` | Narrow the scopes requested at sign-in (space or comma separated). Defaults to what the CLI's commands need |
+| `MUX_OAUTH_AUTHORIZE_URL` / `MUX_OAUTH_TOKEN_URL` / `MUX_OAUTH_REVOKE_URL` | Override a single OAuth endpoint. Takes precedence over both discovery and `MUX_BASE_URL` |
 
 When credentials come from environment variables, the API host is `MUX_BASE_URL` or the default `https://api.mux.com` — never a stored environment's custom host. Similarly, `mux sign` only falls back to a stored environment's signing keys when that environment matches the active credentials, so tokens for one environment cannot mint tokens with another environment's key.
 
@@ -1123,16 +1126,32 @@ mux auth status
 ```
 
 ```
-Active: MUX_TOKEN_ID / MUX_TOKEN_SECRET (environment variables)
-  Environment variables take precedence over the stored login "acme-inc-production".
-  Unset them to use the stored selection below.
+Active:       acme-inc-production
+Sign-in:      browser sign-in
+Environment:  Acme Inc / Production
 
-Stored logins (2): currently shadowed
-* acme-inc-production  oauth  Acme Inc / Production   expires in 47m
-  ci-token             token  env_01H9...
+Other environments (1):
+  ci-token  access token  env_01H9
 
-* = selected stored environment. Change it with 'mux env switch <name>'.
+Switch with 'mux env switch <name>'.
 ```
+
+When `MUX_TOKEN_ID` and `MUX_TOKEN_SECRET` are set they outrank every saved login, so no saved login is active and all of them are listed — including the one that would take over if you unset the variables:
+
+```
+Active:       MUX_TOKEN_ID / MUX_TOKEN_SECRET
+Source:       environment variables
+Note:         takes precedence over the saved login acme-inc-production
+              unset both variables to use that instead
+
+Saved logins (2):
+  acme-inc-production  browser sign-in  Acme Inc / Production  (selected)
+  ci-token             access token     env_01H9
+
+Switch with 'mux env switch <name>'.
+```
+
+An environment reachable both ways reads `browser sign-in (also has access token)`, naming the one requests actually use. Access token expiry is deliberately not shown: it is refreshed automatically, so there is nothing to act on. `--json` carries `expires_at` for callers that want it.
 
 `mux auth login` and `mux auth logout` are aliases of the top-level commands.
 
@@ -1151,7 +1170,7 @@ mux logout --all
 
 #### `mux env list`
 
-Display all configured environments, with the credential kind, the organization and environment they point at, and access token expiry for browser sign-ins.
+Display all configured environments, with the credential kind and the organization and environment they point at. An environment holding both credentials shows `oauth+token`, and a credential that has failed shows a warning line beneath it.
 
 **Options:**
 - `--json` - Output JSON instead of pretty format
@@ -1163,8 +1182,8 @@ mux env list
 ```
 Configured environments:
 
-* acme-inc-production (current)  oauth  Acme Inc / Production  expires in 47m
-  ci-token                       token  env_01H9...
+* acme-inc-production (current)  oauth  Acme Inc / Production
+  ci-token                       token  env_01H9
 
 2 environments total
 ```

--- a/README.md
+++ b/README.md
@@ -1099,6 +1099,7 @@ The four authentication methods are mutually exclusive; passing more than one is
 - `-n, --name <name>` - Name for this environment (default: derived from the organization and environment for browser sign-in, or `default` otherwise)
 - `--print-url` - Print the authorization URL instead of opening a browser
 - `--port <port>` - Local port to receive the login redirect on
+- `--timeout <seconds>` - How long to wait for the browser authorization before giving up (default: 300)
 - `--keep-current` - Save the login without making it the active environment
 
 ```bash
@@ -1110,7 +1111,15 @@ mux login --name production --env-file .env.prod  # named environment
 mux login --print-url                             # no browser available
 ```
 
-`--oauth` and `--interactive` both need a real terminal: they fail immediately with instructions under `--json`, in agent mode, or when stdin is not a TTY (CI, piped input), rather than hanging. Use `--env-file`, `--from-env`, or the environment variables for automation.
+`--interactive` needs a real terminal to prompt on: it fails immediately with instructions under `--json`, in agent mode, or when stdin is not a TTY (CI, piped input), rather than hanging. A bare `mux login` without a TTY and without `--json` or agent mode also fails fast. Use `--env-file`, `--from-env`, or the environment variables for unattended automation.
+
+**Browser sign-in from a coding agent:** with `--json` or in agent mode, `mux login` runs the browser flow without a terminal. The moment the authorization URL is known it is emitted as a single JSON line on **stderr**:
+
+```json
+{"event":"authorization_url","url":"https://...","browserOpened":true,"expiresInSeconds":300}
+```
+
+The command then blocks until the browser redirect arrives (bounded by `--timeout`), and prints the final result as one JSON document on **stdout** (`name`, `identity`, `activated`, `replacedExisting`, `dropped`). The CLI still attempts to open a browser directly; pass `--print-url` to suppress that. Agent harnesses that only surface output when a command exits should run `mux login` in the background and poll its output so the URL can be relayed to the user while the command waits. This works only when the agent and the user's browser share a machine (or the user forwards the port — see below).
 
 **Signing in from a remote or SSH session:** the redirect goes to a loopback address on the machine running the CLI, which your browser cannot reach from elsewhere. Either forward the port (`ssh -L 51372:127.0.0.1:51372 …`, then `mux login --port 51372`) or use `mux login --interactive`.
 

--- a/src/commands/assets/manage/AssetManageApp.tsx
+++ b/src/commands/assets/manage/AssetManageApp.tsx
@@ -110,15 +110,11 @@ export function AssetManageApp({ mux, onPrompt }: AssetManageAppProps) {
           return null;
         }
 
-        return await signPlaybackId(
-          playbackId,
-          credentials,
-          {
-            tokenId: env.environment.tokenId,
-            tokenSecret: env.environment.tokenSecret,
-          },
-          { expiration: '7d' },
-        );
+        // No API credentials: signing is local to the signing key pair, and the
+        // active environment may be an OAuth login with no token pair.
+        return await signPlaybackId(playbackId, credentials, undefined, {
+          expiration: '7d',
+        });
       } catch {
         return null;
       }

--- a/src/commands/auth/index.ts
+++ b/src/commands/auth/index.ts
@@ -1,0 +1,15 @@
+import { Command } from '@cliffy/command';
+import { loginCommand } from '../login.ts';
+import { logoutCommand } from '../logout.ts';
+import { statusCommand } from './status.ts';
+
+export const authCommand = new Command()
+  .description('Inspect and manage Mux credentials')
+  .action(function () {
+    this.showHelp();
+  })
+  .command('status', statusCommand)
+  // Aliases of the top-level commands, so `mux auth login` works for anyone who
+  // reaches for it after running `mux auth status`.
+  .command('login', loginCommand)
+  .command('logout', logoutCommand);

--- a/src/commands/auth/status.test.ts
+++ b/src/commands/auth/status.test.ts
@@ -1,0 +1,205 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type Mock,
+  spyOn,
+} from 'bun:test';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { setEnvironment } from '@/lib/config.ts';
+import { setAgentMode, setJsonFlag } from '@/lib/context.ts';
+import { statusCommand } from './status.ts';
+
+let testConfigDir: string;
+let originalXdgConfigHome: string | undefined;
+let savedTokenId: string | undefined;
+let savedTokenSecret: string | undefined;
+let logSpy: Mock<typeof console.log>;
+
+function nowSeconds(): number {
+  return Math.floor(Date.now() / 1000);
+}
+
+/** Everything the command printed, as one string. */
+function output(): string {
+  return logSpy.mock.calls.map((call) => String(call[0] ?? '')).join('\n');
+}
+
+beforeEach(async () => {
+  testConfigDir = await mkdtemp(join(tmpdir(), 'mux-cli-auth-status-'));
+  originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
+  process.env.XDG_CONFIG_HOME = testConfigDir;
+  savedTokenId = process.env.MUX_TOKEN_ID;
+  savedTokenSecret = process.env.MUX_TOKEN_SECRET;
+  delete process.env.MUX_TOKEN_ID;
+  delete process.env.MUX_TOKEN_SECRET;
+  logSpy = spyOn(console, 'log').mockImplementation(() => {});
+});
+
+afterEach(async () => {
+  if (originalXdgConfigHome === undefined) {
+    delete process.env.XDG_CONFIG_HOME;
+  } else {
+    process.env.XDG_CONFIG_HOME = originalXdgConfigHome;
+  }
+  if (savedTokenId === undefined) delete process.env.MUX_TOKEN_ID;
+  else process.env.MUX_TOKEN_ID = savedTokenId;
+  if (savedTokenSecret === undefined) delete process.env.MUX_TOKEN_SECRET;
+  else process.env.MUX_TOKEN_SECRET = savedTokenSecret;
+  logSpy?.mockRestore();
+  setAgentMode(false);
+  setJsonFlag(false);
+  await rm(testConfigDir, { recursive: true, force: true });
+});
+
+async function storeBothKinds() {
+  await setEnvironment('acme-production', {
+    oauth: {
+      accessToken: 'access_1',
+      refreshToken: 'refresh_1',
+      expiresAt: nowSeconds() + 2820,
+    },
+    environmentId: 'env_123',
+    environmentName: 'Production',
+    organizationName: 'Acme Inc',
+  });
+  await setEnvironment('ci-token', {
+    token: { tokenId: 'token_id_value', tokenSecret: 'token_secret_value' },
+    environmentId: 'env_456',
+  });
+}
+
+describe('mux auth status', () => {
+  it('reports when nothing is configured', async () => {
+    await statusCommand.parse([]);
+
+    expect(output()).toMatch(/not (logged in|signed in)|no credentials/i);
+    expect(output()).toContain('mux login');
+  });
+
+  it('lists both credential kinds with their auth type', async () => {
+    await storeBothKinds();
+
+    await statusCommand.parse([]);
+    const printed = output();
+
+    expect(printed).toContain('acme-production');
+    expect(printed).toContain('oauth');
+    expect(printed).toContain('ci-token');
+    expect(printed).toContain('token');
+  });
+
+  it('shows the organization and environment for an OAuth login', async () => {
+    await storeBothKinds();
+
+    await statusCommand.parse([]);
+
+    expect(output()).toContain('Acme Inc');
+    expect(output()).toContain('Production');
+  });
+
+  it('marks the active stored environment', async () => {
+    await storeBothKinds();
+
+    await statusCommand.parse([]);
+    const rows = output()
+      .split('\n')
+      .filter((line) => /^[* ] \S/.test(line));
+
+    expect(rows).toContainEqual(expect.stringMatching(/^\* acme-production/));
+    expect(rows).toContainEqual(expect.stringMatching(/^ {2}ci-token/));
+  });
+
+  it('reports the access token expiry without a network call', async () => {
+    await storeBothKinds();
+    const fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(
+      (async () => {
+        throw new Error('network should not be reached');
+      }) as unknown as typeof fetch,
+    );
+
+    try {
+      await statusCommand.parse([]);
+
+      expect(output()).toMatch(/expires in \d+m|expired/i);
+      expect(fetchSpy).not.toHaveBeenCalled();
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it('says an expired token will refresh on next use', async () => {
+    await setEnvironment('acme-production', {
+      oauth: {
+        accessToken: 'access_1',
+        refreshToken: 'refresh_1',
+        expiresAt: nowSeconds() - 60,
+      },
+      environmentId: 'env_123',
+    });
+
+    await statusCommand.parse([]);
+
+    expect(output()).toMatch(/expired/i);
+    expect(output()).toMatch(/refresh/i);
+  });
+
+  it('explains that environment variables shadow the stored selection', async () => {
+    await storeBothKinds();
+    process.env.MUX_TOKEN_ID = 'env_token_id';
+    process.env.MUX_TOKEN_SECRET = 'env_token_secret';
+
+    await statusCommand.parse([]);
+    const printed = output();
+
+    expect(printed).toContain('MUX_TOKEN_ID');
+    expect(printed).toMatch(/precedence|shadow/i);
+    expect(printed).toContain('acme-production');
+  });
+
+  it('never prints token material', async () => {
+    await storeBothKinds();
+    process.env.MUX_TOKEN_ID = 'env_token_id';
+    process.env.MUX_TOKEN_SECRET = 'env_token_secret';
+
+    await statusCommand.parse([]);
+    const printed = output();
+
+    expect(printed).not.toContain('access_1');
+    expect(printed).not.toContain('refresh_1');
+    expect(printed).not.toContain('token_secret_value');
+    expect(printed).not.toContain('env_token_secret');
+  });
+
+  it('emits structured JSON with --json and no token material', async () => {
+    await storeBothKinds();
+
+    await statusCommand.parse(['--json']);
+    const parsed = JSON.parse(output());
+
+    expect(parsed.active.source).toBe('config');
+    expect(parsed.active.environment).toBe('acme-production');
+    expect(parsed.environments).toHaveLength(2);
+    const names = parsed.environments.map((e: { name: string }) => e.name);
+    expect(names).toContain('acme-production');
+    expect(names).toContain('ci-token');
+    expect(JSON.stringify(parsed)).not.toContain('access_1');
+    expect(JSON.stringify(parsed)).not.toContain('token_secret_value');
+  });
+
+  it('reports the environment variable source in JSON when it shadows', async () => {
+    await storeBothKinds();
+    process.env.MUX_TOKEN_ID = 'env_token_id';
+    process.env.MUX_TOKEN_SECRET = 'env_token_secret';
+
+    await statusCommand.parse(['--json']);
+    const parsed = JSON.parse(output());
+
+    expect(parsed.active.source).toBe('env');
+    expect(parsed.active.shadows).toBe('acme-production');
+  });
+});

--- a/src/commands/auth/status.test.ts
+++ b/src/commands/auth/status.test.ts
@@ -81,16 +81,35 @@ describe('mux auth status', () => {
     expect(output()).toContain('mux login');
   });
 
-  it('lists both credential kinds with their auth type', async () => {
+  it('describes credential kinds in words rather than internal names', async () => {
     await storeBothKinds();
 
     await statusCommand.parse([]);
     const printed = output();
 
     expect(printed).toContain('acme-production');
-    expect(printed).toContain('oauth');
+    expect(printed).toContain('browser sign-in');
     expect(printed).toContain('ci-token');
-    expect(printed).toContain('token');
+    expect(printed).toContain('access token');
+  });
+
+  it('says which credential an environment with both actually uses', async () => {
+    await storeBothKinds();
+    await setEnvironment('acme-production', {
+      environmentId: 'env_123',
+      environmentName: 'Production',
+      organizationName: 'Acme Inc',
+      oauth: {
+        accessToken: 'access_1',
+        refreshToken: 'refresh_1',
+        expiresAt: nowSeconds() + 2820,
+      },
+      token: { tokenId: 'id', tokenSecret: 'secret' },
+    });
+
+    await statusCommand.parse([]);
+
+    expect(output()).toContain('browser sign-in (also has access token)');
   });
 
   it('shows the organization and environment for an OAuth login', async () => {
@@ -102,19 +121,45 @@ describe('mux auth status', () => {
     expect(output()).toContain('Production');
   });
 
-  it('marks the active stored environment', async () => {
+  it('names the active environment without needing a marker legend', async () => {
     await storeBothKinds();
 
     await statusCommand.parse([]);
-    const rows = output()
-      .split('\n')
-      .filter((line) => /^[* ] \S/.test(line));
+    const printed = output();
 
-    expect(rows).toContainEqual(expect.stringMatching(/^\* acme-production/));
-    expect(rows).toContainEqual(expect.stringMatching(/^ {2}ci-token/));
+    expect(printed).toMatch(/^Active: +acme-production$/m);
+    // The old asterisk-plus-legend format is gone.
+    expect(printed).not.toContain('* =');
+    expect(printed).not.toMatch(/^\* /m);
   });
 
-  it('reports the access token expiry without a network call', async () => {
+  it('lists the environments that are not active separately', async () => {
+    await storeBothKinds();
+
+    await statusCommand.parse([]);
+    const printed = output();
+
+    expect(printed).toContain('Other environments (1):');
+    expect(printed).toContain('ci-token');
+    expect(printed).toContain('mux env switch <name>');
+  });
+
+  it('says nothing about other environments when there is only one', async () => {
+    await setEnvironment('only-one', {
+      environmentId: 'env_1',
+      oauth: {
+        accessToken: 'a',
+        refreshToken: 'r',
+        expiresAt: nowSeconds() + 600,
+      },
+    });
+
+    await statusCommand.parse([]);
+
+    expect(output()).not.toContain('Other environments');
+  });
+
+  it('reads everything locally, with no network call', async () => {
     await storeBothKinds();
     const fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(
       (async () => {
@@ -125,14 +170,16 @@ describe('mux auth status', () => {
     try {
       await statusCommand.parse([]);
 
-      expect(output()).toMatch(/expires in \d+m|expired/i);
+      expect(output()).toContain('acme-production');
       expect(fetchSpy).not.toHaveBeenCalled();
     } finally {
       fetchSpy.mockRestore();
     }
   });
 
-  it('says an expired token will refresh on next use', async () => {
+  it('does not mention expiry, which needs no action from the reader', async () => {
+    // An expiring access token is refreshed automatically. Saying "expired"
+    // only invites someone to re-login when nothing is wrong.
     await setEnvironment('acme-production', {
       oauth: {
         accessToken: 'access_1',
@@ -144,8 +191,7 @@ describe('mux auth status', () => {
 
     await statusCommand.parse([]);
 
-    expect(output()).toMatch(/expired/i);
-    expect(output()).toMatch(/refresh/i);
+    expect(output()).not.toMatch(/expire/i);
   });
 
   it('explains that environment variables shadow the stored selection', async () => {
@@ -157,8 +203,13 @@ describe('mux auth status', () => {
     const printed = output();
 
     expect(printed).toContain('MUX_TOKEN_ID');
-    expect(printed).toMatch(/precedence|shadow/i);
+    expect(printed).toMatch(/precedence/i);
     expect(printed).toContain('acme-production');
+    expect(printed).toMatch(/unset/i);
+    // Every saved login is listed, since none of them is active — including the
+    // one that would take over if the variables were unset.
+    expect(printed).toContain('Saved logins (2):');
+    expect(printed).toContain('(selected)');
   });
 
   it('never prints token material', async () => {

--- a/src/commands/auth/status.ts
+++ b/src/commands/auth/status.ts
@@ -1,5 +1,5 @@
 import { Command } from '@cliffy/command';
-import { readConfig } from '@/lib/config.ts';
+import { type CredentialKind, readConfig } from '@/lib/config.ts';
 import { wantsJson } from '@/lib/context.ts';
 import { summarizeEnvironment } from '@/lib/credentials.ts';
 import { handleCommandError } from '@/lib/errors.ts';
@@ -13,6 +13,31 @@ import { getConfigPath } from '@/lib/xdg.ts';
 
 interface StatusOptions {
   json?: boolean;
+}
+
+/** Width of the label column, matching the `Label:  value` style of whoami. */
+const LABEL_WIDTH = 14;
+
+/** One aligned `Label:  value` line. An empty label indents a continuation. */
+function field(label: string, value: string): string {
+  const prefix = label ? `${label}:` : '';
+  return `${prefix.padEnd(LABEL_WIDTH)}${value}`;
+}
+
+/**
+ * How a credential is described to a person. "oauth" and "token" are the
+ * internal kinds; neither means much to a reader, and an environment reachable
+ * both ways needs to say which one is actually used.
+ */
+function describeKinds(kinds: CredentialKind[]): string {
+  const names: Record<CredentialKind, string> = {
+    oauth: 'browser sign-in',
+    token: 'access token',
+  };
+
+  if (kinds.length === 0) return 'no credentials';
+  if (kinds.length === 1) return names[kinds[0]];
+  return `${names[kinds[0]]} (also has ${names[kinds[1]]})`;
 }
 
 export const statusCommand = new Command()
@@ -41,7 +66,15 @@ export const statusCommand = new Command()
           // biome-ignore lint/style/noNonNullAssertion: name came from this map
           config!.environments[name],
         );
-        return { name, ...summary, selected: name === activeStored };
+        return {
+          name,
+          ...summary,
+          // Epoch, not prose: JSON consumers can compare it, and the human
+          // output deliberately says nothing about expiry (the CLI refreshes on
+          // its own, so it is not something to act on).
+          expiresAt: config?.environments[name].oauth?.expiresAt ?? null,
+          selected: name === activeStored,
+        };
       });
 
       if (json) {
@@ -66,7 +99,7 @@ export const statusCommand = new Command()
                 auth: entry.kinds,
                 preferred: entry.preferred,
                 identity: entry.identity || null,
-                expiry: entry.expiry ?? null,
+                expires_at: entry.expiresAt,
                 warning: entry.warning ?? null,
                 selected: entry.selected,
               })),
@@ -87,63 +120,65 @@ export const statusCommand = new Command()
         return;
       }
 
+      const active = entries.find((entry) => entry.selected);
+
+      // Aligned label/value, matching `mux whoami`. The active credential is
+      // described in full; anything else is a one-line list. No marker legend —
+      // "Active" says which one it is.
       if (envVarsActive) {
-        console.log(
-          'Active: MUX_TOKEN_ID / MUX_TOKEN_SECRET (environment variables)',
-        );
+        console.log(field('Active', 'MUX_TOKEN_ID / MUX_TOKEN_SECRET'));
+        console.log(field('Source', 'environment variables'));
         if (activeStored) {
           console.log(
-            `  Environment variables take precedence over the stored login "${activeStored}".`,
+            field(
+              'Note',
+              `takes precedence over the saved login ${activeStored}`,
+            ),
           );
-          console.log('  Unset them to use the stored selection below.');
+          console.log(field('', 'unset both variables to use that instead'));
         }
-      } else if (activeStored) {
-        const active = entries.find((entry) => entry.selected);
-        console.log(
-          `Active: stored login "${activeStored}"${
-            active?.preferred ? ` (${active.preferred})` : ''
-          }`,
-        );
-        if (active?.identity) {
-          console.log(`  ${active.identity}`);
+      } else if (active) {
+        console.log(field('Active', active.name));
+        console.log(field('Sign-in', describeKinds(active.kinds)));
+        if (active.identity) {
+          console.log(field('Environment', active.identity));
         }
-      }
-
-      if (entries.length === 0) {
-        console.log("\nNo stored logins. Run 'mux login' to add one.");
-        return;
-      }
-
-      console.log(
-        `\nStored logins (${entries.length}):${envVarsActive ? ' currently shadowed' : ''}`,
-      );
-      const nameWidth = Math.max(...entries.map((entry) => entry.name.length));
-      const authWidth = Math.max(
-        ...entries.map((entry) => entry.kinds.join('+').length),
-      );
-      for (const entry of entries) {
-        const marker = entry.selected ? '*' : ' ';
-        // "oauth+token" when an environment is reachable both ways; the first
-        // listed is the one requests will use.
-        const auth = (entry.kinds.join('+') || 'none').padEnd(authWidth);
-        const details = [entry.identity, entry.expiry]
-          .filter(Boolean)
-          .join('   ');
-        console.log(
-          `${marker} ${entry.name.padEnd(nameWidth)}  ${auth}  ${details}`.trimEnd(),
-        );
-        if (entry.warning) {
-          console.log(`${' '.repeat(nameWidth + 2)}  ⚠ ${entry.warning}`);
+        if (active.warning) {
+          console.log(field('Warning', active.warning));
         }
       }
 
-      console.log(
-        "\n* = selected stored environment. Change it with 'mux env switch <name>'.",
-      );
-      if (entries.some((entry) => entry.kinds.length > 1)) {
+      // When environment variables are in charge, no stored login is active, so
+      // every one of them is listed — including the selected one, which is what
+      // would take over if the variables were unset.
+      const listed = envVarsActive
+        ? entries
+        : entries.filter((entry) => !entry.selected);
+
+      if (listed.length > 0) {
         console.log(
-          'Environments listing two credentials are reachable both ways; the first is preferred.',
+          `\n${envVarsActive ? 'Saved logins' : 'Other environments'} (${listed.length}):`,
         );
+        const nameWidth = Math.max(...listed.map((entry) => entry.name.length));
+        const kindWidth = Math.max(
+          ...listed.map((entry) => describeKinds(entry.kinds).length),
+        );
+        for (const entry of listed) {
+          const suffix = envVarsActive && entry.selected ? '  (selected)' : '';
+          const detail = [
+            describeKinds(entry.kinds).padEnd(kindWidth),
+            entry.identity,
+          ]
+            .filter(Boolean)
+            .join('  ');
+          console.log(
+            `  ${entry.name.padEnd(nameWidth)}  ${detail}${suffix}`.trimEnd(),
+          );
+          if (entry.warning) {
+            console.log(`  ${' '.repeat(nameWidth)}  ${entry.warning}`);
+          }
+        }
+        console.log("\nSwitch with 'mux env switch <name>'.");
       }
     } catch (error) {
       await handleCommandError(error, 'auth', 'status', options);

--- a/src/commands/auth/status.ts
+++ b/src/commands/auth/status.ts
@@ -1,0 +1,151 @@
+import { Command } from '@cliffy/command';
+import { readConfig } from '@/lib/config.ts';
+import { wantsJson } from '@/lib/context.ts';
+import { summarizeEnvironment } from '@/lib/credentials.ts';
+import { handleCommandError } from '@/lib/errors.ts';
+import { getConfigPath } from '@/lib/xdg.ts';
+
+/**
+ * `mux auth status` — every credential source the CLI can see, which one is
+ * active, and why. Reads only local state: no network call, no token material in
+ * the output.
+ */
+
+interface StatusOptions {
+  json?: boolean;
+}
+
+export const statusCommand = new Command()
+  .description(
+    'Show every available credential source, which one is active, and how to switch',
+  )
+  .option('--json', 'Output JSON instead of pretty format')
+  .action(async (options: StatusOptions) => {
+    try {
+      const json = wantsJson(options);
+      const config = await readConfig();
+      const names = config ? Object.keys(config.environments) : [];
+      const selected = config?.defaultEnvironment;
+
+      const envTokenId = process.env.MUX_TOKEN_ID;
+      const envTokenSecret = process.env.MUX_TOKEN_SECRET;
+      const envVarsActive = Boolean(envTokenId && envTokenSecret);
+
+      // The selected entry only governs when environment variables are absent;
+      // this mirrors the resolution order in lib/mux.ts.
+      const activeStored =
+        selected && config?.environments[selected] ? selected : names[0];
+
+      const entries = names.map((name) => {
+        const summary = summarizeEnvironment(
+          // biome-ignore lint/style/noNonNullAssertion: name came from this map
+          config!.environments[name],
+        );
+        return { name, ...summary, selected: name === activeStored };
+      });
+
+      if (json) {
+        console.log(
+          JSON.stringify(
+            {
+              active: envVarsActive
+                ? {
+                    source: 'env',
+                    type: 'token',
+                    ...(activeStored && { shadows: activeStored }),
+                  }
+                : activeStored
+                  ? {
+                      source: 'config',
+                      environment: activeStored,
+                      type: entries.find((e) => e.selected)?.preferred,
+                    }
+                  : { source: 'none' },
+              environments: entries.map((entry) => ({
+                name: entry.name,
+                auth: entry.kinds,
+                preferred: entry.preferred,
+                identity: entry.identity || null,
+                expiry: entry.expiry ?? null,
+                warning: entry.warning ?? null,
+                selected: entry.selected,
+              })),
+              config_path: getConfigPath(),
+            },
+            null,
+            2,
+          ),
+        );
+        return;
+      }
+
+      if (!envVarsActive && entries.length === 0) {
+        console.log('Not signed in, and no credentials found.');
+        console.log(
+          "\nRun 'mux login' to sign in, or set MUX_TOKEN_ID and MUX_TOKEN_SECRET.",
+        );
+        return;
+      }
+
+      if (envVarsActive) {
+        console.log(
+          'Active: MUX_TOKEN_ID / MUX_TOKEN_SECRET (environment variables)',
+        );
+        if (activeStored) {
+          console.log(
+            `  Environment variables take precedence over the stored login "${activeStored}".`,
+          );
+          console.log('  Unset them to use the stored selection below.');
+        }
+      } else if (activeStored) {
+        const active = entries.find((entry) => entry.selected);
+        console.log(
+          `Active: stored login "${activeStored}"${
+            active?.preferred ? ` (${active.preferred})` : ''
+          }`,
+        );
+        if (active?.identity) {
+          console.log(`  ${active.identity}`);
+        }
+      }
+
+      if (entries.length === 0) {
+        console.log("\nNo stored logins. Run 'mux login' to add one.");
+        return;
+      }
+
+      console.log(
+        `\nStored logins (${entries.length}):${envVarsActive ? ' currently shadowed' : ''}`,
+      );
+      const nameWidth = Math.max(...entries.map((entry) => entry.name.length));
+      const authWidth = Math.max(
+        ...entries.map((entry) => entry.kinds.join('+').length),
+      );
+      for (const entry of entries) {
+        const marker = entry.selected ? '*' : ' ';
+        // "oauth+token" when an environment is reachable both ways; the first
+        // listed is the one requests will use.
+        const auth = (entry.kinds.join('+') || 'none').padEnd(authWidth);
+        const details = [entry.identity, entry.expiry]
+          .filter(Boolean)
+          .join('   ');
+        console.log(
+          `${marker} ${entry.name.padEnd(nameWidth)}  ${auth}  ${details}`.trimEnd(),
+        );
+        if (entry.warning) {
+          console.log(`${' '.repeat(nameWidth + 2)}  ⚠ ${entry.warning}`);
+        }
+      }
+
+      console.log(
+        "\n* = selected stored environment. Change it with 'mux env switch <name>'.",
+      );
+      if (entries.some((entry) => entry.kinds.length > 1)) {
+        console.log(
+          'Environments listing two credentials are reachable both ways; the first is preferred.',
+        );
+      }
+    } catch (error) {
+      await handleCommandError(error, 'auth', 'status', options);
+    }
+  });

--- a/src/commands/env/env-commands.test.ts
+++ b/src/commands/env/env-commands.test.ts
@@ -1,0 +1,253 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type Mock,
+  spyOn,
+} from 'bun:test';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { getCurrentEnvironment, setEnvironment } from '@/lib/config.ts';
+import { setAgentMode, setJsonFlag } from '@/lib/context.ts';
+import { listCommand } from './list.ts';
+import { switchCommand } from './switch.ts';
+
+let testConfigDir: string;
+let originalXdgConfigHome: string | undefined;
+let savedTokenId: string | undefined;
+let savedTokenSecret: string | undefined;
+let logSpy: Mock<typeof console.log>;
+let errorSpy: Mock<typeof console.error>;
+let exitSpy: Mock<typeof process.exit>;
+
+function nowSeconds(): number {
+  return Math.floor(Date.now() / 1000);
+}
+
+function stdout(): string {
+  return logSpy.mock.calls.map((call) => String(call[0] ?? '')).join('\n');
+}
+
+function stderr(): string {
+  return errorSpy.mock.calls.map((call) => String(call[0] ?? '')).join('\n');
+}
+
+beforeEach(async () => {
+  testConfigDir = await mkdtemp(join(tmpdir(), 'mux-cli-env-cmds-'));
+  originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
+  process.env.XDG_CONFIG_HOME = testConfigDir;
+  savedTokenId = process.env.MUX_TOKEN_ID;
+  savedTokenSecret = process.env.MUX_TOKEN_SECRET;
+  delete process.env.MUX_TOKEN_ID;
+  delete process.env.MUX_TOKEN_SECRET;
+
+  logSpy = spyOn(console, 'log').mockImplementation(() => {});
+  errorSpy = spyOn(console, 'error').mockImplementation(() => {});
+  exitSpy = spyOn(process, 'exit').mockImplementation((() => {
+    throw new Error('process.exit called');
+  }) as never);
+});
+
+afterEach(async () => {
+  if (originalXdgConfigHome === undefined) {
+    delete process.env.XDG_CONFIG_HOME;
+  } else {
+    process.env.XDG_CONFIG_HOME = originalXdgConfigHome;
+  }
+  if (savedTokenId === undefined) delete process.env.MUX_TOKEN_ID;
+  else process.env.MUX_TOKEN_ID = savedTokenId;
+  if (savedTokenSecret === undefined) delete process.env.MUX_TOKEN_SECRET;
+  else process.env.MUX_TOKEN_SECRET = savedTokenSecret;
+  logSpy?.mockRestore();
+  errorSpy?.mockRestore();
+  exitSpy?.mockRestore();
+  setAgentMode(false);
+  setJsonFlag(false);
+  await rm(testConfigDir, { recursive: true, force: true });
+});
+
+async function seedEnvironments() {
+  await setEnvironment('acme-production', {
+    environmentId: 'env_123',
+    environmentName: 'Production',
+    organizationName: 'Acme Inc',
+    oauth: {
+      accessToken: 'access_1',
+      refreshToken: 'refresh_1',
+      expiresAt: nowSeconds() + 2700,
+    },
+    token: { tokenId: 'pair_id', tokenSecret: 'pair_secret' },
+  });
+  await setEnvironment('ci-token', {
+    environmentId: 'env_456',
+    token: { tokenId: 'ci_id', tokenSecret: 'ci_secret' },
+  });
+}
+
+describe('mux env list', () => {
+  it('reports an empty config in both formats', async () => {
+    await listCommand.parse([]);
+    expect(stdout()).toContain('No environments configured');
+
+    logSpy.mockClear();
+    await listCommand.parse(['--json']);
+    expect(JSON.parse(stdout())).toEqual({ environments: [], current: null });
+  });
+
+  it('shows the credential kinds an environment holds, preferred first', async () => {
+    await seedEnvironments();
+
+    await listCommand.parse([]);
+
+    expect(stdout()).toContain('oauth+token');
+    expect(stdout()).toContain('Acme Inc / Production');
+  });
+
+  it('marks the current environment', async () => {
+    await seedEnvironments();
+
+    await listCommand.parse([]);
+    const row = stdout()
+      .split('\n')
+      .find((line) => line.includes('acme-production'));
+
+    expect(row).toStartWith('*');
+    expect(row).toContain('(current)');
+  });
+
+  it('emits structured JSON without token material', async () => {
+    await seedEnvironments();
+
+    await listCommand.parse(['--json']);
+    const parsed = JSON.parse(stdout());
+
+    expect(parsed.current).toBe('acme-production');
+    const production = parsed.environments.find(
+      (e: { name: string }) => e.name === 'acme-production',
+    );
+    expect(production.auth).toEqual(['oauth', 'token']);
+    expect(production.preferred).toBe('oauth');
+    expect(production.environment_id).toBe('env_123');
+    expect(production.expires_at).toBeGreaterThan(nowSeconds());
+    expect(stdout()).not.toContain('access_1');
+    expect(stdout()).not.toContain('pair_secret');
+  });
+
+  it('surfaces a flagged credential as a warning', async () => {
+    await setEnvironment('broken', {
+      environmentId: 'env_dead',
+      oauth: {
+        accessToken: 'a',
+        refreshToken: 'r',
+        expiresAt: nowSeconds() + 600,
+        lastError: { code: 'invalid_grant', at: '2026-08-15T00:00:00Z' },
+      },
+    });
+
+    await listCommand.parse([]);
+    expect(stdout()).toContain('invalid_grant');
+
+    logSpy.mockClear();
+    await listCommand.parse(['--json']);
+    expect(JSON.parse(stdout()).environments[0].warning).toContain(
+      'invalid_grant',
+    );
+  });
+
+  it('warns that environment variables outrank the selection', async () => {
+    await seedEnvironments();
+    process.env.MUX_TOKEN_ID = 'env_id';
+    process.env.MUX_TOKEN_SECRET = 'env_secret';
+
+    await listCommand.parse([]);
+
+    expect(stdout()).toContain('take precedence');
+  });
+});
+
+describe('mux env switch', () => {
+  it('switches to a named environment', async () => {
+    await seedEnvironments();
+
+    await switchCommand.parse(['ci-token']);
+
+    expect((await getCurrentEnvironment())?.name).toBe('ci-token');
+    expect(stdout()).toContain('ci-token');
+  });
+
+  it('rejects an unknown environment without changing the selection', async () => {
+    await seedEnvironments();
+
+    try {
+      await switchCommand.parse(['nope']);
+    } catch {
+      // the mocked process.exit throws to halt parse
+    }
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(stderr()).toContain('does not exist');
+    expect((await getCurrentEnvironment())?.name).toBe('acme-production');
+  });
+
+  it('reports an unknown environment as JSON with --json', async () => {
+    await seedEnvironments();
+
+    try {
+      await switchCommand.parse(['nope', '--json']);
+    } catch {
+      // exits
+    }
+
+    expect(JSON.parse(stderr()).error).toContain('does not exist');
+  });
+
+  it('emits structured JSON on success', async () => {
+    await seedEnvironments();
+
+    await switchCommand.parse(['ci-token', '--json']);
+    const parsed = JSON.parse(stdout());
+
+    expect(parsed).toEqual({
+      success: true,
+      environment: 'ci-token',
+      shadowed_by_environment_variables: false,
+    });
+  });
+
+  it('tells a machine caller when the switch is shadowed by env vars', async () => {
+    await seedEnvironments();
+    process.env.MUX_TOKEN_ID = 'env_id';
+    process.env.MUX_TOKEN_SECRET = 'env_secret';
+
+    await switchCommand.parse(['ci-token', '--json']);
+
+    expect(JSON.parse(stdout()).shadowed_by_environment_variables).toBe(true);
+  });
+
+  it('refuses to prompt with no argument when output must stay parseable', async () => {
+    await seedEnvironments();
+
+    try {
+      await switchCommand.parse(['--json']);
+    } catch {
+      // exits
+    }
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(JSON.parse(stderr()).error).toContain('Specify an environment name');
+  });
+
+  it('reports an empty config rather than prompting', async () => {
+    try {
+      await switchCommand.parse([]);
+    } catch {
+      // exits
+    }
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(stderr()).toContain('No environments configured');
+  });
+});

--- a/src/commands/env/env-commands.test.ts
+++ b/src/commands/env/env-commands.test.ts
@@ -104,6 +104,8 @@ describe('mux env list', () => {
 
     expect(stdout()).toContain('oauth+token');
     expect(stdout()).toContain('Acme Inc / Production');
+    // Expiry is deliberately absent: it refreshes on its own.
+    expect(stdout()).not.toMatch(/expires in/i);
   });
 
   it('marks the current environment', async () => {

--- a/src/commands/env/list.ts
+++ b/src/commands/env/list.ts
@@ -1,29 +1,112 @@
 import { Command } from '@cliffy/command';
 import { readConfig } from '@/lib/config.ts';
+import { wantsJson } from '@/lib/context.ts';
+import { summarizeEnvironment } from '@/lib/credentials.ts';
+
+interface ListOptions {
+  json?: boolean;
+}
 
 export const listCommand = new Command()
   .description('List all configured environments')
-  .action(async () => {
+  .option('--json', 'Output JSON instead of pretty format')
+  .action(async (options: ListOptions) => {
     const config = await readConfig();
+    const json = wantsJson(options);
 
     if (!config || Object.keys(config.environments).length === 0) {
+      if (json) {
+        console.log(
+          JSON.stringify({ environments: [], current: null }, null, 2),
+        );
+        return;
+      }
       console.log('No environments configured.');
       console.log("\nRun 'mux login' to add an environment.");
       return;
     }
 
-    console.log('Configured environments:\n');
-
     const envNames = Object.keys(config.environments);
     const currentEnv = config.defaultEnvironment;
 
+    if (json) {
+      console.log(
+        JSON.stringify(
+          {
+            environments: envNames.map((name) => {
+              const environment = config.environments[name];
+              const summary = summarizeEnvironment(environment);
+              return {
+                name,
+                // Every credential the entry holds, preferred first, since an
+                // environment can be reachable more than one way.
+                auth: summary.kinds,
+                preferred: summary.preferred,
+                environment_id: environment.environmentId ?? null,
+                organization_name: environment.organizationName ?? null,
+                environment_name: environment.environmentName ?? null,
+                expires_at: environment.oauth?.expiresAt ?? null,
+                warning: summary.warning ?? null,
+                current: name === currentEnv,
+              };
+            }),
+            current: currentEnv ?? null,
+          },
+          null,
+          2,
+        ),
+      );
+      return;
+    }
+
+    console.log('Configured environments:\n');
+
+    const labels = new Map(
+      envNames.map((name) => [
+        name,
+        `${name}${name === currentEnv ? ' (current)' : ''}`,
+      ]),
+    );
+    const labelWidth = Math.max(
+      ...[...labels.values()].map((label) => label.length),
+    );
+    const summaries = new Map(
+      envNames.map((name) => [
+        name,
+        summarizeEnvironment(config.environments[name]),
+      ]),
+    );
+    const authWidth = Math.max(
+      ...[...summaries.values()].map((s) => s.kinds.join('+').length),
+    );
+
     for (const name of envNames) {
-      const isCurrent = name === currentEnv;
-      const marker = isCurrent ? '* ' : '  ';
-      console.log(`${marker}${name}${isCurrent ? ' (current)' : ''}`);
+      const summary = summaries.get(name) as ReturnType<
+        typeof summarizeEnvironment
+      >;
+      const marker = name === currentEnv ? '* ' : '  ';
+      // "oauth+token" when an environment holds both; the first is preferred.
+      const auth = (summary.kinds.join('+') || 'none').padEnd(authWidth);
+      const details = [summary.identity, summary.expiry]
+        .filter(Boolean)
+        .join('  ');
+      console.log(
+        `${marker}${(labels.get(name) as string).padEnd(labelWidth)}  ${auth}  ${details}`.trimEnd(),
+      );
+      if (summary.warning) {
+        console.log(`${' '.repeat(2 + labelWidth)}  ⚠ ${summary.warning}`);
+      }
     }
 
     console.log(
       `\n${envNames.length} environment${envNames.length === 1 ? '' : 's'} total`,
     );
+
+    // A forgotten shell variable outranks whatever is marked current here, so
+    // say so rather than letting the asterisk mislead.
+    if (process.env.MUX_TOKEN_ID && process.env.MUX_TOKEN_SECRET) {
+      console.log(
+        "\nNote: MUX_TOKEN_ID/MUX_TOKEN_SECRET are set and take precedence over the selection above. Run 'mux auth status' for details.",
+      );
+    }
   });

--- a/src/commands/env/list.ts
+++ b/src/commands/env/list.ts
@@ -87,9 +87,9 @@ export const listCommand = new Command()
       const marker = name === currentEnv ? '* ' : '  ';
       // "oauth+token" when an environment holds both; the first is preferred.
       const auth = (summary.kinds.join('+') || 'none').padEnd(authWidth);
-      const details = [summary.identity, summary.expiry]
-        .filter(Boolean)
-        .join('  ');
+      // No expiry column: the CLI refreshes on its own, so it is not something
+      // a reader can act on. `--json` still carries expires_at.
+      const details = summary.identity;
       console.log(
         `${marker}${(labels.get(name) as string).padEnd(labelWidth)}  ${auth}  ${details}`.trimEnd(),
       );

--- a/src/commands/env/switch.ts
+++ b/src/commands/env/switch.ts
@@ -1,22 +1,92 @@
 import { Command } from '@cliffy/command';
-import { getEnvironment, setCurrentEnvironment } from '@/lib/config.ts';
+import {
+  getEnvironment,
+  getEnvironmentAuthType,
+  listEnvironments,
+  readConfig,
+  setCurrentEnvironment,
+} from '@/lib/config.ts';
+import { isAgentMode, wantsJson } from '@/lib/context.ts';
+import { inputPrompt } from '@/lib/prompt.ts';
+
+/**
+ * Prompt for one of the configured environments. Interactive only: a missing
+ * argument stays an error under --json or in agent mode, where there is no one
+ * to ask.
+ */
+async function promptForEnvironment(): Promise<string> {
+  const config = await readConfig();
+  const names = config ? Object.keys(config.environments) : [];
+
+  console.log('Configured environments:\n');
+  names.forEach((name, index) => {
+    const environment = config?.environments[name];
+    const current = name === config?.defaultEnvironment ? ' (current)' : '';
+    const type = environment ? `   ${getEnvironmentAuthType(environment)}` : '';
+    console.log(`  ${index + 1}. ${name}${current}${type}`);
+  });
+  console.log('');
+
+  const answer = await inputPrompt({
+    message: 'Environment (name or number):',
+  });
+  const trimmed = answer.trim();
+
+  const byNumber = Number.parseInt(trimmed, 10);
+  if (
+    !Number.isNaN(byNumber) &&
+    byNumber >= 1 &&
+    byNumber <= names.length &&
+    String(byNumber) === trimmed
+  ) {
+    return names[byNumber - 1];
+  }
+
+  return trimmed;
+}
 
 export const switchCommand = new Command()
   .description(
     'Switch the default environment (used by all subsequent mux commands)',
   )
-  .arguments('<name:string>')
-  .action(async (_options, name: string) => {
+  .arguments('[name:string]')
+  .option('--json', 'Output JSON instead of pretty format')
+  .action(async (options: { json?: boolean }, name?: string) => {
+    let target = name;
+
+    if (!target) {
+      const names = await listEnvironments();
+      if (names.length === 0) {
+        console.error('❌ No environments configured.');
+        console.log("\nRun 'mux login' to add one.");
+        process.exit(1);
+      }
+
+      if (wantsJson(options) || isAgentMode() || !process.stdin.isTTY) {
+        console.error('❌ Specify an environment name.');
+        console.log("\nRun 'mux env list' to see available environments.");
+        process.exit(1);
+      }
+
+      target = await promptForEnvironment();
+    }
+
     // Check if environment exists
-    const env = await getEnvironment(name);
+    const env = await getEnvironment(target);
 
     if (!env) {
-      console.error(`❌ Environment "${name}" does not exist.`);
+      console.error(`❌ Environment "${target}" does not exist.`);
       console.log("\nRun 'mux env list' to see available environments.");
       process.exit(1);
     }
 
     // Set as default
-    await setCurrentEnvironment(name);
-    console.log(`✅ Switched default environment to: ${name}`);
+    await setCurrentEnvironment(target);
+    console.log(`✅ Switched default environment to: ${target}`);
+
+    if (process.env.MUX_TOKEN_ID && process.env.MUX_TOKEN_SECRET) {
+      console.log(
+        "\nNote: MUX_TOKEN_ID/MUX_TOKEN_SECRET are set and take precedence over this selection. Run 'mux auth status' for details.",
+      );
+    }
   });

--- a/src/commands/env/switch.ts
+++ b/src/commands/env/switch.ts
@@ -52,20 +52,32 @@ export const switchCommand = new Command()
   .arguments('[name:string]')
   .option('--json', 'Output JSON instead of pretty format')
   .action(async (options: { json?: boolean }, name?: string) => {
+    const json = wantsJson(options);
+
+    /** Report a failure in whichever format the caller asked for, then exit. */
+    const fail = (error: string, hint: string): never => {
+      if (json) {
+        console.error(JSON.stringify({ error }, null, 2));
+      } else {
+        console.error(`❌ ${error}`);
+        console.log(`\n${hint}`);
+      }
+      process.exit(1);
+    };
+
     let target = name;
 
     if (!target) {
       const names = await listEnvironments();
       if (names.length === 0) {
-        console.error('❌ No environments configured.');
-        console.log("\nRun 'mux login' to add one.");
-        process.exit(1);
+        fail('No environments configured.', "Run 'mux login' to add one.");
       }
 
-      if (wantsJson(options) || isAgentMode() || !process.stdin.isTTY) {
-        console.error('❌ Specify an environment name.');
-        console.log("\nRun 'mux env list' to see available environments.");
-        process.exit(1);
+      if (json || isAgentMode() || !process.stdin.isTTY) {
+        fail(
+          'Specify an environment name.',
+          "Run 'mux env list' to see available environments.",
+        );
       }
 
       target = await promptForEnvironment();
@@ -75,16 +87,39 @@ export const switchCommand = new Command()
     const env = await getEnvironment(target);
 
     if (!env) {
-      console.error(`❌ Environment "${target}" does not exist.`);
-      console.log("\nRun 'mux env list' to see available environments.");
-      process.exit(1);
+      fail(
+        `Environment "${target}" does not exist.`,
+        "Run 'mux env list' to see available environments.",
+      );
     }
 
     // Set as default
     await setCurrentEnvironment(target);
+
+    const shadowed = Boolean(
+      process.env.MUX_TOKEN_ID && process.env.MUX_TOKEN_SECRET,
+    );
+
+    if (json) {
+      console.log(
+        JSON.stringify(
+          {
+            success: true,
+            environment: target,
+            // Env var credentials outrank this selection, so a machine caller
+            // needs to know the switch will not change which account is used.
+            shadowed_by_environment_variables: shadowed,
+          },
+          null,
+          2,
+        ),
+      );
+      return;
+    }
+
     console.log(`✅ Switched default environment to: ${target}`);
 
-    if (process.env.MUX_TOKEN_ID && process.env.MUX_TOKEN_SECRET) {
+    if (shadowed) {
       console.log(
         "\nNote: MUX_TOKEN_ID/MUX_TOKEN_SECRET are set and take precedence over this selection. Run 'mux auth status' for details.",
       );

--- a/src/commands/login-mode.test.ts
+++ b/src/commands/login-mode.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'bun:test';
+import { ENV_VARS_DETECTED_MESSAGE, resolveLoginMode } from './login-mode.ts';
+
+const WITH_ENV = { MUX_TOKEN_ID: 'id', MUX_TOKEN_SECRET: 'secret' };
+const NO_ENV = {};
+
+describe('resolveLoginMode', () => {
+  describe('with no shell credentials', () => {
+    it('defaults to OAuth', () => {
+      expect(resolveLoginMode({}, NO_ENV)).toBe('oauth');
+    });
+
+    it('honors each explicit mode', () => {
+      expect(resolveLoginMode({ oauth: true }, NO_ENV)).toBe('oauth');
+      expect(resolveLoginMode({ interactive: true }, NO_ENV)).toBe(
+        'interactive',
+      );
+      expect(resolveLoginMode({ envFile: '.env' }, NO_ENV)).toBe('env-file');
+    });
+
+    it('rejects --from-env with a message naming the missing variables', () => {
+      expect(() => resolveLoginMode({ fromEnv: true }, NO_ENV)).toThrow(
+        /MUX_TOKEN_ID and MUX_TOKEN_SECRET are not set/,
+      );
+    });
+
+    it('points at the alternatives when --from-env cannot be satisfied', () => {
+      expect(() => resolveLoginMode({ fromEnv: true }, NO_ENV)).toThrow(
+        /--env-file|--interactive|--oauth/,
+      );
+    });
+  });
+
+  describe('with shell credentials present', () => {
+    it('refuses to guess, and explains that no login is needed', () => {
+      expect(() => resolveLoginMode({}, WITH_ENV)).toThrow(
+        /MUX_TOKEN_ID and MUX_TOKEN_SECRET detected/,
+      );
+    });
+
+    it('lists all four ways to log in explicitly', () => {
+      const message = ENV_VARS_DETECTED_MESSAGE;
+
+      expect(message).toContain('--from-env');
+      expect(message).toContain('--env-file');
+      expect(message).toContain('--interactive');
+      expect(message).toContain('--oauth');
+    });
+
+    it('says commands work without logging in at all', () => {
+      expect(ENV_VARS_DETECTED_MESSAGE).toMatch(
+        /No .?mux login.? is necessary|without calling/i,
+      );
+    });
+
+    it('accepts --from-env', () => {
+      expect(resolveLoginMode({ fromEnv: true }, WITH_ENV)).toBe('from-env');
+    });
+
+    it('accepts the other explicit modes too', () => {
+      // Shell credentials do not force the from-env path: the caller may want a
+      // browser login or a specific file saved instead.
+      expect(resolveLoginMode({ oauth: true }, WITH_ENV)).toBe('oauth');
+      expect(resolveLoginMode({ interactive: true }, WITH_ENV)).toBe(
+        'interactive',
+      );
+      expect(resolveLoginMode({ envFile: '.env' }, WITH_ENV)).toBe('env-file');
+    });
+  });
+
+  describe('mutual exclusivity', () => {
+    it('rejects two modes at once', () => {
+      expect(() =>
+        resolveLoginMode({ oauth: true, interactive: true }, NO_ENV),
+      ).toThrow(/only one/i);
+    });
+
+    it('names the flags that conflicted', () => {
+      expect(() =>
+        resolveLoginMode({ envFile: '.env', fromEnv: true }, WITH_ENV),
+      ).toThrow(/--env-file.*--from-env|--from-env.*--env-file/s);
+    });
+
+    it('rejects three or more', () => {
+      expect(() =>
+        resolveLoginMode(
+          { oauth: true, interactive: true, fromEnv: true },
+          NO_ENV,
+        ),
+      ).toThrow(/only one/i);
+    });
+
+    it('allows a single mode alongside unrelated flags', () => {
+      expect(
+        resolveLoginMode(
+          { oauth: true, name: 'staging', printUrl: true },
+          NO_ENV,
+        ),
+      ).toBe('oauth');
+    });
+  });
+});

--- a/src/commands/login-mode.ts
+++ b/src/commands/login-mode.ts
@@ -1,0 +1,88 @@
+/**
+ * Which authentication method `mux login` should use.
+ *
+ * The rule is that the CLI never guesses when the shell already carries
+ * credentials. Environment variables always win at runtime, so silently saving
+ * them on `mux login` produced a config entry that had no effect while those
+ * variables stayed set — the caller has to say what they actually meant.
+ */
+
+export type LoginMode = 'oauth' | 'interactive' | 'env-file' | 'from-env';
+
+export interface LoginModeOptions {
+  oauth?: boolean;
+  interactive?: boolean;
+  fromEnv?: boolean;
+  envFile?: string;
+  [key: string]: unknown;
+}
+
+export const ENV_VARS_DETECTED_MESSAGE = [
+  'MUX_TOKEN_ID and MUX_TOKEN_SECRET detected. No `mux login` is necessary.',
+  "You can run commands directly without calling 'login'.",
+  '',
+  'If you also want a persistent login saved to the config,',
+  'then specify how to authenticate:',
+  '  Use `mux login --from-env` to save the shell env var credentials',
+  '  Use `mux login --env-file <path>` to use credentials from a specific env file',
+  '  Use `mux login --interactive` to manually enter credentials',
+  '  Use `mux login --oauth` to sign in with a browser',
+].join('\n');
+
+const NO_ENV_VARS_MESSAGE = [
+  '--from-env was passed, but MUX_TOKEN_ID and MUX_TOKEN_SECRET are not set in this shell.',
+  'Set both variables, or choose another method:',
+  '  `mux login --env-file <path>` to read credentials from a file',
+  '  `mux login --interactive` to enter them manually',
+  '  `mux login --oauth` to sign in with a browser',
+].join('\n');
+
+/** The flag that selects each mode, for error messages. */
+const MODE_FLAGS: Record<LoginMode, string> = {
+  oauth: '--oauth',
+  interactive: '--interactive',
+  'env-file': '--env-file',
+  'from-env': '--from-env',
+};
+
+/**
+ * Resolve the login mode, or throw a message explaining what to pass instead.
+ *
+ * `env` is injectable so this stays a pure function.
+ */
+export function resolveLoginMode(
+  options: LoginModeOptions,
+  env: Record<string, string | undefined> = process.env,
+): LoginMode {
+  const selected: LoginMode[] = [];
+  if (options.oauth) selected.push('oauth');
+  if (options.interactive) selected.push('interactive');
+  if (options.envFile) selected.push('env-file');
+  if (options.fromEnv) selected.push('from-env');
+
+  if (selected.length > 1) {
+    const flags = selected.map((mode) => MODE_FLAGS[mode]).join(', ');
+    throw new Error(
+      `Pass only one of --env-file, --from-env, --oauth, or --interactive (got ${flags}).`,
+    );
+  }
+
+  const hasEnvCredentials = Boolean(env.MUX_TOKEN_ID && env.MUX_TOKEN_SECRET);
+
+  if (selected.length === 1) {
+    const mode = selected[0];
+    if (mode === 'from-env' && !hasEnvCredentials) {
+      throw new Error(NO_ENV_VARS_MESSAGE);
+    }
+    return mode;
+  }
+
+  // No explicit mode. Shell credentials make the intent ambiguous — saving them
+  // is a different outcome from starting a browser login — so ask rather than
+  // pick. Without them, the browser flow is the default.
+  if (hasEnvCredentials) {
+    throw new Error(ENV_VARS_DETECTED_MESSAGE);
+  }
+
+  return 'oauth';
+}

--- a/src/commands/login.test.ts
+++ b/src/commands/login.test.ts
@@ -515,7 +515,7 @@ describe('Login command - action', () => {
     // nothing re-supplies baseUrl — it has to survive from the existing entry.
     await setEnvironment('default', {
       environmentId: 'env_mock_123',
-      baseUrl: 'https://mux-proxy.internal.example',
+      baseUrl: 'https://api.custom.example',
       token: { tokenId: 'old_id', tokenSecret: 'old_secret' },
     });
     process.env.MUX_TOKEN_ID = 'new_id';
@@ -524,7 +524,7 @@ describe('Login command - action', () => {
     await loginCommand.parse(['--from-env']);
 
     expect((await getEnvironment('default'))?.baseUrl).toBe(
-      'https://mux-proxy.internal.example',
+      'https://api.custom.example',
     );
   });
 

--- a/src/commands/login.test.ts
+++ b/src/commands/login.test.ts
@@ -17,7 +17,12 @@ import {
   setEnvironment,
 } from '../lib/config.ts';
 import { setAgentMode } from '../lib/context.ts';
-import { credentialsFromEnv, loginCommand, parseEnvFile } from './login.ts';
+import {
+  credentialsFromEnv,
+  formatAuthorizationNotice,
+  loginCommand,
+  parseEnvFile,
+} from './login.ts';
 
 describe('Login command - parseEnvFile', () => {
   let testDir: string;
@@ -304,6 +309,44 @@ describe('Login command - credentialsFromEnv', () => {
       if (originalSecret === undefined) delete process.env.MUX_TOKEN_SECRET;
       else process.env.MUX_TOKEN_SECRET = originalSecret;
     }
+  });
+});
+
+describe('formatAuthorizationNotice', () => {
+  const url =
+    'https://api.mux.com/ui/v1/oauth/authorize?response_type=code&state=abc';
+
+  it('shows the URL even when the browser reported success', () => {
+    // open/xdg-open exit 0 whether or not a window actually appeared, so the
+    // URL is the only reliable recovery path.
+    const lines = formatAuthorizationNotice(url, true);
+
+    expect(lines.join('\n')).toContain(url);
+    expect(lines.join('\n')).toContain('Opened your browser');
+    expect(lines.join('\n')).toMatch(/didn't open/);
+  });
+
+  it('asks the user to open the URL when no browser was launched', () => {
+    const lines = formatAuthorizationNotice(url, false);
+
+    expect(lines.join('\n')).toContain(url);
+    expect(lines.join('\n')).toContain('Open this URL');
+    expect(lines.join('\n')).not.toMatch(/didn't open/);
+  });
+
+  it('always ends by saying it is waiting, and how to cancel', () => {
+    for (const opened of [true, false]) {
+      const lines = formatAuthorizationNotice(url, opened);
+      expect(lines.at(-1)).toContain('Waiting for authorization');
+      expect(lines.at(-1)).toContain('Ctrl+C');
+    }
+  });
+
+  it('puts the URL on its own line so it can be copied cleanly', () => {
+    const lines = formatAuthorizationNotice(url, true);
+    const urlLine = lines.find((line) => line.includes(url)) as string;
+
+    expect(urlLine.trim()).toBe(url);
   });
 });
 

--- a/src/commands/login.test.ts
+++ b/src/commands/login.test.ts
@@ -12,8 +12,11 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
   type Environment,
+  getCurrentEnvironment,
   getEnvironment,
   listEnvironments,
+  readConfig,
+  setCurrentEnvironment,
   setEnvironment,
 } from '../lib/config.ts';
 import { setAgentMode } from '../lib/context.ts';
@@ -504,6 +507,68 @@ describe('Login command - action', () => {
     expect(exitSpy).toHaveBeenCalledWith(1);
     const parsed = JSON.parse(String(errorSpy.mock.calls[0][0]));
     expect(parsed.error).toBeDefined();
+  });
+
+  it('keeps the active environment active when re-logging into it', async () => {
+    // Regression: the entry used to be removed and recreated, and removing the
+    // current environment reassigns defaultEnvironment — so re-logging into the
+    // environment you were already using silently switched accounts.
+    await setEnvironment('default', {
+      token: { tokenId: 'old_id', tokenSecret: 'old_secret' },
+    });
+    await setEnvironment('other', {
+      token: { tokenId: 'o_id', tokenSecret: 'o_secret' },
+      environmentId: 'env_OTHER',
+    });
+    await setCurrentEnvironment('default');
+    process.env.MUX_TOKEN_ID = 'new_id';
+    process.env.MUX_TOKEN_SECRET = 'new_secret';
+
+    await loginCommand.parse(['--from-env']);
+
+    expect((await getCurrentEnvironment())?.name).toBe('default');
+  });
+
+  it('keeps the selection when the entry has no environmentId to compare', async () => {
+    // An entry written by an older version has no environmentId, so it can never
+    // match — the path most users would have hit.
+    await setEnvironment('default', {
+      token: { tokenId: 'old_id', tokenSecret: 'old_secret' },
+    });
+    await setEnvironment('second', {
+      token: { tokenId: 's_id', tokenSecret: 's_secret' },
+    });
+    await setCurrentEnvironment('default');
+    process.env.MUX_TOKEN_ID = 'new_id';
+    process.env.MUX_TOKEN_SECRET = 'new_secret';
+
+    await loginCommand.parse(['--from-env']);
+
+    const config = await readConfig();
+    expect(config?.defaultEnvironment).toBe('default');
+    expect(Object.keys(config?.environments ?? {}).sort()).toEqual([
+      'default',
+      'second',
+    ]);
+  });
+
+  it('keeps a browser sign-in for the same environment when saving a token pair', async () => {
+    await setEnvironment('default', {
+      environmentId: 'env_mock_123',
+      oauth: {
+        accessToken: 'access_1',
+        refreshToken: 'refresh_1',
+        expiresAt: 4_102_444_800,
+      },
+    });
+    process.env.MUX_TOKEN_ID = 'new_id';
+    process.env.MUX_TOKEN_SECRET = 'new_secret';
+
+    await loginCommand.parse(['--from-env']);
+
+    const saved = await getEnvironment('default');
+    expect(saved?.oauth?.accessToken).toBe('access_1');
+    expect(saved?.token?.tokenId).toBe('new_id');
   });
 
   it('refuses to guess when shell credentials are set, and says why', async () => {

--- a/src/commands/login.test.ts
+++ b/src/commands/login.test.ts
@@ -10,7 +10,12 @@ import {
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { getEnvironment, setEnvironment } from '../lib/config.ts';
+import {
+  type Environment,
+  getEnvironment,
+  listEnvironments,
+  setEnvironment,
+} from '../lib/config.ts';
 import { setAgentMode } from '../lib/context.ts';
 import { credentialsFromEnv, loginCommand, parseEnvFile } from './login.ts';
 
@@ -363,11 +368,11 @@ describe('Login command - action', () => {
     process.env.MUX_TOKEN_ID = 'env_id';
     process.env.MUX_TOKEN_SECRET = 'env_secret';
 
-    await loginCommand.parse([]);
+    await loginCommand.parse(['--from-env']);
 
-    const saved = await getEnvironment('default');
-    expect(saved?.tokenId).toBe('env_id');
-    expect(saved?.tokenSecret).toBe('env_secret');
+    const saved = (await getEnvironment('default')) as Environment | null;
+    expect(saved?.token?.tokenId).toBe('env_id');
+    expect(saved?.token?.tokenSecret).toBe('env_secret');
   });
 
   it('prefers --env-file over environment variables', async () => {
@@ -381,16 +386,16 @@ describe('Login command - action', () => {
 
     await loginCommand.parse(['--env-file', envPath]);
 
-    const saved = await getEnvironment('default');
-    expect(saved?.tokenId).toBe('file_id');
-    expect(saved?.tokenSecret).toBe('file_secret');
+    const saved = (await getEnvironment('default')) as Environment | null;
+    expect(saved?.token?.tokenId).toBe('file_id');
+    expect(saved?.token?.tokenSecret).toBe('file_secret');
   });
 
   it('outputs machine-readable JSON with --json', async () => {
     process.env.MUX_TOKEN_ID = 'env_id';
     process.env.MUX_TOKEN_SECRET = 'env_secret';
 
-    await loginCommand.parse(['--json']);
+    await loginCommand.parse(['--json', '--from-env']);
 
     const output = logSpy.mock.calls.map((c) => String(c[0])).join('\n');
     const parsed = JSON.parse(output);
@@ -404,7 +409,7 @@ describe('Login command - action', () => {
     process.env.MUX_TOKEN_SECRET = 'env_secret';
     setAgentMode(true);
 
-    await loginCommand.parse([]);
+    await loginCommand.parse(['--from-env']);
 
     const output = logSpy.mock.calls.map((c) => String(c[0])).join('\n');
     expect(JSON.parse(output).success).toBe(true);
@@ -448,7 +453,7 @@ describe('Login command - action', () => {
     );
 
     try {
-      await loginCommand.parse([]);
+      await loginCommand.parse(['--from-env']);
     } catch (_error) {
       // handleCommandError exits; the mocked process.exit throws to halt parse
     }
@@ -456,6 +461,96 @@ describe('Login command - action', () => {
     expect(exitSpy).toHaveBeenCalledWith(1);
     const parsed = JSON.parse(String(errorSpy.mock.calls[0][0]));
     expect(parsed.error).toBeDefined();
+  });
+
+  it('refuses to guess when shell credentials are set, and says why', async () => {
+    process.env.MUX_TOKEN_ID = 'env_id';
+    process.env.MUX_TOKEN_SECRET = 'env_secret';
+
+    try {
+      await loginCommand.parse([]);
+    } catch (_error) {
+      // handleCommandError exits; the mocked process.exit throws to halt parse
+    }
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const message = String(errorSpy.mock.calls[0][0]);
+    expect(message).toContain('MUX_TOKEN_ID and MUX_TOKEN_SECRET detected');
+    expect(message).toContain('--from-env');
+    expect(message).toContain('--env-file');
+    expect(message).toContain('--interactive');
+    expect(message).toContain('--oauth');
+  });
+
+  it('writes nothing to the config when it refuses to guess', async () => {
+    process.env.MUX_TOKEN_ID = 'env_id';
+    process.env.MUX_TOKEN_SECRET = 'env_secret';
+
+    try {
+      await loginCommand.parse([]);
+    } catch (_error) {
+      // handleCommandError exits
+    }
+
+    expect(await listEnvironments()).toEqual([]);
+  });
+
+  it('rejects two login methods at once', async () => {
+    try {
+      await loginCommand.parse(['--oauth', '--interactive']);
+    } catch (_error) {
+      // handleCommandError exits
+    }
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(String(errorSpy.mock.calls[0][0])).toMatch(/only one/i);
+  });
+
+  it('rejects --from-env when the shell has no credentials', async () => {
+    try {
+      await loginCommand.parse(['--from-env']);
+    } catch (_error) {
+      // handleCommandError exits
+    }
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(String(errorSpy.mock.calls[0][0])).toMatch(
+      /MUX_TOKEN_ID and MUX_TOKEN_SECRET are not set/,
+    );
+  });
+
+  it('warns that a login saved with shell credentials set is shadowed', async () => {
+    process.env.MUX_TOKEN_ID = 'env_id';
+    process.env.MUX_TOKEN_SECRET = 'env_secret';
+
+    await loginCommand.parse(['--from-env']);
+
+    const printed = logSpy.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(printed).toContain('take precedence over the saved login');
+    expect(printed).toMatch(/Unset them/);
+  });
+
+  it('refuses browser sign-in with no terminal to drive it', async () => {
+    // Tests run without a TTY, which is exactly the CI / piped-stdin case.
+    try {
+      await loginCommand.parse(['--oauth']);
+    } catch (_error) {
+      // handleCommandError exits
+    }
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(String(errorSpy.mock.calls[0][0])).toMatch(/interactive terminal/i);
+  });
+
+  it('refuses --interactive with no terminal to prompt on', async () => {
+    try {
+      await loginCommand.parse(['--interactive']);
+    } catch (_error) {
+      // handleCommandError exits
+    }
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(String(errorSpy.mock.calls[0][0])).toMatch(/interactive terminal/i);
   });
 
   it('keeps human-readable errors when not in JSON or agent mode', async () => {
@@ -477,10 +572,10 @@ describe('Login command - action', () => {
     process.env.MUX_TOKEN_ID = 'env_id';
     process.env.MUX_TOKEN_SECRET = 'env_secret';
 
-    await loginCommand.parse(['--name', 'staging']);
+    await loginCommand.parse(['--name', 'staging', '--from-env']);
 
-    const saved = await getEnvironment('staging');
-    expect(saved?.tokenId).toBe('env_id');
+    const saved = (await getEnvironment('staging')) as Environment | null;
+    expect(saved?.token?.tokenId).toBe('env_id');
   });
 
   it('saves signing keys from the env file when both are present', async () => {
@@ -492,7 +587,7 @@ describe('Login command - action', () => {
 
     await loginCommand.parse(['--env-file', envPath]);
 
-    const saved = await getEnvironment('default');
+    const saved = (await getEnvironment('default')) as Environment | null;
     expect(saved?.signingKeyId).toBe('key_abc');
     expect(saved?.signingPrivateKey).toBe('private_base64');
   });
@@ -513,7 +608,7 @@ describe('Login command - action', () => {
       else process.env.MUX_BASE_URL = originalBaseUrl;
     }
 
-    const saved = await getEnvironment('default');
+    const saved = (await getEnvironment('default')) as Environment | null;
     expect(saved?.baseUrl).toBe('https://file.example.com');
     const validationUrl = String(fetchSpy.mock.calls[0][0]);
     expect(validationUrl.startsWith('https://file.example.com')).toBe(true);
@@ -535,7 +630,7 @@ describe('Login command - action', () => {
       else process.env.MUX_BASE_URL = originalBaseUrl;
     }
 
-    const saved = await getEnvironment('default');
+    const saved = (await getEnvironment('default')) as Environment | null;
     expect(saved?.baseUrl).toBe('https://shell.example.com');
   });
 
@@ -546,13 +641,13 @@ describe('Login command - action', () => {
     process.env.MUX_PRIVATE_KEY = 'private_env';
 
     try {
-      await loginCommand.parse([]);
+      await loginCommand.parse(['--from-env']);
     } finally {
       delete process.env.MUX_SIGNING_KEY;
       delete process.env.MUX_PRIVATE_KEY;
     }
 
-    const saved = await getEnvironment('default');
+    const saved = (await getEnvironment('default')) as Environment | null;
     expect(saved?.signingKeyId).toBe('key_env');
     expect(saved?.signingPrivateKey).toBe('private_env');
   });
@@ -561,8 +656,7 @@ describe('Login command - action', () => {
     // The mocked /whoami returns env_mock_123, so this entry matches the
     // environment the new credentials belong to.
     await setEnvironment('default', {
-      tokenId: 'old_id',
-      tokenSecret: 'old_secret',
+      token: { tokenId: 'old_id', tokenSecret: 'old_secret' },
       environmentId: 'env_mock_123',
       signingKeyId: 'key_saved',
       signingPrivateKey: 'private_saved',
@@ -571,10 +665,10 @@ describe('Login command - action', () => {
     process.env.MUX_TOKEN_ID = 'new_id';
     process.env.MUX_TOKEN_SECRET = 'new_secret';
 
-    await loginCommand.parse([]);
+    await loginCommand.parse(['--from-env']);
 
-    const saved = await getEnvironment('default');
-    expect(saved?.tokenId).toBe('new_id');
+    const saved = (await getEnvironment('default')) as Environment | null;
+    expect(saved?.token?.tokenId).toBe('new_id');
     expect(saved?.signingKeyId).toBe('key_saved');
     expect(saved?.signingPrivateKey).toBe('private_saved');
     expect(saved?.forwardUrl).toBe('http://localhost:3000/webhooks');
@@ -582,8 +676,7 @@ describe('Login command - action', () => {
 
   it('does not carry signing keys over when the new credentials belong to a different environment', async () => {
     await setEnvironment('default', {
-      tokenId: 'old_id',
-      tokenSecret: 'old_secret',
+      token: { tokenId: 'old_id', tokenSecret: 'old_secret' },
       environmentId: 'env_different_999',
       signingKeyId: 'key_saved',
       signingPrivateKey: 'private_saved',
@@ -592,10 +685,10 @@ describe('Login command - action', () => {
     process.env.MUX_TOKEN_ID = 'new_id';
     process.env.MUX_TOKEN_SECRET = 'new_secret';
 
-    await loginCommand.parse([]);
+    await loginCommand.parse(['--from-env']);
 
-    const saved = await getEnvironment('default');
-    expect(saved?.tokenId).toBe('new_id');
+    const saved = (await getEnvironment('default')) as Environment | null;
+    expect(saved?.token?.tokenId).toBe('new_id');
     expect(saved?.signingKeyId).toBeUndefined();
     expect(saved?.signingPrivateKey).toBeUndefined();
     expect(saved?.forwardUrl).toBeUndefined();
@@ -603,24 +696,22 @@ describe('Login command - action', () => {
 
   it('does not preserve fields from a legacy entry with no environmentId', async () => {
     await setEnvironment('default', {
-      tokenId: 'old_id',
-      tokenSecret: 'old_secret',
+      token: { tokenId: 'old_id', tokenSecret: 'old_secret' },
       signingKeyId: 'key_saved',
       signingPrivateKey: 'private_saved',
     });
     process.env.MUX_TOKEN_ID = 'new_id';
     process.env.MUX_TOKEN_SECRET = 'new_secret';
 
-    await loginCommand.parse([]);
+    await loginCommand.parse(['--from-env']);
 
-    const saved = await getEnvironment('default');
+    const saved = (await getEnvironment('default')) as Environment | null;
     expect(saved?.signingKeyId).toBeUndefined();
   });
 
   it('prefers newly provided signing keys over preserved ones', async () => {
     await setEnvironment('default', {
-      tokenId: 'old_id',
-      tokenSecret: 'old_secret',
+      token: { tokenId: 'old_id', tokenSecret: 'old_secret' },
       environmentId: 'env_mock_123',
       signingKeyId: 'key_saved',
       signingPrivateKey: 'private_saved',
@@ -633,7 +724,7 @@ describe('Login command - action', () => {
 
     await loginCommand.parse(['--env-file', envPath]);
 
-    const saved = await getEnvironment('default');
+    const saved = (await getEnvironment('default')) as Environment | null;
     expect(saved?.signingKeyId).toBe('key_new');
     expect(saved?.signingPrivateKey).toBe('private_new');
   });
@@ -647,7 +738,7 @@ describe('Login command - action', () => {
 
     await loginCommand.parse(['--env-file', envPath]);
 
-    const saved = await getEnvironment('default');
+    const saved = (await getEnvironment('default')) as Environment | null;
     expect(saved?.signingKeyId).toBeUndefined();
     expect(saved?.signingPrivateKey).toBeUndefined();
   });

--- a/src/commands/login.test.ts
+++ b/src/commands/login.test.ts
@@ -20,11 +20,14 @@ import {
   setEnvironment,
 } from '../lib/config.ts';
 import { setAgentMode } from '../lib/context.ts';
+import type { OAuthTokens } from '../lib/oauth.ts';
+import type { OAuthLoginDeps } from '../lib/oauth-login.ts';
 import {
   credentialsFromEnv,
   formatAuthorizationNotice,
   loginCommand,
   parseEnvFile,
+  runOAuthLogin,
 } from './login.ts';
 
 describe('Login command - parseEnvFile', () => {
@@ -353,6 +356,187 @@ describe('formatAuthorizationNotice', () => {
   });
 });
 
+describe('runOAuthLogin in machine-readable mode', () => {
+  let testConfigDir: string;
+  let originalXdgConfigHome: string | undefined;
+  let logSpy: Mock<typeof console.log>;
+  let errorSpy: Mock<typeof console.error>;
+
+  const TOKENS: OAuthTokens = {
+    accessToken: 'access_1',
+    refreshToken: 'refresh_1',
+    expiresAt: Math.floor(Date.now() / 1000) + 3600,
+    tokenType: 'Bearer',
+  };
+
+  /** Every external step stubbed, mirroring oauth-login.test.ts. */
+  function fakeDeps(overrides: Partial<OAuthLoginDeps> = {}): OAuthLoginDeps {
+    return {
+      startServer: async () => ({
+        port: 51372,
+        redirectUri: 'http://127.0.0.1:51372/callback',
+        waitForCode: async () => 'auth_code',
+        stop: () => {},
+      }),
+      openBrowser: async () => true,
+      endpoints: {
+        clientId: 'test_client',
+        authorizationUrl: 'https://dash.test/oauth/authorize',
+        tokenUrl: 'https://api.test/oauth/token',
+        revocationUrl: 'https://api.test/oauth/revoke',
+        scopes: ['video:read', 'system:read'],
+      },
+      exchange: async () => TOKENS,
+      validate: async () => ({
+        valid: true as const,
+        identity: {
+          environmentId: 'env_123',
+          environmentName: 'Production',
+          organizationId: 'org_123',
+          organizationName: 'Acme Inc',
+          permissions: ['video'],
+        },
+      }),
+      ...overrides,
+    };
+  }
+
+  beforeEach(async () => {
+    testConfigDir = await mkdtemp(join(tmpdir(), 'mux-cli-agent-oauth-'));
+    originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
+    process.env.XDG_CONFIG_HOME = testConfigDir;
+    logSpy = spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    if (originalXdgConfigHome === undefined) {
+      delete process.env.XDG_CONFIG_HOME;
+    } else {
+      process.env.XDG_CONFIG_HOME = originalXdgConfigHome;
+    }
+    logSpy?.mockRestore();
+    errorSpy?.mockRestore();
+    setAgentMode(false);
+    await rm(testConfigDir, { recursive: true, force: true });
+  });
+
+  it('completes without a TTY in agent mode and prints exactly one JSON document on stdout', async () => {
+    // Tests run without a TTY, which is exactly the coding-agent case.
+    setAgentMode(true);
+
+    await runOAuthLogin({}, fakeDeps());
+
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    const result = JSON.parse(String(logSpy.mock.calls[0][0]));
+    expect(result.name).toBe('acme-inc-production');
+    expect(result.identity.environmentId).toBe('env_123');
+    expect(result.activated).toBe(true);
+    expect(result.replacedExisting).toBe(false);
+  });
+
+  it('emits the authorization_url event on stderr before waiting for the redirect', async () => {
+    setAgentMode(true);
+    let eventsWhenWaitStarted = -1;
+
+    await runOAuthLogin(
+      {},
+      fakeDeps({
+        startServer: async () => ({
+          port: 51372,
+          redirectUri: 'http://127.0.0.1:51372/callback',
+          waitForCode: async () => {
+            eventsWhenWaitStarted = errorSpy.mock.calls.length;
+            return 'auth_code';
+          },
+          stop: () => {},
+        }),
+      }),
+    );
+
+    // The agent can only relay the URL if it is out before the flow blocks.
+    expect(eventsWhenWaitStarted).toBeGreaterThanOrEqual(1);
+    const event = JSON.parse(String(errorSpy.mock.calls[0][0]));
+    expect(event.event).toBe('authorization_url');
+    expect(event.url).toContain('code_challenge');
+    expect(event.browserOpened).toBe(true);
+    expect(event.expiresInSeconds).toBe(300);
+  });
+
+  it('honors --json outside agent mode with the same contract', async () => {
+    await runOAuthLogin({ json: true }, fakeDeps());
+
+    const event = JSON.parse(String(errorSpy.mock.calls[0][0]));
+    expect(event.event).toBe('authorization_url');
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(String(logSpy.mock.calls[0][0])).name).toBe(
+      'acme-inc-production',
+    );
+  });
+
+  it('still attempts to open a browser in agent mode', async () => {
+    // Agents typically run on the user's machine, so the browser opening
+    // directly is the best UX; the URL is emitted regardless.
+    setAgentMode(true);
+    let opened = false;
+
+    await runOAuthLogin(
+      {},
+      fakeDeps({
+        openBrowser: async () => {
+          opened = true;
+          return true;
+        },
+      }),
+    );
+
+    expect(opened).toBe(true);
+  });
+
+  it('passes --timeout through to the loopback server and reports it in the event', async () => {
+    setAgentMode(true);
+    let requestedTimeoutMs: number | undefined;
+
+    await runOAuthLogin(
+      { timeout: 600 },
+      fakeDeps({
+        startServer: async (options) => {
+          requestedTimeoutMs = options.timeoutMs;
+          return {
+            port: 51372,
+            redirectUri: 'http://127.0.0.1:51372/callback',
+            waitForCode: async () => 'auth_code',
+            stop: () => {},
+          };
+        },
+      }),
+    );
+
+    expect(requestedTimeoutMs).toBe(600_000);
+    const event = JSON.parse(String(errorSpy.mock.calls[0][0]));
+    expect(event.expiresInSeconds).toBe(600);
+  });
+
+  it('rejects a non-positive --timeout', async () => {
+    setAgentMode(true);
+
+    await expect(runOAuthLogin({ timeout: 0 }, fakeDeps())).rejects.toThrow(
+      /--timeout/,
+    );
+    await expect(runOAuthLogin({ timeout: -5 }, fakeDeps())).rejects.toThrow(
+      /--timeout/,
+    );
+  });
+
+  it('still refuses the pretty flow without a terminal', async () => {
+    // Neither --json nor agent mode: a bare `mux login` in a pipe or CI runner
+    // must keep failing fast rather than blocking on a redirect.
+    await expect(runOAuthLogin({}, fakeDeps())).rejects.toThrow(
+      /interactive terminal/i,
+    );
+  });
+});
+
 describe('Login command - action', () => {
   let testConfigDir: string;
   let originalXdgConfigHome: string | undefined;
@@ -461,9 +645,9 @@ describe('Login command - action', () => {
     expect(JSON.parse(output).success).toBe(true);
   });
 
-  it('fails fast with a JSON error on --json when no credentials are available', async () => {
+  it('fails fast with a JSON error on --json --interactive, and points at the alternatives', async () => {
     try {
-      await loginCommand.parse(['--json']);
+      await loginCommand.parse(['--json', '--interactive']);
     } catch (_error) {
       // handleCommandError exits; the mocked process.exit throws to halt parse
     }
@@ -471,21 +655,71 @@ describe('Login command - action', () => {
     expect(exitSpy).toHaveBeenCalledWith(1);
     const parsed = JSON.parse(String(errorSpy.mock.calls[0][0]));
     expect(parsed.error).toMatch(/MUX_TOKEN_ID and MUX_TOKEN_SECRET/);
+    // The browser flow works in machine-readable mode now, so the error must
+    // not steer callers away from it.
+    expect(parsed.error).toMatch(/--oauth/);
+    expect(parsed.error).not.toMatch(/Interactive login is not available/);
   });
 
-  it('fails fast with a JSON error in agent mode instead of prompting when no credentials are available', async () => {
+  it('fails fast with a JSON error on --interactive in agent mode instead of prompting', async () => {
     setAgentMode(true);
 
     try {
-      await loginCommand.parse([]);
+      await loginCommand.parse(['--interactive']);
     } catch (_error) {
       // handleCommandError exits; the mocked process.exit throws to halt parse
     }
 
     expect(exitSpy).toHaveBeenCalledWith(1);
     const parsed = JSON.parse(String(errorSpy.mock.calls[0][0]));
-    expect(parsed.error).toMatch(/Interactive login is not available/);
+    expect(parsed.error).toMatch(/MUX_TOKEN_ID and MUX_TOKEN_SECRET/);
+    expect(parsed.error).toMatch(/--oauth/);
   });
+
+  it('runs the browser flow end to end in agent mode and surfaces a timeout as a JSON error', async () => {
+    // Integration: real loopback server, real timeout. Discovery goes through
+    // the mocked fetch and falls back to built-in endpoints; --print-url keeps
+    // the test from opening a real browser.
+    setAgentMode(true);
+    const originalXdgCacheHome = process.env.XDG_CACHE_HOME;
+    process.env.XDG_CACHE_HOME = testConfigDir;
+
+    try {
+      await loginCommand.parse(['--print-url', '--timeout', '1']);
+    } catch (_error) {
+      // handleCommandError exits; the mocked process.exit throws to halt parse
+    } finally {
+      if (originalXdgCacheHome === undefined) delete process.env.XDG_CACHE_HOME;
+      else process.env.XDG_CACHE_HOME = originalXdgCacheHome;
+    }
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const lines = errorSpy.mock.calls.map((c) => String(c[0]));
+    const event = lines
+      .map((line) => {
+        try {
+          return JSON.parse(line);
+        } catch {
+          return null;
+        }
+      })
+      .find((parsed) => parsed?.event === 'authorization_url');
+    expect(event).toBeDefined();
+    expect(event.url).toContain('code_challenge');
+    expect(event.browserOpened).toBe(false);
+    expect(event.expiresInSeconds).toBe(1);
+
+    const failure = lines
+      .map((line) => {
+        try {
+          return JSON.parse(line);
+        } catch {
+          return null;
+        }
+      })
+      .find((parsed) => typeof parsed?.error === 'string');
+    expect(failure?.error).toMatch(/timed out/i);
+  }, 15_000);
 
   it('reports credential validation failures as JSON in agent mode', async () => {
     process.env.MUX_TOKEN_ID = 'bad_id';

--- a/src/commands/login.test.ts
+++ b/src/commands/login.test.ts
@@ -509,6 +509,46 @@ describe('Login command - action', () => {
     expect(parsed.error).toBeDefined();
   });
 
+  it('keeps a stored custom API host when re-logging into the same environment', async () => {
+    // The whole entry is rewritten on save, so a field missing from the carried
+    // list is silently lost. Here the login resolves to the default host, so
+    // nothing re-supplies baseUrl — it has to survive from the existing entry.
+    await setEnvironment('default', {
+      environmentId: 'env_mock_123',
+      baseUrl: 'https://mux-proxy.internal.example',
+      token: { tokenId: 'old_id', tokenSecret: 'old_secret' },
+    });
+    process.env.MUX_TOKEN_ID = 'new_id';
+    process.env.MUX_TOKEN_SECRET = 'new_secret';
+
+    await loginCommand.parse(['--from-env']);
+
+    expect((await getEnvironment('default'))?.baseUrl).toBe(
+      'https://mux-proxy.internal.example',
+    );
+  });
+
+  it('lets an explicit host override the stored one', async () => {
+    await setEnvironment('default', {
+      environmentId: 'env_mock_123',
+      baseUrl: 'https://old-host.example',
+      token: { tokenId: 'old_id', tokenSecret: 'old_secret' },
+    });
+    process.env.MUX_TOKEN_ID = 'new_id';
+    process.env.MUX_TOKEN_SECRET = 'new_secret';
+    process.env.MUX_BASE_URL = 'https://new-host.example';
+
+    try {
+      await loginCommand.parse(['--from-env']);
+
+      expect((await getEnvironment('default'))?.baseUrl).toBe(
+        'https://new-host.example',
+      );
+    } finally {
+      delete process.env.MUX_BASE_URL;
+    }
+  });
+
   it('keeps the active environment active when re-logging into it', async () => {
     // Regression: the entry used to be removed and recreated, and removing the
     // current environment reassigns defaultEnvironment — so re-logging into the

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -4,8 +4,7 @@ import { Command } from '@cliffy/command';
 import {
   getEnvironment,
   listEnvironments,
-  removeEnvironment,
-  setCredential,
+  setEnvironment,
 } from '../lib/config.ts';
 import { wantsJson } from '../lib/context.ts';
 import { handleCommandError } from '../lib/errors.ts';
@@ -203,6 +202,16 @@ async function runOAuthLogin(options: {
   const id = identity.environmentId ? ` (${identity.environmentId})` : '';
   console.log(`\n✅ Signed in to ${org} / ${env}${id}`);
 
+  // Losing a signing key or an access token pair must never be silent, and an
+  // access token secret cannot be recovered from the dashboard after creation.
+  if (result.dropped.length > 0) {
+    console.log(
+      `\n⚠️  "${result.name}" previously held a different Mux environment, so its ${result.dropped.join(
+        ', ',
+      )} ${result.dropped.length === 1 ? 'was' : 'were'} discarded.`,
+    );
+  }
+
   const verb = result.replacedExisting ? 'Updated' : 'Saved as';
   if (result.activated) {
     console.log(
@@ -386,22 +395,42 @@ export const loginCommand = new Command()
         existing?.environmentId &&
         existing.environmentId === validation.environmentId;
 
-      if (existing && !sameEnvironment) {
-        // Entry is being repointed at another environment: clear it first so no
-        // stale signing keys, forward URL, or OAuth login survive.
-        await removeEnvironment(envName);
-      }
+      // Written as one whole entry rather than removing and recreating. Removing
+      // an entry reassigns `defaultEnvironment` when it happens to be the active
+      // one, so re-logging into the environment you were already using would
+      // silently switch you to a different account — and any entry without an
+      // `environmentId`, which includes older configs, took that path.
+      const preserved =
+        existing && sameEnvironment
+          ? {
+              ...(existing.environmentName && {
+                environmentName: existing.environmentName,
+              }),
+              ...(existing.organizationId && {
+                organizationId: existing.organizationId,
+              }),
+              ...(existing.organizationName && {
+                organizationName: existing.organizationName,
+              }),
+              ...(existing.signingKeyId && {
+                signingKeyId: existing.signingKeyId,
+              }),
+              ...(existing.signingPrivateKey && {
+                signingPrivateKey: existing.signingPrivateKey,
+              }),
+              ...(existing.forwardUrl && { forwardUrl: existing.forwardUrl }),
+              // A browser sign-in for this same environment stays usable.
+              ...(existing.oauth && { oauth: existing.oauth }),
+            }
+          : {};
 
-      await setCredential(
-        envName,
-        'token',
-        { tokenId: tokenId.trim(), tokenSecret: tokenSecret.trim() },
-        {
-          environmentId: validation.environmentId,
-          ...(baseUrl !== DEFAULT_BASE_URL && { baseUrl }),
-          ...signingKeys,
-        },
-      );
+      await setEnvironment(envName, {
+        ...preserved,
+        environmentId: validation.environmentId,
+        ...(baseUrl !== DEFAULT_BASE_URL && { baseUrl }),
+        ...signingKeys,
+        token: { tokenId: tokenId.trim(), tokenSecret: tokenSecret.trim() },
+      });
 
       if (json) {
         console.log(

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -14,7 +14,8 @@ import {
   getMuxBaseUrl,
   validateCredentials,
 } from '../lib/mux.ts';
-import { performOAuthLogin } from '../lib/oauth-login.ts';
+import { type OAuthLoginDeps, performOAuthLogin } from '../lib/oauth-login.ts';
+import { DEFAULT_TIMEOUT_MS } from '../lib/oauth-loopback.ts';
 import { inputPrompt, secretPrompt } from '../lib/prompt.ts';
 import { getConfigPath } from '../lib/xdg.ts';
 import { resolveLoginMode } from './login-mode.ts';
@@ -159,40 +160,91 @@ export function formatAuthorizationNotice(
  * Run the browser-based OAuth login and report the result. Organization and
  * environment selection happens in the dashboard, so the CLI only reports what
  * came back.
+ *
+ * Works without a terminal when the caller declared machine-readable intent
+ * (--json or agent mode): the flow itself never reads stdin, and the loopback
+ * timeout bounds the wait. `deps` is injectable for tests only; the command
+ * action always uses the real flow.
  */
-async function runOAuthLogin(options: {
-  name?: string;
-  port?: number;
-  printUrl?: boolean;
-  keepCurrent?: boolean;
-  json?: boolean;
-}): Promise<void> {
+export async function runOAuthLogin(
+  options: {
+    name?: string;
+    port?: number;
+    printUrl?: boolean;
+    keepCurrent?: boolean;
+    timeout?: number;
+    json?: boolean;
+  },
+  deps: OAuthLoginDeps = {},
+): Promise<void> {
   const json = wantsJson(options);
 
-  // Interactive by definition: there is no browser to drive and no terminal to
-  // print an authorization URL to in machine-readable mode.
-  if (json) {
-    throw new Error(
-      "Interactive login is not available with --json or in agent mode. Set MUX_TOKEN_ID and MUX_TOKEN_SECRET, run 'mux login --env-file <path>', or run 'mux login' in an interactive terminal.",
-    );
+  // Machine-readable callers relay the authorization URL themselves, so only
+  // the default pretty flow insists on a terminal: a bare `mux login` in a
+  // pipe or CI runner still fails fast instead of hanging on a redirect.
+  if (!json) {
+    requireInteractiveTerminal('Browser sign-in');
   }
-  requireInteractiveTerminal('Browser sign-in');
+
+  if (
+    options.timeout !== undefined &&
+    (!Number.isFinite(options.timeout) || options.timeout <= 0)
+  ) {
+    throw new Error('--timeout must be a positive number of seconds.');
+  }
+  const timeoutMs =
+    options.timeout !== undefined ? options.timeout * 1000 : undefined;
 
   const result = await performOAuthLogin(
     {
       ...(options.name && { name: options.name }),
       ...(options.port !== undefined && { port: options.port }),
+      ...(timeoutMs !== undefined && { timeoutMs }),
       noBrowser: options.printUrl === true,
       activate: options.keepCurrent !== true,
     },
     {
+      ...deps,
       onAuthorizationUrl: (url, opened) => {
+        if (json) {
+          // Progress goes to stderr as a JSON line so stdout stays a single
+          // parseable document. Emitted the moment the URL is known, so a
+          // caller polling the stream can relay it before the flow blocks.
+          console.error(
+            JSON.stringify({
+              event: 'authorization_url',
+              url,
+              browserOpened: opened,
+              expiresInSeconds: Math.round(
+                (timeoutMs ?? DEFAULT_TIMEOUT_MS) / 1000,
+              ),
+            }),
+          );
+          return;
+        }
         for (const line of formatAuthorizationNotice(url, opened)) {
           console.log(line);
         }
       },
     },
   );
+
+  if (json) {
+    console.log(
+      JSON.stringify(
+        {
+          name: result.name,
+          identity: result.identity,
+          activated: result.activated,
+          replacedExisting: result.replacedExisting,
+          dropped: result.dropped,
+        },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
 
   const { identity } = result;
   const org = identity.organizationName ?? identity.organizationId ?? 'unknown';
@@ -229,7 +281,9 @@ async function runOAuthLogin(options: {
 // chained options without leaking an internal module path into the .d.ts.
 export const loginCommand = new Command()
   .description(
-    'Sign in to Mux. Opens your browser to select an organization and environment; use --interactive, --env-file, or --from-env for a Mux API access token instead.',
+    'Sign in to Mux. Opens your browser to select an organization and environment; use --interactive, --env-file, or --from-env for a Mux API access token instead. ' +
+      'With --json or in agent mode, the authorization URL is emitted as a JSON event on stderr and the result as JSON on stdout. ' +
+      'The browser must be able to reach this machine to complete the sign-in (see --port for SSH port forwarding).',
   )
   .option(
     '-f, --env-file <path:string>',
@@ -256,6 +310,10 @@ export const loginCommand = new Command()
     'Print the authorization URL instead of opening a browser',
   )
   .option('--port <port:number>', 'Local port to receive the login redirect on')
+  .option(
+    '--timeout <seconds:number>',
+    'How long to wait for the browser authorization before giving up (default: 300)',
+  )
   .option(
     '--keep-current',
     'Save the login without making it the active environment',
@@ -350,7 +408,7 @@ export const loginCommand = new Command()
         // instead of blocking on stdin.
         if (json) {
           throw new Error(
-            'No credentials provided. Set MUX_TOKEN_ID and MUX_TOKEN_SECRET environment variables, or pass --env-file <path>. Interactive login is not available with --json or in agent mode.',
+            'Manual credential entry needs a terminal to prompt on. Set MUX_TOKEN_ID and MUX_TOKEN_SECRET environment variables, pass --env-file <path>, or run `mux login --oauth` to sign in with a browser.',
           );
         }
         requireInteractiveTerminal('--interactive');

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -4,7 +4,8 @@ import { Command } from '@cliffy/command';
 import {
   getEnvironment,
   listEnvironments,
-  setEnvironment,
+  removeEnvironment,
+  setCredential,
 } from '../lib/config.ts';
 import { wantsJson } from '../lib/context.ts';
 import { handleCommandError } from '../lib/errors.ts';
@@ -13,8 +14,10 @@ import {
   getMuxBaseUrl,
   validateCredentials,
 } from '../lib/mux.ts';
+import { performOAuthLogin } from '../lib/oauth-login.ts';
 import { inputPrompt, secretPrompt } from '../lib/prompt.ts';
 import { getConfigPath } from '../lib/xdg.ts';
+import { resolveLoginMode } from './login-mode.ts';
 
 export interface EnvVars {
   MUX_TOKEN_ID?: string;
@@ -98,22 +101,145 @@ export function credentialsFromEnv(
   };
 }
 
+/**
+ * Both interactive login methods need a real terminal: one to prompt on, one to
+ * print an authorization URL to and wait. Fail fast rather than hanging on a
+ * pipe or a CI runner.
+ */
+function requireInteractiveTerminal(flag: string): void {
+  if (process.stdin.isTTY) return;
+
+  throw new Error(
+    `${flag} needs an interactive terminal, and this shell is not one. ` +
+      'Use `mux login --env-file <path>`, or set MUX_TOKEN_ID and MUX_TOKEN_SECRET and run `mux login --from-env`.',
+  );
+}
+
+/**
+ * Notice printed after a successful login when shell credentials are set. The
+ * saved login has no effect until they are unset, and silently saving something
+ * inert is exactly the confusion this is meant to prevent.
+ */
+function noticeSavedLoginIsShadowed(json: boolean): void {
+  if (json || !credentialsFromEnv()) return;
+
+  console.log(
+    '\nSaved. Note: MUX_TOKEN_ID/MUX_TOKEN_SECRET are set in this shell and take precedence over the saved login. Unset them to use this login.',
+  );
+}
+
+/**
+ * Run the browser-based OAuth login and report the result. Organization and
+ * environment selection happens in the dashboard, so the CLI only reports what
+ * came back.
+ */
+async function runOAuthLogin(options: {
+  name?: string;
+  port?: number;
+  printUrl?: boolean;
+  keepCurrent?: boolean;
+  json?: boolean;
+}): Promise<void> {
+  const json = wantsJson(options);
+
+  // Interactive by definition: there is no browser to drive and no terminal to
+  // print an authorization URL to in machine-readable mode.
+  if (json) {
+    throw new Error(
+      "Interactive login is not available with --json or in agent mode. Set MUX_TOKEN_ID and MUX_TOKEN_SECRET, run 'mux login --env-file <path>', or run 'mux login' in an interactive terminal.",
+    );
+  }
+  requireInteractiveTerminal('Browser sign-in');
+
+  const result = await performOAuthLogin(
+    {
+      ...(options.name && { name: options.name }),
+      ...(options.port !== undefined && { port: options.port }),
+      noBrowser: options.printUrl === true,
+      activate: options.keepCurrent !== true,
+    },
+    {
+      onAuthorizationUrl: (url, opened) => {
+        if (opened) {
+          console.log('Opened your browser to continue signing in.');
+        } else {
+          console.log(
+            'Open this URL in your browser to continue signing in:\n',
+          );
+          console.log(`  ${url}\n`);
+        }
+        console.log('Waiting for authorization (press Ctrl+C to cancel)...');
+      },
+    },
+  );
+
+  const { identity } = result;
+  const org = identity.organizationName ?? identity.organizationId ?? 'unknown';
+  const env = identity.environmentName ?? identity.environmentId ?? 'unknown';
+
+  console.log(`\n✅ Signed in to ${org} / ${env}`);
+  if (identity.environmentId) {
+    console.log(`   Environment ID: ${identity.environmentId}`);
+  }
+  console.log(
+    `✅ ${result.replacedExisting ? 'Updated' : 'Saved as'} environment "${result.name}" in ${getConfigPath()}`,
+  );
+  if (result.activated) {
+    console.log('✅ Set as the active environment');
+  } else {
+    console.log(`   Run 'mux env switch ${result.name}' to use it.`);
+  }
+  noticeSavedLoginIsShadowed(json);
+}
+
+// Explicitly annotated: Cliffy's builder type cannot be named across this many
+// chained options without leaking an internal module path into the .d.ts.
 export const loginCommand = new Command()
   .description(
-    'Authenticate with Mux API credentials (Token ID and Secret from dashboard.mux.com)',
+    'Sign in to Mux. Opens your browser to select an organization and environment; use --interactive, --env-file, or --from-env for a Mux API access token instead.',
   )
   .option(
     '-f, --env-file <path:string>',
-    'Path to .env file containing MUX_TOKEN_ID, MUX_TOKEN_SECRET, and optionally MUX_SIGNING_KEY and MUX_PRIVATE_KEY for signed URLs',
+    'Save credentials from a .env file containing MUX_TOKEN_ID, MUX_TOKEN_SECRET, and optionally MUX_SIGNING_KEY and MUX_PRIVATE_KEY for signed URLs',
   )
   .option(
     '-n, --name <name:string>',
-    "Name for this environment (default: 'default')",
+    "Name for this environment (default: derived from the organization and environment for OAuth, or 'default' otherwise)",
+  )
+  .option(
+    '--from-env',
+    'Save the MUX_TOKEN_ID and MUX_TOKEN_SECRET already set in this shell',
+  )
+  .option(
+    '--interactive',
+    'Enter a Mux API access token (Token ID and Secret) manually',
+  )
+  .option('--oauth', 'Sign in with a browser (the default)')
+  // Named without a `--no-` prefix deliberately: Cliffy's negatable options
+  // generate a type that cannot be named under this project's declaration
+  // settings, and these read just as clearly as flags to opt into.
+  .option(
+    '--print-url',
+    'Print the authorization URL instead of opening a browser',
+  )
+  .option('--port <port:number>', 'Local port to receive the login redirect on')
+  .option(
+    '--keep-current',
+    'Save the login without making it the active environment',
   )
   .option('--json', 'Output JSON instead of pretty format')
   .action(async (options) => {
     const json = wantsJson(options);
     try {
+      // Throws with guidance when the flags conflict, when --from-env has
+      // nothing to read, or when shell credentials make the intent ambiguous.
+      const mode = resolveLoginMode(options);
+
+      if (mode === 'oauth') {
+        await runOAuthLogin(options);
+        return;
+      }
+
       let tokenId: string;
       let tokenSecret: string;
       let source: 'env-file' | 'env' | 'interactive';
@@ -131,7 +257,6 @@ export const loginCommand = new Command()
       }
 
       let baseUrl: string;
-      const envCredentials = credentialsFromEnv();
 
       if (options.envFile) {
         // Read from .env file
@@ -162,10 +287,11 @@ export const loginCommand = new Command()
           };
         }
         source = 'env-file';
-      } else if (
-        envCredentials?.MUX_TOKEN_ID &&
-        envCredentials.MUX_TOKEN_SECRET
-      ) {
+      } else if (mode === 'from-env') {
+        // resolveLoginMode already established that both variables are set.
+        const envCredentials = credentialsFromEnv() as NonNullable<
+          ReturnType<typeof credentialsFromEnv>
+        >;
         // Read from environment variables
         if (!json) {
           console.log(
@@ -173,8 +299,8 @@ export const loginCommand = new Command()
           );
         }
 
-        tokenId = envCredentials.MUX_TOKEN_ID;
-        tokenSecret = envCredentials.MUX_TOKEN_SECRET;
+        tokenId = envCredentials.MUX_TOKEN_ID as string;
+        tokenSecret = envCredentials.MUX_TOKEN_SECRET as string;
         baseUrl = getMuxBaseUrl({
           environment: { baseUrl: envCredentials.MUX_BASE_URL },
         });
@@ -186,13 +312,15 @@ export const loginCommand = new Command()
         }
         source = 'env';
       } else {
-        // Interactive prompts are not possible in machine-readable mode;
-        // fail fast with recovery guidance instead of blocking on stdin.
+        // Interactive prompts are not possible in machine-readable mode, nor
+        // with no terminal to prompt on; fail fast with recovery guidance
+        // instead of blocking on stdin.
         if (json) {
           throw new Error(
             'No credentials provided. Set MUX_TOKEN_ID and MUX_TOKEN_SECRET environment variables, or pass --env-file <path>. Interactive login is not available with --json or in agent mode.',
           );
         }
+        requireInteractiveTerminal('--interactive');
 
         console.log('Enter your Mux API credentials.');
         console.log(
@@ -226,34 +354,31 @@ export const loginCommand = new Command()
         throw new Error(validation.error || 'Invalid credentials');
       }
 
-      // Refreshing credentials must not destroy environment-bound state
-      // (signing keys, forward URL). Preserve those fields only when the
-      // new credentials verifiably belong to the same environment; carrying
-      // them across an environment change would desync the config.
+      // Saving credentials must not destroy environment-bound state (signing
+      // keys, forward URL) or a separate OAuth login for the same environment.
+      // When the new credentials belong to a *different* environment, that state
+      // no longer applies and is dropped rather than silently carried over.
       const existing = await getEnvironment(envName);
-      const preserved =
+      const sameEnvironment =
         existing?.environmentId &&
-        existing.environmentId === validation.environmentId
-          ? {
-              ...(existing.signingKeyId && {
-                signingKeyId: existing.signingKeyId,
-              }),
-              ...(existing.signingPrivateKey && {
-                signingPrivateKey: existing.signingPrivateKey,
-              }),
-              ...(existing.forwardUrl && { forwardUrl: existing.forwardUrl }),
-            }
-          : {};
+        existing.environmentId === validation.environmentId;
 
-      // Save to config
-      await setEnvironment(envName, {
-        ...preserved,
-        tokenId: tokenId.trim(),
-        tokenSecret: tokenSecret.trim(),
-        environmentId: validation.environmentId,
-        ...(baseUrl !== DEFAULT_BASE_URL && { baseUrl }),
-        ...signingKeys,
-      });
+      if (existing && !sameEnvironment) {
+        // Entry is being repointed at another environment: clear it first so no
+        // stale signing keys, forward URL, or OAuth login survive.
+        await removeEnvironment(envName);
+      }
+
+      await setCredential(
+        envName,
+        'token',
+        { tokenId: tokenId.trim(), tokenSecret: tokenSecret.trim() },
+        {
+          environmentId: validation.environmentId,
+          ...(baseUrl !== DEFAULT_BASE_URL && { baseUrl }),
+          ...signingKeys,
+        },
+      );
 
       if (json) {
         console.log(
@@ -280,6 +405,8 @@ export const loginCommand = new Command()
       if (existingEnvs.length === 0) {
         console.log(`✅ Set as default environment`);
       }
+
+      noticeSavedLoginIsShadowed(json);
     } catch (error) {
       await handleCommandError(error, 'login', 'login', options);
     }

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -7,6 +7,7 @@ import {
   setEnvironment,
 } from '../lib/config.ts';
 import { wantsJson } from '../lib/context.ts';
+import { environmentSettings } from '../lib/credentials.ts';
 import { handleCommandError } from '../lib/errors.ts';
 import {
   DEFAULT_BASE_URL,
@@ -403,6 +404,8 @@ export const loginCommand = new Command()
       const preserved =
         existing && sameEnvironment
           ? {
+              // Signing keys, forward URL, and the bound API host.
+              ...environmentSettings(existing),
               ...(existing.environmentName && {
                 environmentName: existing.environmentName,
               }),
@@ -412,13 +415,6 @@ export const loginCommand = new Command()
               ...(existing.organizationName && {
                 organizationName: existing.organizationName,
               }),
-              ...(existing.signingKeyId && {
-                signingKeyId: existing.signingKeyId,
-              }),
-              ...(existing.signingPrivateKey && {
-                signingPrivateKey: existing.signingPrivateKey,
-              }),
-              ...(existing.forwardUrl && { forwardUrl: existing.forwardUrl }),
               // A browser sign-in for this same environment stays usable.
               ...(existing.oauth && { oauth: existing.oauth }),
             }

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -129,6 +129,33 @@ function noticeSavedLoginIsShadowed(json: boolean): void {
 }
 
 /**
+ * What to print once the authorization URL is known.
+ *
+ * The URL is always shown, even when the browser reported success: `open` and
+ * `xdg-open` exit 0 whether or not a window actually appeared — wrong default
+ * browser, a background profile, a browser still launching — and without the URL
+ * on screen the only recovery is Ctrl+C and a second run with --print-url.
+ *
+ * Returned as lines rather than printed so this stays testable; the command
+ * layer owns the writing.
+ */
+export function formatAuthorizationNotice(
+  url: string,
+  opened: boolean,
+): string[] {
+  return [
+    opened
+      ? 'Opened your browser to continue signing in.'
+      : 'Open this URL in your browser to continue signing in:',
+    '',
+    `  ${url}`,
+    '',
+    ...(opened ? ["If your browser didn't open, use the URL above."] : []),
+    'Waiting for authorization (press Ctrl+C to cancel)...',
+  ];
+}
+
+/**
  * Run the browser-based OAuth login and report the result. Organization and
  * environment selection happens in the dashboard, so the CLI only reports what
  * came back.
@@ -160,15 +187,9 @@ async function runOAuthLogin(options: {
     },
     {
       onAuthorizationUrl: (url, opened) => {
-        if (opened) {
-          console.log('Opened your browser to continue signing in.');
-        } else {
-          console.log(
-            'Open this URL in your browser to continue signing in:\n',
-          );
-          console.log(`  ${url}\n`);
+        for (const line of formatAuthorizationNotice(url, opened)) {
+          console.log(line);
         }
-        console.log('Waiting for authorization (press Ctrl+C to cancel)...');
       },
     },
   );

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -198,16 +198,18 @@ async function runOAuthLogin(options: {
   const org = identity.organizationName ?? identity.organizationId ?? 'unknown';
   const env = identity.environmentName ?? identity.environmentId ?? 'unknown';
 
-  console.log(`\n✅ Signed in to ${org} / ${env}`);
-  if (identity.environmentId) {
-    console.log(`   Environment ID: ${identity.environmentId}`);
-  }
-  console.log(
-    `✅ ${result.replacedExisting ? 'Updated' : 'Saved as'} environment "${result.name}" in ${getConfigPath()}`,
-  );
+  // No config path: where credentials live is not something a user acts on at
+  // sign-in time, and `mux auth status` answers it when they do want to know.
+  const id = identity.environmentId ? ` (${identity.environmentId})` : '';
+  console.log(`\n✅ Signed in to ${org} / ${env}${id}`);
+
+  const verb = result.replacedExisting ? 'Updated' : 'Saved as';
   if (result.activated) {
-    console.log('✅ Set as the active environment');
+    console.log(
+      `✅ ${verb} "${result.name}" and set as the active environment`,
+    );
   } else {
+    console.log(`✅ ${verb} "${result.name}"`);
     console.log(`   Run 'mux env switch ${result.name}' to use it.`);
   }
   noticeSavedLoginIsShadowed(json);
@@ -419,9 +421,7 @@ export const loginCommand = new Command()
       }
 
       console.log('✅ Credentials validated successfully');
-      console.log(
-        `✅ Credentials saved to ${getConfigPath()} for environment: ${envName}`,
-      );
+      console.log(`✅ Saved as environment "${envName}"`);
 
       if (existingEnvs.length === 0) {
         console.log(`✅ Set as default environment`);

--- a/src/commands/logout.test.ts
+++ b/src/commands/logout.test.ts
@@ -1,0 +1,266 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type Mock,
+  spyOn,
+} from 'bun:test';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  getCurrentEnvironment,
+  listEnvironments,
+  setEnvironment,
+} from '../lib/config.ts';
+import { setAgentMode, setJsonFlag } from '../lib/context.ts';
+import { logoutCommand } from './logout.ts';
+
+let testConfigDir: string;
+let originalXdgConfigHome: string | undefined;
+let savedOAuthEnv: Record<string, string | undefined>;
+let logSpy: Mock<typeof console.log>;
+let errorSpy: Mock<typeof console.error>;
+let exitSpy: Mock<typeof process.exit>;
+let fetchSpy: Mock<typeof fetch> | undefined;
+
+const OAUTH_ENV_KEYS = ['MUX_OAUTH_CLIENT_ID', 'MUX_OAUTH_REVOKE_URL'] as const;
+
+function stdout(): string {
+  return logSpy.mock.calls.map((call) => String(call[0] ?? '')).join('\n');
+}
+
+function stderr(): string {
+  return errorSpy.mock.calls.map((call) => String(call[0] ?? '')).join('\n');
+}
+
+/** Revocation succeeds; discovery 404s so only the revoke call is counted. */
+function mockRevocation(status = 200) {
+  fetchSpy = spyOn(globalThis, 'fetch').mockImplementation((async (
+    input: string,
+  ) => {
+    if (String(input).includes('/.well-known/')) {
+      return new Response('not found', { status: 404 });
+    }
+    return new Response('{}', { status });
+  }) as unknown as typeof fetch);
+  return fetchSpy;
+}
+
+function revocationCalls(): string[] {
+  return (fetchSpy?.mock.calls ?? [])
+    .map((call) => String(call[0]))
+    .filter((url) => !url.includes('/.well-known/'));
+}
+
+beforeEach(async () => {
+  testConfigDir = await mkdtemp(join(tmpdir(), 'mux-cli-logout-'));
+  originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
+  process.env.XDG_CONFIG_HOME = testConfigDir;
+  process.env.XDG_CACHE_HOME = testConfigDir;
+
+  savedOAuthEnv = {};
+  for (const key of OAUTH_ENV_KEYS) {
+    savedOAuthEnv[key] = process.env[key];
+  }
+  process.env.MUX_OAUTH_CLIENT_ID = 'test_client';
+  process.env.MUX_OAUTH_REVOKE_URL = 'https://api.test/oauth/revoke';
+
+  logSpy = spyOn(console, 'log').mockImplementation(() => {});
+  errorSpy = spyOn(console, 'error').mockImplementation(() => {});
+  exitSpy = spyOn(process, 'exit').mockImplementation((() => {
+    throw new Error('process.exit called');
+  }) as never);
+});
+
+afterEach(async () => {
+  if (originalXdgConfigHome === undefined) {
+    delete process.env.XDG_CONFIG_HOME;
+  } else {
+    process.env.XDG_CONFIG_HOME = originalXdgConfigHome;
+  }
+  delete process.env.XDG_CACHE_HOME;
+  for (const key of OAUTH_ENV_KEYS) {
+    if (savedOAuthEnv[key] === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = savedOAuthEnv[key];
+    }
+  }
+  logSpy?.mockRestore();
+  errorSpy?.mockRestore();
+  exitSpy?.mockRestore();
+  fetchSpy?.mockRestore();
+  fetchSpy = undefined;
+  setAgentMode(false);
+  setJsonFlag(false);
+  await rm(testConfigDir, { recursive: true, force: true });
+});
+
+async function seed() {
+  await setEnvironment('acme-production', {
+    environmentId: 'env_123',
+    oauth: {
+      accessToken: 'access_1',
+      refreshToken: 'refresh_1',
+      expiresAt: 4_102_444_800,
+    },
+  });
+  await setEnvironment('ci-token', {
+    environmentId: 'env_456',
+    token: { tokenId: 'ci_id', tokenSecret: 'ci_secret' },
+  });
+}
+
+describe('mux logout', () => {
+  it('removes a named environment', async () => {
+    await seed();
+    mockRevocation();
+
+    await logoutCommand.parse(['ci-token']);
+
+    expect(await listEnvironments()).toEqual(['acme-production']);
+  });
+
+  it('revokes the refresh token for an OAuth login', async () => {
+    await seed();
+    mockRevocation();
+
+    await logoutCommand.parse(['acme-production']);
+
+    expect(revocationCalls()).toEqual(['https://api.test/oauth/revoke']);
+  });
+
+  it('does not call revocation for an access token environment', async () => {
+    await seed();
+    mockRevocation();
+
+    await logoutCommand.parse(['ci-token']);
+
+    expect(revocationCalls()).toEqual([]);
+  });
+
+  it('removes the credentials even when revocation fails', async () => {
+    await seed();
+    mockRevocation(500);
+
+    await logoutCommand.parse(['acme-production']);
+
+    expect(await listEnvironments()).toEqual(['ci-token']);
+    expect(stderr()).toContain('Could not revoke');
+  });
+
+  it('selects a new current environment when the active one is removed', async () => {
+    await seed();
+    mockRevocation();
+
+    await logoutCommand.parse(['acme-production']);
+
+    expect((await getCurrentEnvironment())?.name).toBe('ci-token');
+  });
+
+  it('errors when no name is given', async () => {
+    await seed();
+
+    try {
+      await logoutCommand.parse([]);
+    } catch {
+      // the mocked process.exit throws to halt parse
+    }
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(stderr()).toContain('--all');
+  });
+
+  it('errors on an unknown environment', async () => {
+    await seed();
+
+    try {
+      await logoutCommand.parse(['nope']);
+    } catch {
+      // exits
+    }
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(stderr()).toContain('does not exist');
+  });
+
+  describe('--all', () => {
+    it('removes every environment', async () => {
+      await seed();
+      mockRevocation();
+
+      await logoutCommand.parse(['--all']);
+
+      expect(await listEnvironments()).toEqual([]);
+    });
+
+    it('revokes each OAuth login it removes', async () => {
+      await seed();
+      mockRevocation();
+
+      await logoutCommand.parse(['--all']);
+
+      expect(revocationCalls()).toHaveLength(1);
+    });
+
+    it('reports an empty config without failing', async () => {
+      await logoutCommand.parse(['--all']);
+
+      expect(exitSpy).not.toHaveBeenCalled();
+      expect(stdout()).toContain('No environments configured');
+    });
+  });
+
+  describe('--json', () => {
+    it('emits the removed environments and the new current one', async () => {
+      await seed();
+      mockRevocation();
+
+      await logoutCommand.parse(['acme-production', '--json']);
+      const parsed = JSON.parse(stdout());
+
+      expect(parsed.success).toBe(true);
+      expect(parsed.removed).toEqual(['acme-production']);
+      expect(parsed.current_environment).toBe('ci-token');
+      expect(parsed.warnings).toEqual([]);
+    });
+
+    it('reports a revocation failure as a warning rather than prose', async () => {
+      await seed();
+      mockRevocation(500);
+
+      await logoutCommand.parse(['acme-production', '--json']);
+      const parsed = JSON.parse(stdout());
+
+      expect(parsed.success).toBe(true);
+      expect(parsed.warnings[0]).toContain('Could not revoke');
+      // Machine-readable mode must not mix prose into stderr.
+      expect(stderr()).toBe('');
+    });
+
+    it('reports errors as JSON', async () => {
+      await seed();
+
+      try {
+        await logoutCommand.parse(['nope', '--json']);
+      } catch {
+        // exits
+      }
+
+      expect(JSON.parse(stderr()).error).toContain('does not exist');
+    });
+
+    it('never prints token material', async () => {
+      await seed();
+      mockRevocation();
+
+      await logoutCommand.parse(['--all', '--json']);
+
+      expect(stdout()).not.toContain('refresh_1');
+      expect(stdout()).not.toContain('ci_secret');
+    });
+  });
+});

--- a/src/commands/logout.ts
+++ b/src/commands/logout.ts
@@ -5,25 +5,37 @@ import {
   listEnvironments,
   removeEnvironment,
 } from '../lib/config.ts';
+import { wantsJson } from '../lib/context.ts';
 import { revokeRefreshToken } from '../lib/oauth.ts';
+
+interface LogoutOptions {
+  all?: boolean;
+  json?: boolean;
+}
 
 /**
  * Revoke an OAuth refresh token server-side. Best effort: the user's intent is
  * to stop using the credential here, and that happens whether or not the
  * authorization server can be reached.
  */
-async function revokeIfOAuth(name: string): Promise<void> {
+async function revokeIfOAuth(
+  name: string,
+  json: boolean,
+): Promise<string | null> {
   const environment = await getEnvironment(name);
-  if (!environment?.oauth) return;
+  if (!environment?.oauth) return null;
 
   try {
     await revokeRefreshToken(environment.oauth.refreshToken);
+    return null;
   } catch (error) {
-    console.error(
-      `⚠️  Could not revoke the refresh token for "${name}" (${
-        error instanceof Error ? error.message : String(error)
-      }). Removing the local credentials anyway.`,
-    );
+    const warning = `Could not revoke the refresh token for "${name}" (${
+      error instanceof Error ? error.message : String(error)
+    }). Removing the local credentials anyway.`;
+    if (!json) {
+      console.error(`⚠️  ${warning}`);
+    }
+    return warning;
   }
 }
 
@@ -31,18 +43,48 @@ export const logoutCommand = new Command()
   .description('Remove stored credentials for an environment by name')
   .arguments('[name:string]')
   .option('--all', 'Remove stored credentials for every environment')
-  .action(async (options: { all?: boolean }, name?: string) => {
+  .option('--json', 'Output JSON instead of pretty format')
+  .action(async (options: LogoutOptions, name?: string) => {
+    const json = wantsJson(options);
+
+    // Explicitly typed: TypeScript only narrows after a never-returning call
+    // when the callee's type is declared, not just inferred.
+    const fail: (error: string, hint?: string) => never = (error, hint) => {
+      if (json) {
+        console.error(JSON.stringify({ error }, null, 2));
+      } else {
+        console.error(`❌ ${error}`);
+        if (hint) console.log(`\n${hint}`);
+      }
+      process.exit(1);
+    };
+
     if (options.all) {
       const names = await listEnvironments();
       if (names.length === 0) {
-        console.log('No environments configured.');
+        if (json) {
+          console.log(JSON.stringify({ success: true, removed: [] }, null, 2));
+        } else {
+          console.log('No environments configured.');
+        }
         return;
       }
 
+      const warnings: string[] = [];
       for (const envName of names) {
-        await revokeIfOAuth(envName);
+        const warning = await revokeIfOAuth(envName, json);
+        if (warning) warnings.push(warning);
         await removeEnvironment(envName);
-        console.log(`✅ Removed environment: ${envName}`);
+        if (!json) {
+          console.log(`✅ Removed environment: ${envName}`);
+        }
+      }
+
+      if (json) {
+        console.log(
+          JSON.stringify({ success: true, removed: names, warnings }, null, 2),
+        );
+        return;
       }
 
       console.log("\nRun 'mux login' to sign in again.");
@@ -50,33 +92,52 @@ export const logoutCommand = new Command()
     }
 
     if (!name) {
-      console.error('❌ Specify an environment name, or pass --all.');
-      console.log("\nRun 'mux env list' to see available environments.");
-      process.exit(1);
+      fail(
+        'Specify an environment name, or pass --all.',
+        "Run 'mux env list' to see available environments.",
+      );
     }
 
     // Check if environment exists
     const env = await getEnvironment(name);
 
     if (!env) {
-      console.error(`❌ Environment "${name}" does not exist.`);
-      console.log("\nRun 'mux env list' to see available environments.");
-      process.exit(1);
+      fail(
+        `Environment "${name}" does not exist.`,
+        "Run 'mux env list' to see available environments.",
+      );
     }
 
     // Check if this is the current environment
     const currentEnv = await getCurrentEnvironment();
     const wasCurrent = currentEnv?.name === name;
 
-    await revokeIfOAuth(name);
+    const warning = await revokeIfOAuth(name, json);
 
     // Remove the environment
     await removeEnvironment(name);
 
+    const newCurrent = wasCurrent ? await getCurrentEnvironment() : currentEnv;
+
+    if (json) {
+      console.log(
+        JSON.stringify(
+          {
+            success: true,
+            removed: [name],
+            current_environment: newCurrent?.name ?? null,
+            warnings: warning ? [warning] : [],
+          },
+          null,
+          2,
+        ),
+      );
+      return;
+    }
+
     console.log(`✅ Removed environment: ${name}`);
 
     if (wasCurrent) {
-      const newCurrent = await getCurrentEnvironment();
       if (newCurrent) {
         console.log(`✅ New current environment: ${newCurrent.name}`);
       } else {

--- a/src/commands/logout.ts
+++ b/src/commands/logout.ts
@@ -2,13 +2,59 @@ import { Command } from '@cliffy/command';
 import {
   getCurrentEnvironment,
   getEnvironment,
+  listEnvironments,
   removeEnvironment,
 } from '../lib/config.ts';
+import { revokeRefreshToken } from '../lib/oauth.ts';
+
+/**
+ * Revoke an OAuth refresh token server-side. Best effort: the user's intent is
+ * to stop using the credential here, and that happens whether or not the
+ * authorization server can be reached.
+ */
+async function revokeIfOAuth(name: string): Promise<void> {
+  const environment = await getEnvironment(name);
+  if (!environment?.oauth) return;
+
+  try {
+    await revokeRefreshToken(environment.oauth.refreshToken);
+  } catch (error) {
+    console.error(
+      `⚠️  Could not revoke the refresh token for "${name}" (${
+        error instanceof Error ? error.message : String(error)
+      }). Removing the local credentials anyway.`,
+    );
+  }
+}
 
 export const logoutCommand = new Command()
   .description('Remove stored credentials for an environment by name')
-  .arguments('<name:string>')
-  .action(async (_options, name: string) => {
+  .arguments('[name:string]')
+  .option('--all', 'Remove stored credentials for every environment')
+  .action(async (options: { all?: boolean }, name?: string) => {
+    if (options.all) {
+      const names = await listEnvironments();
+      if (names.length === 0) {
+        console.log('No environments configured.');
+        return;
+      }
+
+      for (const envName of names) {
+        await revokeIfOAuth(envName);
+        await removeEnvironment(envName);
+        console.log(`✅ Removed environment: ${envName}`);
+      }
+
+      console.log("\nRun 'mux login' to sign in again.");
+      return;
+    }
+
+    if (!name) {
+      console.error('❌ Specify an environment name, or pass --all.');
+      console.log("\nRun 'mux env list' to see available environments.");
+      process.exit(1);
+    }
+
     // Check if environment exists
     const env = await getEnvironment(name);
 
@@ -21,6 +67,8 @@ export const logoutCommand = new Command()
     // Check if this is the current environment
     const currentEnv = await getCurrentEnvironment();
     const wasCurrent = currentEnv?.name === name;
+
+    await revokeIfOAuth(name);
 
     // Remove the environment
     await removeEnvironment(name);

--- a/src/commands/sign.test.ts
+++ b/src/commands/sign.test.ts
@@ -212,8 +212,7 @@ describe('mux sign command', () => {
 
     test('error mentions env vars when signing keys are not configured anywhere', async () => {
       await setEnvironment('default', {
-        tokenId: 'stored_id',
-        tokenSecret: 'stored_secret',
+        token: { tokenId: 'stored_id', tokenSecret: 'stored_secret' },
       });
 
       try {
@@ -243,8 +242,7 @@ describe('mux sign command', () => {
 
     test('env var signing keys take precedence over stored config keys', async () => {
       await setEnvironment('default', {
-        tokenId: 'stored_id',
-        tokenSecret: 'stored_secret',
+        token: { tokenId: 'stored_id', tokenSecret: 'stored_secret' },
         signingKeyId: 'key_from_config',
         signingPrivateKey: privateKeyBase64,
       });
@@ -259,8 +257,7 @@ describe('mux sign command', () => {
 
     test('still signs with stored config keys when env vars are absent', async () => {
       await setEnvironment('default', {
-        tokenId: 'stored_id',
-        tokenSecret: 'stored_secret',
+        token: { tokenId: 'stored_id', tokenSecret: 'stored_secret' },
         signingKeyId: 'key_from_config',
         signingPrivateKey: privateKeyBase64,
       });
@@ -273,8 +270,7 @@ describe('mux sign command', () => {
 
     test('uses stored signing keys when env credentials match the stored environment', async () => {
       await setEnvironment('default', {
-        tokenId: 'stored_id',
-        tokenSecret: 'stored_secret',
+        token: { tokenId: 'stored_id', tokenSecret: 'stored_secret' },
         environmentId: 'env_same_123',
         signingKeyId: 'key_from_config',
         signingPrivateKey: privateKeyBase64,
@@ -301,8 +297,7 @@ describe('mux sign command', () => {
 
     test('refuses stored signing keys when env credentials point at a different environment', async () => {
       await setEnvironment('default', {
-        tokenId: 'stored_id',
-        tokenSecret: 'stored_secret',
+        token: { tokenId: 'stored_id', tokenSecret: 'stored_secret' },
         environmentId: 'env_stored_123',
         signingKeyId: 'key_from_config',
         signingPrivateKey: privateKeyBase64,
@@ -332,8 +327,7 @@ describe('mux sign command', () => {
 
     test('errors when MUX_SIGNING_KEY is set without MUX_PRIVATE_KEY', async () => {
       await setEnvironment('default', {
-        tokenId: 'stored_id',
-        tokenSecret: 'stored_secret',
+        token: { tokenId: 'stored_id', tokenSecret: 'stored_secret' },
         signingKeyId: 'key_from_config',
         signingPrivateKey: privateKeyBase64,
       });
@@ -353,8 +347,7 @@ describe('mux sign command', () => {
 
     test('errors when MUX_PRIVATE_KEY is set without MUX_SIGNING_KEY', async () => {
       await setEnvironment('default', {
-        tokenId: 'stored_id',
-        tokenSecret: 'stored_secret',
+        token: { tokenId: 'stored_id', tokenSecret: 'stored_secret' },
         signingKeyId: 'key_from_config',
         signingPrivateKey: privateKeyBase64,
       });
@@ -374,8 +367,7 @@ describe('mux sign command', () => {
 
     test('signs offline when env credentials byte-match the stored environment', async () => {
       await setEnvironment('default', {
-        tokenId: 'same_id',
-        tokenSecret: 'same_secret',
+        token: { tokenId: 'same_id', tokenSecret: 'same_secret' },
         environmentId: 'env_same_123',
         signingKeyId: 'key_from_config',
         signingPrivateKey: privateKeyBase64,

--- a/src/commands/signing-keys/create.test.ts
+++ b/src/commands/signing-keys/create.test.ts
@@ -132,8 +132,7 @@ describe('mux signing-keys create command', () => {
 
     test('saves the key to the stored environment when credentials come from config', async () => {
       await setEnvironment('default', {
-        tokenId: 'stored_id',
-        tokenSecret: 'stored_secret',
+        token: { tokenId: 'stored_id', tokenSecret: 'stored_secret' },
         environmentId: 'env_stored_123',
       });
       mockApi('env_stored_123');
@@ -165,8 +164,7 @@ describe('mux signing-keys create command', () => {
 
     test('does not save to a stored environment that env var credentials do not match', async () => {
       await setEnvironment('default', {
-        tokenId: 'stored_id',
-        tokenSecret: 'stored_secret',
+        token: { tokenId: 'stored_id', tokenSecret: 'stored_secret' },
         environmentId: 'env_stored_123',
         signingKeyId: 'key_existing',
         signingPrivateKey: 'existing_private_key',
@@ -187,13 +185,11 @@ describe('mux signing-keys create command', () => {
 
     test('saves to a non-default stored environment when env var credentials match it', async () => {
       await setEnvironment('production', {
-        tokenId: 'prod_id',
-        tokenSecret: 'prod_secret',
+        token: { tokenId: 'prod_id', tokenSecret: 'prod_secret' },
         environmentId: 'env_prod_123',
       });
       await setEnvironment('staging', {
-        tokenId: 'staging_id',
-        tokenSecret: 'staging_secret',
+        token: { tokenId: 'staging_id', tokenSecret: 'staging_secret' },
         environmentId: 'env_staging_456',
       });
       process.env.MUX_TOKEN_ID = 'env_id';
@@ -213,8 +209,7 @@ describe('mux signing-keys create command', () => {
 
     test('saves to the stored environment when env var credentials match it', async () => {
       await setEnvironment('default', {
-        tokenId: 'stored_id',
-        tokenSecret: 'stored_secret',
+        token: { tokenId: 'stored_id', tokenSecret: 'stored_secret' },
         environmentId: 'env_same_123',
       });
       process.env.MUX_TOKEN_ID = 'env_id';
@@ -231,8 +226,7 @@ describe('mux signing-keys create command', () => {
 
     test('fails fast in JSON mode when a signing key exists and --force is omitted', async () => {
       await setEnvironment('default', {
-        tokenId: 'stored_id',
-        tokenSecret: 'stored_secret',
+        token: { tokenId: 'stored_id', tokenSecret: 'stored_secret' },
         environmentId: 'env_stored_123',
         signingKeyId: 'key_existing',
         signingPrivateKey: 'existing_private_key',
@@ -256,8 +250,7 @@ describe('mux signing-keys create command', () => {
 
     test('replaces an existing signing key in JSON mode with --force', async () => {
       await setEnvironment('default', {
-        tokenId: 'stored_id',
-        tokenSecret: 'stored_secret',
+        token: { tokenId: 'stored_id', tokenSecret: 'stored_secret' },
         environmentId: 'env_stored_123',
         signingKeyId: 'key_existing',
         signingPrivateKey: 'existing_private_key',
@@ -274,8 +267,7 @@ describe('mux signing-keys create command', () => {
 
     test('emits the private key once when saving to config fails', async () => {
       await setEnvironment('default', {
-        tokenId: 'stored_id',
-        tokenSecret: 'stored_secret',
+        token: { tokenId: 'stored_id', tokenSecret: 'stored_secret' },
         environmentId: 'env_stored_123',
       });
       mockApi('env_stored_123');

--- a/src/commands/webhooks/events/list.test.ts
+++ b/src/commands/webhooks/events/list.test.ts
@@ -95,8 +95,7 @@ describe('mux webhooks events list command', () => {
 
   test('lists events for the stored environment id when logged in', async () => {
     await setEnvironment('default', {
-      tokenId: 'stored_id',
-      tokenSecret: 'stored_secret',
+      token: { tokenId: 'stored_id', tokenSecret: 'stored_secret' },
       environmentId: 'env_stored_123',
     });
     appendEvent(makeEvent('evt_stored', 'env_stored_123'));
@@ -110,8 +109,7 @@ describe('mux webhooks events list command', () => {
 
   test('lists events for the env var credentials environment, not the stored one', async () => {
     await setEnvironment('default', {
-      tokenId: 'stored_id',
-      tokenSecret: 'stored_secret',
+      token: { tokenId: 'stored_id', tokenSecret: 'stored_secret' },
       environmentId: 'env_stored_123',
     });
     appendEvent(makeEvent('evt_stored', 'env_stored_123'));

--- a/src/commands/webhooks/events/replay.test.ts
+++ b/src/commands/webhooks/events/replay.test.ts
@@ -85,8 +85,7 @@ describe('mux webhooks events replay command', () => {
 
   test('unknown event ID is a JSON error in JSON mode', async () => {
     await setEnvironment('default', {
-      tokenId: 'stored_id',
-      tokenSecret: 'stored_secret',
+      token: { tokenId: 'stored_id', tokenSecret: 'stored_secret' },
       environmentId: 'env_replay_qa_isolated',
     });
 
@@ -102,8 +101,7 @@ describe('mux webhooks events replay command', () => {
 
   test('empty replay set emits JSON in JSON mode', async () => {
     await setEnvironment('default', {
-      tokenId: 'stored_id',
-      tokenSecret: 'stored_secret',
+      token: { tokenId: 'stored_id', tokenSecret: 'stored_secret' },
       environmentId: 'env_replay_qa_isolated',
     });
 

--- a/src/commands/webhooks/listen.ts
+++ b/src/commands/webhooks/listen.ts
@@ -4,7 +4,11 @@ import { updateEnvironment } from '@/lib/config.ts';
 import { wantsJson } from '@/lib/context.ts';
 import { checkFetchPermissionError } from '@/lib/errors.ts';
 import { appendEvent, type StoredEvent } from '@/lib/events-store.ts';
-import { getAuthHeaders, resolveActiveEnvironment } from '@/lib/mux.ts';
+import {
+  getAuthHeaders,
+  refreshActiveOAuthCredentials,
+  resolveActiveEnvironment,
+} from '@/lib/mux.ts';
 import { parseSSEStream } from '@/lib/sse.ts';
 import { buildSignedHeaders, getSigningSecret } from '@/lib/webhook-signing.ts';
 
@@ -73,8 +77,13 @@ export const listenCommand = new Command()
       });
     }
 
-    const authHeaders = await getAuthHeaders();
     const url = `${active.baseUrl}/system/v1/webhook-events/stream`;
+
+    // This command holds a connection open for hours, so an OAuth access token
+    // will expire mid-run. Credentials are resolved per connection attempt
+    // (which refreshes an expiring token), and a 401 triggers one forced
+    // refresh and reconnect before being treated as fatal.
+    let refreshedAfterUnauthorized = false;
 
     let signingSecret: string | undefined;
     if (options.forwardTo) {
@@ -102,6 +111,7 @@ export const listenCommand = new Command()
 
     while (!controller.signal.aborted) {
       try {
+        const authHeaders = await getAuthHeaders();
         const response = await fetch(url, {
           headers: {
             ...authHeaders,
@@ -109,6 +119,18 @@ export const listenCommand = new Command()
           },
           signal: controller.signal,
         });
+
+        if (response.status === 401 && !refreshedAfterUnauthorized) {
+          // The token may have been revoked or rotated server-side. Try once
+          // with a fresh one before reporting an auth failure.
+          refreshedAfterUnauthorized = true;
+          if (await refreshActiveOAuthCredentials().catch(() => false)) {
+            if (!wantsJson(options)) {
+              console.log(colors.dim('Refreshed credentials, reconnecting...'));
+            }
+            continue;
+          }
+        }
 
         if (!response.ok) {
           // Check for permission issues before entering the reconnection loop.
@@ -137,6 +159,9 @@ export const listenCommand = new Command()
         )) {
           if (sseEvent.event === 'connected') {
             backoffMs = INITIAL_BACKOFF_MS;
+            // A healthy connection re-arms the one-shot refresh, so a token
+            // revoked hours from now is still handled.
+            refreshedAfterUnauthorized = false;
             if (!wantsJson(options)) {
               console.log(colors.dim('Connected to event stream.\n'));
             }

--- a/src/commands/webhooks/trigger.ts
+++ b/src/commands/webhooks/trigger.ts
@@ -38,8 +38,13 @@ export const triggerCommand = new Command()
 
       const active = await resolveActiveEnvironment();
       const envLabel = active.stored?.name ?? active.environmentId;
+      // Only used as a short cosmetic marker in the example payload. An
+      // OAuth-only environment has no token id, so the marker falls back to the
+      // env var and then to empty.
       const tokenId =
-        active.stored?.environment.tokenId ?? process.env.MUX_TOKEN_ID ?? '';
+        active.stored?.environment.token?.tokenId ??
+        process.env.MUX_TOKEN_ID ??
+        '';
 
       const payload = generateExampleWebhook(
         eventType as WebhookEventType,

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { CompletionsCommand } from '@cliffy/command/completions';
 import pkg from '../package.json';
 import { annotationsCommand } from './commands/annotations/index.ts';
 import { assetsCommand } from './commands/assets/index.ts';
+import { authCommand } from './commands/auth/index.ts';
 import { completionsInstallCommand } from './commands/completions-install.ts';
 import { deliveryUsageCommand } from './commands/delivery-usage/index.ts';
 import { dimensionsCommand } from './commands/dimensions/index.ts';
@@ -47,6 +48,7 @@ const cli = new Command()
   .allowEmpty(true)
   .command('login', loginCommand)
   .command('logout', logoutCommand)
+  .command('auth', authCommand)
   .command('env', envCommand)
   .command('assets', assetsCommand)
   .command('live', liveCommand)

--- a/src/lib/bearer-retry.test.ts
+++ b/src/lib/bearer-retry.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'bun:test';
+import { createBearerRetryFetch } from './bearer-retry.ts';
+
+function authOf(init: RequestInit | undefined): string | null {
+  return new Headers(init?.headers).get('Authorization');
+}
+
+describe('createBearerRetryFetch', () => {
+  it('passes a successful request straight through', async () => {
+    let calls = 0;
+    let refreshes = 0;
+    const wrapped = createBearerRetryFetch({
+      refresh: async () => {
+        refreshes += 1;
+        return 'access_2';
+      },
+      fetchImpl: (async () => {
+        calls += 1;
+        return new Response('{}', { status: 200 });
+      }) as unknown as typeof fetch,
+    });
+
+    const response = await wrapped('https://api.test/video/v1/assets');
+
+    expect(response.status).toBe(200);
+    expect(calls).toBe(1);
+    expect(refreshes).toBe(0);
+  });
+
+  it('refreshes once and retries with the new token on 401', async () => {
+    const seen: (string | null)[] = [];
+    const wrapped = createBearerRetryFetch({
+      refresh: async () => 'access_2',
+      fetchImpl: (async (_url: string, init: RequestInit) => {
+        seen.push(authOf(init));
+        return new Response('{}', { status: seen.length === 1 ? 401 : 200 });
+      }) as unknown as typeof fetch,
+    });
+
+    const response = await wrapped('https://api.test/video/v1/assets', {
+      headers: { Authorization: 'Bearer access_1' },
+    });
+
+    expect(response.status).toBe(200);
+    expect(seen).toEqual(['Bearer access_1', 'Bearer access_2']);
+  });
+
+  it('preserves the method, body, and other headers on the retry', async () => {
+    const seen: RequestInit[] = [];
+    const wrapped = createBearerRetryFetch({
+      refresh: async () => 'access_2',
+      fetchImpl: (async (_url: string, init: RequestInit) => {
+        seen.push(init);
+        return new Response('{}', { status: seen.length === 1 ? 401 : 200 });
+      }) as unknown as typeof fetch,
+    });
+
+    await wrapped('https://api.test/video/v1/assets', {
+      method: 'POST',
+      body: '{"input":"x"}',
+      headers: {
+        Authorization: 'Bearer access_1',
+        'Content-Type': 'application/json',
+        'User-Agent': 'Mux CLI/test',
+      },
+    });
+
+    const retry = seen[1];
+    expect(retry.method).toBe('POST');
+    expect(retry.body).toBe('{"input":"x"}');
+    expect(new Headers(retry.headers).get('Content-Type')).toBe(
+      'application/json',
+    );
+    expect(new Headers(retry.headers).get('User-Agent')).toBe('Mux CLI/test');
+  });
+
+  it('retries only once, so a persistent 401 surfaces to the caller', async () => {
+    let calls = 0;
+    let refreshes = 0;
+    const wrapped = createBearerRetryFetch({
+      refresh: async () => {
+        refreshes += 1;
+        return 'access_2';
+      },
+      fetchImpl: (async () => {
+        calls += 1;
+        return new Response('{}', { status: 401 });
+      }) as unknown as typeof fetch,
+    });
+
+    const response = await wrapped('https://api.test/video/v1/assets');
+
+    expect(response.status).toBe(401);
+    expect(calls).toBe(2);
+    expect(refreshes).toBe(1);
+  });
+
+  it('returns the original 401 when the refresh itself fails', async () => {
+    const wrapped = createBearerRetryFetch({
+      refresh: async () => {
+        throw new Error('refresh token revoked');
+      },
+      fetchImpl: (async () =>
+        new Response('{}', { status: 401 })) as unknown as typeof fetch,
+    });
+
+    // The caller's own 401 handling is more useful here than a refresh error
+    // raised from inside an unrelated API call.
+    const response = await wrapped('https://api.test/video/v1/assets');
+    expect(response.status).toBe(401);
+  });
+
+  it('does not refresh on other error statuses', async () => {
+    let refreshes = 0;
+    const wrapped = createBearerRetryFetch({
+      refresh: async () => {
+        refreshes += 1;
+        return 'access_2';
+      },
+      fetchImpl: (async () =>
+        new Response('{}', { status: 403 })) as unknown as typeof fetch,
+    });
+
+    expect((await wrapped('https://api.test/x')).status).toBe(403);
+    expect(refreshes).toBe(0);
+  });
+
+  it('handles a Request object as input', async () => {
+    const seen: (string | null)[] = [];
+    const wrapped = createBearerRetryFetch({
+      refresh: async () => 'access_2',
+      fetchImpl: (async (input: Request | string, init?: RequestInit) => {
+        const header =
+          input instanceof Request
+            ? input.headers.get('Authorization')
+            : authOf(init);
+        seen.push(header);
+        return new Response('{}', { status: seen.length === 1 ? 401 : 200 });
+      }) as unknown as typeof fetch,
+    });
+
+    const response = await wrapped(
+      new Request('https://api.test/video/v1/assets', {
+        headers: { Authorization: 'Bearer access_1' },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(seen[0]).toBe('Bearer access_1');
+    expect(seen[1]).toBe('Bearer access_2');
+  });
+});

--- a/src/lib/bearer-retry.ts
+++ b/src/lib/bearer-retry.ts
@@ -1,0 +1,61 @@
+/**
+ * A `fetch` wrapper that refreshes an OAuth access token once on a 401 and
+ * retries the request.
+ *
+ * Proactive refresh (see token-refresh.ts) covers expiry, but a token can be
+ * invalidated server-side while the CLI still considers it fresh. Handing this
+ * to the Mux SDK as its `fetch` implementation makes every command reactive to
+ * that without any command knowing about tokens.
+ */
+export interface BearerRetryOptions {
+  /** Obtain a new access token. Returns the token to retry with. */
+  refresh: () => Promise<string>;
+  fetchImpl?: typeof fetch;
+}
+
+/** Rebuild request arguments with a replaced Authorization header. */
+function withBearer(
+  input: Parameters<typeof fetch>[0],
+  init: RequestInit | undefined,
+  accessToken: string,
+): [Parameters<typeof fetch>[0], RequestInit | undefined] {
+  if (input instanceof Request && !init) {
+    const headers = new Headers(input.headers);
+    headers.set('Authorization', `Bearer ${accessToken}`);
+    return [new Request(input, { headers }), undefined];
+  }
+
+  const headers = new Headers(
+    init?.headers ?? (input instanceof Request ? input.headers : undefined),
+  );
+  headers.set('Authorization', `Bearer ${accessToken}`);
+  return [input, { ...init, headers }];
+}
+
+export function createBearerRetryFetch(
+  options: BearerRetryOptions,
+): typeof fetch {
+  const fetchImpl = options.fetchImpl ?? fetch;
+
+  return (async (
+    input: Parameters<typeof fetch>[0],
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const response = await fetchImpl(input, init);
+    if (response.status !== 401) {
+      return response;
+    }
+
+    let accessToken: string;
+    try {
+      accessToken = await options.refresh();
+    } catch {
+      // Surface the original 401 rather than a refresh error raised from inside
+      // an unrelated API call: the caller's 401 handling is the useful message.
+      return response;
+    }
+
+    const [retryInput, retryInit] = withBearer(input, init, accessToken);
+    return fetchImpl(retryInput, retryInit);
+  }) as typeof fetch;
+}

--- a/src/lib/browser.test.ts
+++ b/src/lib/browser.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'bun:test';
+import { browserCommand } from './browser.ts';
+
+// A real authorization URL: several `&` separators and percent-encoding, which is
+// what breaks naive Windows shell invocations.
+const URL_WITH_AMPERSANDS =
+  'https://api.mux.com/ui/v1/oauth/authorize?response_type=code&client_id=abc&redirect_uri=http%3A%2F%2F127.0.0.1%3A57460%2Fcallback&scope=video%3Aread+data%3Aread&state=XYZ&code_challenge=Q&code_challenge_method=S256';
+
+describe('browserCommand', () => {
+  it('uses open on macOS', () => {
+    expect(browserCommand(URL_WITH_AMPERSANDS, 'darwin')).toEqual([
+      'open',
+      URL_WITH_AMPERSANDS,
+    ]);
+  });
+
+  it('uses xdg-open elsewhere on POSIX', () => {
+    expect(browserCommand(URL_WITH_AMPERSANDS, 'linux')).toEqual([
+      'xdg-open',
+      URL_WITH_AMPERSANDS,
+    ]);
+    expect(browserCommand(URL_WITH_AMPERSANDS, 'freebsd')[0]).toBe('xdg-open');
+  });
+
+  describe('on Windows', () => {
+    it('does not route the URL through cmd.exe', () => {
+      // cmd treats `&` as a command separator, so `cmd /c start <url>` opens a
+      // truncated URL and runs the rest of the query string as commands.
+      const command = browserCommand(URL_WITH_AMPERSANDS, 'win32');
+
+      expect(command).not.toContain('cmd');
+      expect(command).not.toContain('start');
+    });
+
+    it('hands the URL to the registered protocol handler', () => {
+      expect(browserCommand(URL_WITH_AMPERSANDS, 'win32')).toEqual([
+        'rundll32',
+        'url.dll,FileProtocolHandler',
+        URL_WITH_AMPERSANDS,
+      ]);
+    });
+  });
+
+  it('keeps the URL intact as a single argument on every platform', () => {
+    // Whatever the platform, the URL must arrive as one argv entry with nothing
+    // trimmed at the first `&`.
+    for (const platform of ['darwin', 'linux', 'win32'] as NodeJS.Platform[]) {
+      const command = browserCommand(URL_WITH_AMPERSANDS, platform);
+      const urlArgs = command.filter((arg) => arg.includes('oauth/authorize'));
+
+      expect(urlArgs).toEqual([URL_WITH_AMPERSANDS]);
+      expect(urlArgs[0]).toContain('code_challenge_method=S256');
+    }
+  });
+
+  it('never passes an empty argument that could be read as the URL', () => {
+    // `cmd /c start "" <url>` needed a placeholder title argument; nothing does
+    // now, and an empty argv entry would be a sign that crept back in.
+    for (const platform of ['darwin', 'linux', 'win32'] as NodeJS.Platform[]) {
+      expect(browserCommand(URL_WITH_AMPERSANDS, platform)).not.toContain('');
+    }
+  });
+});

--- a/src/lib/browser.ts
+++ b/src/lib/browser.ts
@@ -1,20 +1,45 @@
 /**
  * Open a URL in the user's default browser.
+ */
+
+/**
+ * The command used to hand a URL to the platform's default browser.
  *
+ * Exported for tests: the Windows form is easy to get wrong and impossible to
+ * verify from a POSIX machine, so at least the argument vector is pinned down.
+ */
+export function browserCommand(
+  url: string,
+  platform: NodeJS.Platform = process.platform,
+): string[] {
+  switch (platform) {
+    case 'darwin':
+      return ['open', url];
+
+    case 'win32':
+      // Deliberately not `cmd /c start`: cmd.exe treats `&` as a command
+      // separator, and an authorization URL always contains `&` between query
+      // parameters, so the browser would receive a truncated URL (and the rest
+      // would be run as commands). Quoting it away is unreliable here because
+      // Bun offers no way to bypass its own argument escaping on Windows.
+      //
+      // rundll32 hands the URL straight to the registered protocol handler —
+      // the default browser — with no shell in the path to reinterpret it.
+      return ['rundll32', 'url.dll,FileProtocolHandler', url];
+
+    default:
+      return ['xdg-open', url];
+  }
+}
+
+/**
  * Returns false rather than throwing when no browser could be launched —
  * headless hosts, restricted environments, and SSH sessions are expected, and
  * the caller falls back to printing the URL.
  */
 export async function openBrowser(url: string): Promise<boolean> {
-  const command =
-    process.platform === 'darwin'
-      ? ['open', url]
-      : process.platform === 'win32'
-        ? ['cmd', '/c', 'start', '', url]
-        : ['xdg-open', url];
-
   try {
-    const proc = Bun.spawn(command, {
+    const proc = Bun.spawn(browserCommand(url), {
       stdout: 'ignore',
       stderr: 'ignore',
       stdin: 'ignore',

--- a/src/lib/browser.ts
+++ b/src/lib/browser.ts
@@ -1,0 +1,26 @@
+/**
+ * Open a URL in the user's default browser.
+ *
+ * Returns false rather than throwing when no browser could be launched —
+ * headless hosts, restricted environments, and SSH sessions are expected, and
+ * the caller falls back to printing the URL.
+ */
+export async function openBrowser(url: string): Promise<boolean> {
+  const command =
+    process.platform === 'darwin'
+      ? ['open', url]
+      : process.platform === 'win32'
+        ? ['cmd', '/c', 'start', '', url]
+        : ['xdg-open', url];
+
+  try {
+    const proc = Bun.spawn(command, {
+      stdout: 'ignore',
+      stderr: 'ignore',
+      stdin: 'ignore',
+    });
+    return (await proc.exited) === 0;
+  } catch {
+    return false;
+  }
+}

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -1,15 +1,22 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { readdirSync, statSync } from 'node:fs';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
   type Config,
   type Environment,
+  findEnvironmentByEnvironmentId,
+  flagCredential,
   getCurrentEnvironment,
   getEnvironment,
+  getEnvironmentAuthType,
+  isOAuthEnvironment,
   listEnvironments,
   readConfig,
+  removeCredential,
   removeEnvironment,
+  setCredential,
   setCurrentEnvironment,
   setEnvironment,
   writeConfig,
@@ -51,8 +58,7 @@ describe('Config manager', () => {
       const testConfig: Config = {
         environments: {
           test: {
-            tokenId: 'test_id',
-            tokenSecret: 'test_secret',
+            token: { tokenId: 'test_id', tokenSecret: 'test_secret' },
           },
         },
         defaultEnvironment: 'test',
@@ -77,8 +83,7 @@ describe('Config manager', () => {
       const testConfig: Config = {
         environments: {
           test: {
-            tokenId: 'test_id',
-            tokenSecret: 'test_secret',
+            token: { tokenId: 'test_id', tokenSecret: 'test_secret' },
           },
         },
       };
@@ -93,8 +98,7 @@ describe('Config manager', () => {
       const testConfig: Config = {
         environments: {
           test: {
-            tokenId: 'test_id',
-            tokenSecret: 'test_secret',
+            token: { tokenId: 'test_id', tokenSecret: 'test_secret' },
           },
         },
         defaultEnvironment: 'test',
@@ -121,8 +125,7 @@ describe('Config manager', () => {
       await writeConfig({
         environments: {
           other: {
-            tokenId: 'other_id',
-            tokenSecret: 'other_secret',
+            token: { tokenId: 'other_id', tokenSecret: 'other_secret' },
           },
         },
       });
@@ -133,8 +136,7 @@ describe('Config manager', () => {
 
     it('should return environment when it exists', async () => {
       const testEnv: Environment = {
-        tokenId: 'test_id',
-        tokenSecret: 'test_secret',
+        token: { tokenId: 'test_id', tokenSecret: 'test_secret' },
       };
 
       await writeConfig({
@@ -151,8 +153,7 @@ describe('Config manager', () => {
   describe('setEnvironment', () => {
     it('should create new config with single environment', async () => {
       const testEnv: Environment = {
-        tokenId: 'test_id',
-        tokenSecret: 'test_secret',
+        token: { tokenId: 'test_id', tokenSecret: 'test_secret' },
       };
 
       await setEnvironment('test', testEnv);
@@ -168,8 +169,7 @@ describe('Config manager', () => {
 
     it('should set first environment as default', async () => {
       const testEnv: Environment = {
-        tokenId: 'test_id',
-        tokenSecret: 'test_secret',
+        token: { tokenId: 'test_id', tokenSecret: 'test_secret' },
       };
 
       await setEnvironment('production', testEnv);
@@ -180,12 +180,10 @@ describe('Config manager', () => {
 
     it('should add environment to existing config', async () => {
       const firstEnv: Environment = {
-        tokenId: 'first_id',
-        tokenSecret: 'first_secret',
+        token: { tokenId: 'first_id', tokenSecret: 'first_secret' },
       };
       const secondEnv: Environment = {
-        tokenId: 'second_id',
-        tokenSecret: 'second_secret',
+        token: { tokenId: 'second_id', tokenSecret: 'second_secret' },
       };
 
       await setEnvironment('first', firstEnv);
@@ -200,12 +198,10 @@ describe('Config manager', () => {
 
     it('should update existing environment', async () => {
       const originalEnv: Environment = {
-        tokenId: 'original_id',
-        tokenSecret: 'original_secret',
+        token: { tokenId: 'original_id', tokenSecret: 'original_secret' },
       };
       const updatedEnv: Environment = {
-        tokenId: 'updated_id',
-        tokenSecret: 'updated_secret',
+        token: { tokenId: 'updated_id', tokenSecret: 'updated_secret' },
       };
 
       await setEnvironment('test', originalEnv);
@@ -230,8 +226,7 @@ describe('Config manager', () => {
 
     it('should return the only environment when only one exists', async () => {
       const testEnv: Environment = {
-        tokenId: 'test_id',
-        tokenSecret: 'test_secret',
+        token: { tokenId: 'test_id', tokenSecret: 'test_secret' },
       };
 
       await setEnvironment('test', testEnv);
@@ -245,12 +240,10 @@ describe('Config manager', () => {
 
     it('should return the default environment when multiple exist', async () => {
       const firstEnv: Environment = {
-        tokenId: 'first_id',
-        tokenSecret: 'first_secret',
+        token: { tokenId: 'first_id', tokenSecret: 'first_secret' },
       };
       const secondEnv: Environment = {
-        tokenId: 'second_id',
-        tokenSecret: 'second_secret',
+        token: { tokenId: 'second_id', tokenSecret: 'second_secret' },
       };
 
       await setEnvironment('first', firstEnv);
@@ -277,8 +270,7 @@ describe('Config manager', () => {
       await writeConfig({
         environments: {
           other: {
-            tokenId: 'other_id',
-            tokenSecret: 'other_secret',
+            token: { tokenId: 'other_id', tokenSecret: 'other_secret' },
           },
         },
       });
@@ -290,12 +282,10 @@ describe('Config manager', () => {
 
     it('should set default environment', async () => {
       const firstEnv: Environment = {
-        tokenId: 'first_id',
-        tokenSecret: 'first_secret',
+        token: { tokenId: 'first_id', tokenSecret: 'first_secret' },
       };
       const secondEnv: Environment = {
-        tokenId: 'second_id',
-        tokenSecret: 'second_secret',
+        token: { tokenId: 'second_id', tokenSecret: 'second_secret' },
       };
 
       await setEnvironment('first', firstEnv);
@@ -315,16 +305,13 @@ describe('Config manager', () => {
 
     it('should return array of environment names', async () => {
       await setEnvironment('first', {
-        tokenId: 'first_id',
-        tokenSecret: 'first_secret',
+        token: { tokenId: 'first_id', tokenSecret: 'first_secret' },
       });
       await setEnvironment('second', {
-        tokenId: 'second_id',
-        tokenSecret: 'second_secret',
+        token: { tokenId: 'second_id', tokenSecret: 'second_secret' },
       });
       await setEnvironment('third', {
-        tokenId: 'third_id',
-        tokenSecret: 'third_secret',
+        token: { tokenId: 'third_id', tokenSecret: 'third_secret' },
       });
 
       const result = await listEnvironments();
@@ -346,8 +333,7 @@ describe('Config manager', () => {
       await writeConfig({
         environments: {
           other: {
-            tokenId: 'other_id',
-            tokenSecret: 'other_secret',
+            token: { tokenId: 'other_id', tokenSecret: 'other_secret' },
           },
         },
       });
@@ -359,12 +345,10 @@ describe('Config manager', () => {
 
     it('should remove environment from config', async () => {
       await setEnvironment('first', {
-        tokenId: 'first_id',
-        tokenSecret: 'first_secret',
+        token: { tokenId: 'first_id', tokenSecret: 'first_secret' },
       });
       await setEnvironment('second', {
-        tokenId: 'second_id',
-        tokenSecret: 'second_secret',
+        token: { tokenId: 'second_id', tokenSecret: 'second_secret' },
       });
 
       await removeEnvironment('first');
@@ -376,12 +360,10 @@ describe('Config manager', () => {
 
     it('should set new default when removing default environment', async () => {
       await setEnvironment('first', {
-        tokenId: 'first_id',
-        tokenSecret: 'first_secret',
+        token: { tokenId: 'first_id', tokenSecret: 'first_secret' },
       });
       await setEnvironment('second', {
-        tokenId: 'second_id',
-        tokenSecret: 'second_secret',
+        token: { tokenId: 'second_id', tokenSecret: 'second_secret' },
       });
 
       // first is the default
@@ -398,8 +380,7 @@ describe('Config manager', () => {
 
     it('should set default to undefined when removing last environment', async () => {
       await setEnvironment('only', {
-        tokenId: 'only_id',
-        tokenSecret: 'only_secret',
+        token: { tokenId: 'only_id', tokenSecret: 'only_secret' },
       });
 
       await removeEnvironment('only');
@@ -411,12 +392,10 @@ describe('Config manager', () => {
 
     it('should not change default when removing non-default environment', async () => {
       await setEnvironment('first', {
-        tokenId: 'first_id',
-        tokenSecret: 'first_secret',
+        token: { tokenId: 'first_id', tokenSecret: 'first_secret' },
       });
       await setEnvironment('second', {
-        tokenId: 'second_id',
-        tokenSecret: 'second_secret',
+        token: { tokenId: 'second_id', tokenSecret: 'second_secret' },
       });
 
       // first is the default
@@ -435,8 +414,7 @@ describe('Config manager', () => {
   describe('Environment with signing keys', () => {
     it('should store and retrieve environment with signing keys', async () => {
       const envWithSigningKeys: Environment = {
-        tokenId: 'test_id',
-        tokenSecret: 'test_secret',
+        token: { tokenId: 'test_id', tokenSecret: 'test_secret' },
         signingKeyId: 'signing_key_id',
         signingPrivateKey:
           '-----BEGIN RSA PRIVATE KEY-----\ntest_key\n-----END RSA PRIVATE KEY-----',
@@ -452,8 +430,7 @@ describe('Config manager', () => {
 
     it('should support environments without signing keys', async () => {
       const envWithoutSigningKeys: Environment = {
-        tokenId: 'test_id',
-        tokenSecret: 'test_secret',
+        token: { tokenId: 'test_id', tokenSecret: 'test_secret' },
       };
 
       await setEnvironment('dev', envWithoutSigningKeys);
@@ -468,8 +445,7 @@ describe('Config manager', () => {
       const legacyConfig: Config = {
         environments: {
           legacy: {
-            tokenId: 'legacy_id',
-            tokenSecret: 'legacy_secret',
+            token: { tokenId: 'legacy_id', tokenSecret: 'legacy_secret' },
           },
         },
         defaultEnvironment: 'legacy',
@@ -477,24 +453,22 @@ describe('Config manager', () => {
 
       await writeConfig(legacyConfig);
       const config = await readConfig();
-      const env = await getEnvironment('legacy');
+      const env = (await getEnvironment('legacy')) as Environment;
 
       expect(config).toEqual(legacyConfig);
-      expect(env?.tokenId).toBe('legacy_id');
+      expect(env?.token?.tokenId).toBe('legacy_id');
       expect(env?.signingKeyId).toBeUndefined();
     });
 
     it('should update environment to add signing keys', async () => {
       const envWithoutKeys: Environment = {
-        tokenId: 'test_id',
-        tokenSecret: 'test_secret',
+        token: { tokenId: 'test_id', tokenSecret: 'test_secret' },
       };
 
       await setEnvironment('test', envWithoutKeys);
 
       const envWithKeys: Environment = {
-        tokenId: 'test_id',
-        tokenSecret: 'test_secret',
+        token: { tokenId: 'test_id', tokenSecret: 'test_secret' },
         signingKeyId: 'new_signing_key',
         signingPrivateKey:
           '-----BEGIN RSA PRIVATE KEY-----\nkey_data\n-----END RSA PRIVATE KEY-----',
@@ -509,8 +483,7 @@ describe('Config manager', () => {
 
     it('should allow removing signing keys from environment', async () => {
       const envWithKeys: Environment = {
-        tokenId: 'test_id',
-        tokenSecret: 'test_secret',
+        token: { tokenId: 'test_id', tokenSecret: 'test_secret' },
         signingKeyId: 'signing_key',
         signingPrivateKey:
           '-----BEGIN RSA PRIVATE KEY-----\nkey\n-----END RSA PRIVATE KEY-----',
@@ -519,8 +492,7 @@ describe('Config manager', () => {
       await setEnvironment('test', envWithKeys);
 
       const envWithoutKeys: Environment = {
-        tokenId: 'test_id',
-        tokenSecret: 'test_secret',
+        token: { tokenId: 'test_id', tokenSecret: 'test_secret' },
       };
 
       await setEnvironment('test', envWithoutKeys);
@@ -528,6 +500,268 @@ describe('Config manager', () => {
 
       expect(env?.signingKeyId).toBeUndefined();
       expect(env?.signingPrivateKey).toBeUndefined();
+    });
+  });
+});
+
+describe('Config manager - credential blocks', () => {
+  let testConfigDir: string;
+  let originalXdgConfigHome: string | undefined;
+
+  const oauthCredential = {
+    accessToken: 'access_1',
+    refreshToken: 'refresh_1',
+    expiresAt: 1_800_000_000,
+    scope: 'video:read',
+    tokenType: 'Bearer' as const,
+  };
+  const tokenCredential = { tokenId: 'id_1', tokenSecret: 'secret_1' };
+
+  beforeEach(async () => {
+    testConfigDir = await mkdtemp(join(tmpdir(), 'mux-cli-oauth-config-'));
+    originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
+    process.env.XDG_CONFIG_HOME = testConfigDir;
+  });
+
+  afterEach(async () => {
+    if (originalXdgConfigHome === undefined) {
+      delete process.env.XDG_CONFIG_HOME;
+    } else {
+      process.env.XDG_CONFIG_HOME = originalXdgConfigHome;
+    }
+    await rm(testConfigDir, { recursive: true, force: true });
+  });
+
+  describe('reading historical entry shapes', () => {
+    it('reads a pre-OAuth flat entry as a token block', async () => {
+      // Written by a released version of the CLI: no discriminator, no nesting.
+      await Bun.write(
+        getConfigPath(),
+        JSON.stringify({
+          environments: {
+            production: {
+              tokenId: 'legacy_id',
+              tokenSecret: 'legacy_secret',
+              environmentId: 'env_legacy',
+              signingKeyId: 'key_legacy',
+            },
+          },
+          defaultEnvironment: 'production',
+        }),
+      );
+
+      const env = await getEnvironment('production');
+
+      expect(env?.token).toEqual({
+        tokenId: 'legacy_id',
+        tokenSecret: 'legacy_secret',
+      });
+      expect(env?.environmentId).toBe('env_legacy');
+      expect(env?.signingKeyId).toBe('key_legacy');
+      expect(getEnvironmentAuthType(env as Environment)).toBe('token');
+    });
+
+    it('reads a flat type: oauth entry as an oauth block', async () => {
+      await Bun.write(
+        getConfigPath(),
+        JSON.stringify({
+          environments: {
+            'acme-production': {
+              type: 'oauth',
+              accessToken: 'access_1',
+              refreshToken: 'refresh_1',
+              expiresAt: 1_800_000_000,
+              environmentId: 'env_123',
+              organizationName: 'Acme Inc',
+            },
+          },
+        }),
+      );
+
+      const env = await getEnvironment('acme-production');
+
+      expect(env?.oauth?.accessToken).toBe('access_1');
+      expect(env?.organizationName).toBe('Acme Inc');
+      expect(isOAuthEnvironment(env as Environment)).toBe(true);
+    });
+  });
+
+  describe('setCredential', () => {
+    it('stores a credential block and environment fields together', async () => {
+      await setCredential('acme-production', 'oauth', oauthCredential, {
+        environmentId: 'env_123',
+        organizationName: 'Acme Inc',
+      });
+
+      const env = await getEnvironment('acme-production');
+      expect(env?.oauth).toEqual(oauthCredential);
+      expect(env?.environmentId).toBe('env_123');
+      expect(env?.organizationName).toBe('Acme Inc');
+    });
+
+    it('lets one environment hold both credential kinds', async () => {
+      await setCredential('acme-production', 'token', tokenCredential, {
+        environmentId: 'env_123',
+      });
+      await setCredential('acme-production', 'oauth', oauthCredential);
+
+      const env = await getEnvironment('acme-production');
+      expect(env?.token).toEqual(tokenCredential);
+      expect(env?.oauth).toEqual(oauthCredential);
+      // OAuth is preferred when both are present.
+      expect(getEnvironmentAuthType(env as Environment)).toBe('oauth');
+    });
+
+    it('does not disturb environment-bound state when adding a credential', async () => {
+      await setCredential('acme-production', 'token', tokenCredential, {
+        signingKeyId: 'key_1',
+        signingPrivateKey: 'private_1',
+        forwardUrl: 'http://localhost:3000/webhooks',
+      });
+      await setCredential('acme-production', 'oauth', oauthCredential);
+
+      const env = await getEnvironment('acme-production');
+      expect(env?.signingKeyId).toBe('key_1');
+      expect(env?.signingPrivateKey).toBe('private_1');
+      expect(env?.forwardUrl).toBe('http://localhost:3000/webhooks');
+    });
+
+    it('replaces the same block rather than merging into it', async () => {
+      await setCredential('acme-production', 'oauth', oauthCredential);
+      await setCredential('acme-production', 'oauth', {
+        accessToken: 'access_2',
+        refreshToken: 'refresh_2',
+        expiresAt: 1_900_000_000,
+      });
+
+      const env = await getEnvironment('acme-production');
+      expect(env?.oauth?.accessToken).toBe('access_2');
+      // The old scope must not survive onto a differently-scoped grant.
+      expect(env?.oauth?.scope).toBeUndefined();
+    });
+
+    it('sets the first environment as the default', async () => {
+      await setCredential('acme-production', 'oauth', oauthCredential);
+
+      expect((await readConfig())?.defaultEnvironment).toBe('acme-production');
+    });
+
+    it('keeps the restrictive file mode for token material', async () => {
+      await setCredential('acme-production', 'oauth', oauthCredential);
+
+      expect(statSync(getConfigPath()).mode & 0o777).toBe(0o600);
+    });
+  });
+
+  describe('flagCredential', () => {
+    it('records a failure on one block without touching the other', async () => {
+      await setCredential('acme-production', 'token', tokenCredential);
+      await setCredential('acme-production', 'oauth', oauthCredential);
+
+      await flagCredential('acme-production', 'oauth', {
+        code: 'invalid_grant',
+        at: '2026-08-14T00:00:00Z',
+      });
+
+      const env = await getEnvironment('acme-production');
+      expect(env?.oauth?.lastError?.code).toBe('invalid_grant');
+      expect(env?.token?.lastError).toBeUndefined();
+      // Flagging is not deleting: the credential is still there to inspect.
+      expect(env?.oauth?.refreshToken).toBe('refresh_1');
+      // And the healthy token pair becomes the preferred credential.
+      expect(getEnvironmentAuthType(env as Environment)).toBe('token');
+    });
+
+    it('clears a previous failure when passed null', async () => {
+      await setCredential('acme-production', 'oauth', oauthCredential);
+      await flagCredential('acme-production', 'oauth', {
+        code: 'invalid_grant',
+        at: 'now',
+      });
+
+      await flagCredential('acme-production', 'oauth', null);
+
+      expect(
+        (await getEnvironment('acme-production'))?.oauth?.lastError,
+      ).toBeUndefined();
+    });
+
+    it('is a no-op for an unknown environment', async () => {
+      await flagCredential('absent', 'oauth', { code: 'x', at: 'now' });
+
+      expect(await readConfig()).toBeNull();
+    });
+  });
+
+  describe('removeCredential', () => {
+    it('removes one block and keeps the environment and its other credential', async () => {
+      await setCredential('acme-production', 'token', tokenCredential, {
+        environmentId: 'env_123',
+      });
+      await setCredential('acme-production', 'oauth', oauthCredential);
+
+      expect(await removeCredential('acme-production', 'oauth')).toBe(true);
+
+      const env = await getEnvironment('acme-production');
+      expect(env?.oauth).toBeUndefined();
+      expect(env?.token).toEqual(tokenCredential);
+      expect(env?.environmentId).toBe('env_123');
+    });
+
+    it('reports false when the block is not there', async () => {
+      await setCredential('acme-production', 'token', tokenCredential);
+
+      expect(await removeCredential('acme-production', 'oauth')).toBe(false);
+    });
+  });
+
+  describe('findEnvironmentByEnvironmentId', () => {
+    it('finds an entry by Mux environment id regardless of its name', async () => {
+      await setCredential('some-name', 'oauth', oauthCredential, {
+        environmentId: 'env_123',
+      });
+
+      expect((await findEnvironmentByEnvironmentId('env_123'))?.name).toBe(
+        'some-name',
+      );
+    });
+
+    it('returns null when no entry matches', async () => {
+      await setCredential('some-name', 'oauth', oauthCredential, {
+        environmentId: 'env_123',
+      });
+
+      expect(await findEnvironmentByEnvironmentId('env_absent')).toBeNull();
+    });
+
+    it('returns null when no config exists', async () => {
+      expect(await findEnvironmentByEnvironmentId('env_123')).toBeNull();
+    });
+  });
+
+  describe('atomic writes', () => {
+    it('never leaves a partially written config behind', async () => {
+      await setCredential('acme-production', 'oauth', oauthCredential);
+
+      await Promise.all(
+        Array.from({ length: 12 }, (_, i) =>
+          setCredential(`env-${i}`, 'token', {
+            tokenId: `id_${i}`,
+            tokenSecret: `secret_${i}`,
+          }),
+        ),
+      );
+
+      // A torn write would surface as invalid JSON here.
+      const config = await readConfig();
+      expect(config).not.toBeNull();
+      expect(config?.environments['acme-production']).toBeDefined();
+    });
+
+    it('leaves no temporary files in the config directory', async () => {
+      await setCredential('acme-production', 'oauth', oauthCredential);
+
+      expect(readdirSync(`${testConfigDir}/mux`)).toEqual(['config.json']);
     });
   });
 });

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,21 +1,50 @@
+import { randomBytes } from 'node:crypto';
 import { existsSync } from 'node:fs';
-import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, rename, unlink, writeFile } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import { getConfigPath } from './xdg.ts';
 
-export interface Environment {
-  tokenId: string;
-  tokenSecret: string;
-  environmentId?: string;
-  baseUrl?: string;
-  signingKeyId?: string;
-  signingPrivateKey?: string;
-  forwardUrl?: string;
-}
+export type {
+  CredentialError,
+  CredentialKind,
+  Environment,
+  OAuthCredentials,
+  TokenCredentials,
+} from './credentials.ts';
+
+import {
+  type CredentialError,
+  type CredentialKind,
+  type Environment,
+  getPreferredCredential,
+  normalizeEnvironment,
+  flagCredential as withFlag,
+} from './credentials.ts';
+
+/**
+ * Partial update to an environment. Credential blocks are replaced wholesale by
+ * `setCredential`; this covers the environment-level fields.
+ */
+export type EnvironmentUpdate = Partial<Omit<Environment, 'oauth' | 'token'>> &
+  Partial<Pick<Environment, 'oauth' | 'token'>>;
 
 export interface Config {
   environments: Record<string, Environment>;
   defaultEnvironment?: string;
+}
+
+/** Whether an environment's preferred credential is an OAuth login. */
+export function isOAuthEnvironment(environment: Environment): boolean {
+  return getPreferredCredential(environment)?.kind === 'oauth';
+}
+
+/** The credential kind a request would use for this environment. */
+export function getEnvironmentAuthType(
+  environment: Environment,
+): CredentialKind {
+  // An entry with no credentials at all still has to render as something;
+  // 'token' matches how a type-less legacy entry has always been read.
+  return getPreferredCredential(environment)?.kind ?? 'token';
 }
 
 /**
@@ -28,29 +57,49 @@ export async function readConfig(): Promise<Config | null> {
     return null;
   }
 
+  let parsed: Config;
   try {
     const content = await readFile(configPath, 'utf-8');
-    return JSON.parse(content);
+    parsed = JSON.parse(content);
   } catch (error) {
     throw new Error(`Failed to read config: ${error}`);
   }
+
+  // Normalize on read so the rest of the CLI only ever sees the nested
+  // credential shape. Older flat entries keep working untouched on disk until
+  // something writes them back.
+  const environments: Record<string, Environment> = {};
+  for (const [name, environment] of Object.entries(parsed.environments ?? {})) {
+    environments[name] = normalizeEnvironment(environment);
+  }
+
+  return { ...parsed, environments };
 }
 
 /**
- * Write the config file, creating the directory if needed
+ * Write the config file, creating the directory if needed.
+ *
+ * The write is atomic: content goes to a temporary file in the same directory
+ * and is then renamed over the target. Token refresh can run concurrently with
+ * other invocations, and a reader must never observe a half-written config.
  */
 export async function writeConfig(config: Config): Promise<void> {
   const configPath = getConfigPath();
   const configDir = dirname(configPath);
+  // Same directory, so the rename stays within one filesystem; pid keeps
+  // concurrent writers from clobbering each other's temporary file.
+  const tempPath = `${configPath}.tmp-${process.pid}-${randomBytes(4).toString('hex')}`;
 
   try {
     // Create directory if needed - recursive: true makes this idempotent
     await mkdir(configDir, { recursive: true, mode: 0o700 });
 
-    await writeFile(configPath, JSON.stringify(config, null, 2), {
+    await writeFile(tempPath, JSON.stringify(config, null, 2), {
       mode: 0o600, // Only readable/writable by owner
     });
+    await rename(tempPath, configPath);
   } catch (error) {
+    await unlink(tempPath).catch(() => {});
     throw new Error(`Failed to write config: ${error}`);
   }
 }
@@ -93,14 +142,99 @@ export async function setEnvironment(
  */
 export async function updateEnvironment(
   name: string,
-  updates: Partial<Environment>,
+  updates: EnvironmentUpdate,
 ): Promise<void> {
   const config = await readConfig();
   if (!config || !config.environments[name]) {
     throw new Error(`Environment "${name}" does not exist`);
   }
-  config.environments[name] = { ...config.environments[name], ...updates };
+  config.environments[name] = {
+    ...config.environments[name],
+    ...updates,
+  };
   await writeConfig(config);
+}
+
+/**
+ * Save one credential block, leaving the other and every environment-level
+ * field untouched. This is what lets a single environment hold both an OAuth
+ * login and an access token pair.
+ */
+export async function setCredential(
+  name: string,
+  kind: CredentialKind,
+  credential: NonNullable<Environment['oauth' | 'token']>,
+  environmentFields: Partial<Omit<Environment, 'oauth' | 'token'>> = {},
+): Promise<void> {
+  const config = (await readConfig()) || { environments: {} };
+  const existing = config.environments[name] ?? {};
+
+  config.environments[name] = {
+    ...existing,
+    ...environmentFields,
+    [kind]: credential,
+  } as Environment;
+
+  if (Object.keys(config.environments).length === 1) {
+    config.defaultEnvironment = name;
+  }
+
+  await writeConfig(config);
+}
+
+/**
+ * Record or clear a credential failure. Never deletes the credential: removing
+ * it is the user's call, and a flagged block still lets `mux auth status`
+ * explain what happened.
+ */
+export async function flagCredential(
+  name: string,
+  kind: CredentialKind,
+  error: CredentialError | null,
+): Promise<void> {
+  const config = await readConfig();
+  if (!config?.environments[name]) return;
+
+  config.environments[name] = withFlag(config.environments[name], kind, error);
+  await writeConfig(config);
+}
+
+/**
+ * Remove a single credential block, keeping the environment (and its other
+ * credential) when one remains. Returns false when the entry or block is absent.
+ */
+export async function removeCredential(
+  name: string,
+  kind: CredentialKind,
+): Promise<boolean> {
+  const config = await readConfig();
+  const existing = config?.environments[name];
+  if (!config || !existing?.[kind]) return false;
+
+  const { [kind]: _removed, ...rest } = existing;
+  config.environments[name] = rest;
+  await writeConfig(config);
+  return true;
+}
+
+/**
+ * Find the environment holding a given Mux environment id, whatever its local
+ * name. Re-login resolves an existing entry this way rather than by name, so
+ * logging in to a second environment adds an entry instead of overwriting one.
+ */
+export async function findEnvironmentByEnvironmentId(
+  environmentId: string,
+): Promise<{ name: string; environment: Environment } | null> {
+  const config = await readConfig();
+  if (!config) return null;
+
+  for (const [name, environment] of Object.entries(config.environments)) {
+    if (environment.environmentId === environmentId) {
+      return { name, environment };
+    }
+  }
+
+  return null;
 }
 
 /**

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -43,7 +43,7 @@ export function getEnvironmentAuthType(
   environment: Environment,
 ): CredentialKind {
   // An entry with no credentials at all still has to render as something;
-  // 'token' matches how a type-less legacy entry has always been read.
+  // 'token' matches how an entry with no explicit kind has always been read.
   return getPreferredCredential(environment)?.kind ?? 'token';
 }
 
@@ -66,8 +66,11 @@ export async function readConfig(): Promise<Config | null> {
   }
 
   // Normalize on read so the rest of the CLI only ever sees the nested
-  // credential shape. Older flat entries keep working untouched on disk until
-  // something writes them back.
+  // credential layout. Files written by earlier versions stay as they are on
+  // disk until something writes them back — and note that any write persists
+  // every entry in the current layout, including ones the command never
+  // touched, so an older CLI will read them as having no credentials. The
+  // credentials themselves are untouched, just relocated within the file.
   const environments: Record<string, Environment> = {};
   for (const [name, environment] of Object.entries(parsed.environments ?? {})) {
     environments[name] = normalizeEnvironment(environment);

--- a/src/lib/credentials.test.ts
+++ b/src/lib/credentials.test.ts
@@ -123,7 +123,7 @@ describe('environmentSettings', () => {
       signingKeyId: 'key_1',
       signingPrivateKey: 'private_1',
       forwardUrl: 'http://localhost:3000/webhooks',
-      baseUrl: 'https://api.staging.example',
+      baseUrl: 'https://api.custom.example',
       // Identity and credentials are not settings: they come from the grant or
       // the credential itself.
       environmentId: 'env_123',
@@ -136,14 +136,14 @@ describe('environmentSettings', () => {
       signingKeyId: 'key_1',
       signingPrivateKey: 'private_1',
       forwardUrl: 'http://localhost:3000/webhooks',
-      baseUrl: 'https://api.staging.example',
+      baseUrl: 'https://api.custom.example',
     });
   });
 
   it('includes the bound API host, which a re-login must not silently reset', () => {
     expect(
-      environmentSettings({ baseUrl: 'https://mux-proxy.internal.example' }),
-    ).toEqual({ baseUrl: 'https://mux-proxy.internal.example' });
+      environmentSettings({ baseUrl: 'https://api.custom.example' }),
+    ).toEqual({ baseUrl: 'https://api.custom.example' });
   });
 
   it('omits absent fields rather than writing undefined', () => {

--- a/src/lib/credentials.test.ts
+++ b/src/lib/credentials.test.ts
@@ -242,18 +242,14 @@ describe('summarizeEnvironment', () => {
     ).toBe('env_123');
   });
 
-  it('reports OAuth expiry in human terms', () => {
-    const soon = Math.floor(Date.now() / 1000) + 1800;
-    expect(
-      summarizeEnvironment({ oauth: { ...OAUTH, expiresAt: soon } }).expiry,
-    ).toBe('expires in 30m');
-  });
+  it('says nothing about expiry, which the CLI handles on its own', () => {
+    // An expiring access token is refreshed automatically, so surfacing it only
+    // invites the reader to act where there is nothing to do.
+    const summary = summarizeEnvironment({
+      oauth: { ...OAUTH, expiresAt: Math.floor(Date.now() / 1000) - 10 },
+    });
 
-  it('reports an expired token as refreshing on next use', () => {
-    const past = Math.floor(Date.now() / 1000) - 10;
-    expect(
-      summarizeEnvironment({ oauth: { ...OAUTH, expiresAt: past } }).expiry,
-    ).toMatch(/expired/i);
+    expect(JSON.stringify(summary)).not.toMatch(/expire/i);
   });
 
   it('surfaces a flagged failure ahead of expiry', () => {

--- a/src/lib/credentials.test.ts
+++ b/src/lib/credentials.test.ts
@@ -1,0 +1,274 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  type Environment,
+  flagCredential,
+  getPreferredCredential,
+  hasOAuth,
+  hasTokenPair,
+  normalizeEnvironment,
+  summarizeEnvironment,
+} from './credentials.ts';
+
+const OAUTH = {
+  accessToken: 'access_1',
+  refreshToken: 'refresh_1',
+  expiresAt: 1_900_000_000,
+};
+const PAIR = { tokenId: 'id_1', tokenSecret: 'secret_1' };
+
+describe('normalizeEnvironment', () => {
+  it('reads a pre-OAuth flat entry as a token block', () => {
+    // Configs written before any OAuth support: no discriminator at all.
+    const normalized = normalizeEnvironment({
+      tokenId: 'id_1',
+      tokenSecret: 'secret_1',
+      environmentId: 'env_123',
+      signingKeyId: 'key_1',
+    });
+
+    expect(normalized.token).toEqual(PAIR);
+    expect(normalized.oauth).toBeUndefined();
+    expect(normalized.environmentId).toBe('env_123');
+    expect(normalized.signingKeyId).toBe('key_1');
+  });
+
+  it('reads a flat entry tagged type: token as a token block', () => {
+    const normalized = normalizeEnvironment({
+      type: 'token',
+      tokenId: 'id_1',
+      tokenSecret: 'secret_1',
+    });
+
+    expect(normalized.token).toEqual(PAIR);
+  });
+
+  it('reads a flat type: oauth entry as an oauth block', () => {
+    const normalized = normalizeEnvironment({
+      type: 'oauth',
+      accessToken: 'access_1',
+      refreshToken: 'refresh_1',
+      expiresAt: 1_900_000_000,
+      scope: 'video:read',
+      tokenType: 'Bearer',
+      environmentId: 'env_123',
+      environmentName: 'Production',
+      organizationName: 'Acme Inc',
+    });
+
+    expect(normalized.oauth).toEqual({
+      ...OAUTH,
+      scope: 'video:read',
+      tokenType: 'Bearer',
+    });
+    expect(normalized.token).toBeUndefined();
+    expect(normalized.environmentName).toBe('Production');
+    expect(normalized.organizationName).toBe('Acme Inc');
+  });
+
+  it('leaves an already-nested entry untouched', () => {
+    const entry: Environment = {
+      environmentId: 'env_123',
+      oauth: OAUTH,
+      token: PAIR,
+    };
+
+    expect(normalizeEnvironment(entry)).toEqual(entry);
+  });
+
+  it('drops the legacy discriminator and flat credential fields', () => {
+    const normalized = normalizeEnvironment({
+      type: 'oauth',
+      accessToken: 'access_1',
+      refreshToken: 'refresh_1',
+      expiresAt: 1,
+    }) as Record<string, unknown>;
+
+    expect(normalized.type).toBeUndefined();
+    expect(normalized.accessToken).toBeUndefined();
+    expect(normalized.refreshToken).toBeUndefined();
+    expect(normalized.expiresAt).toBeUndefined();
+  });
+
+  it('keeps both blocks when a flat entry somehow carries both', () => {
+    const normalized = normalizeEnvironment({
+      tokenId: 'id_1',
+      tokenSecret: 'secret_1',
+      accessToken: 'access_1',
+      refreshToken: 'refresh_1',
+      expiresAt: 1_900_000_000,
+    });
+
+    expect(normalized.token).toEqual(PAIR);
+    expect(normalized.oauth).toEqual(OAUTH);
+  });
+
+  it('produces an entry with no credentials rather than throwing on junk', () => {
+    const normalized = normalizeEnvironment({ environmentId: 'env_123' });
+
+    expect(normalized.oauth).toBeUndefined();
+    expect(normalized.token).toBeUndefined();
+    expect(normalized.environmentId).toBe('env_123');
+  });
+
+  it('ignores a partial token pair', () => {
+    // Half a pair cannot authenticate anything, so it is not a credential.
+    expect(normalizeEnvironment({ tokenId: 'id_1' }).token).toBeUndefined();
+  });
+});
+
+describe('getPreferredCredential', () => {
+  it('prefers OAuth when both are present', () => {
+    // OAuth goes stale unless refreshed, so the CLI must exercise it rather
+    // than quietly living on the token pair.
+    const preferred = getPreferredCredential({ oauth: OAUTH, token: PAIR });
+
+    expect(preferred?.kind).toBe('oauth');
+  });
+
+  it('uses the token pair when there is no OAuth block', () => {
+    expect(getPreferredCredential({ token: PAIR })?.kind).toBe('token');
+  });
+
+  it('uses OAuth when there is no token pair', () => {
+    expect(getPreferredCredential({ oauth: OAUTH })?.kind).toBe('oauth');
+  });
+
+  it('falls back to the token pair when OAuth is flagged dead', () => {
+    const preferred = getPreferredCredential({
+      oauth: { ...OAUTH, lastError: { code: 'invalid_grant', at: 'now' } },
+      token: PAIR,
+    });
+
+    expect(preferred?.kind).toBe('token');
+  });
+
+  it('still returns flagged OAuth when it is the only credential', () => {
+    // Better to try and fail with a real API error than to claim there are no
+    // credentials at all.
+    const preferred = getPreferredCredential({
+      oauth: { ...OAUTH, lastError: { code: 'invalid_grant', at: 'now' } },
+    });
+
+    expect(preferred?.kind).toBe('oauth');
+  });
+
+  it('prefers OAuth over a flagged token pair', () => {
+    const preferred = getPreferredCredential({
+      oauth: OAUTH,
+      token: { ...PAIR, lastError: { code: '401', at: 'now' } },
+    });
+
+    expect(preferred?.kind).toBe('oauth');
+  });
+
+  it('returns null when an entry holds no credentials', () => {
+    expect(getPreferredCredential({ environmentId: 'env_123' })).toBeNull();
+  });
+});
+
+describe('hasOAuth / hasTokenPair', () => {
+  it('detect each block independently', () => {
+    expect(hasOAuth({ oauth: OAUTH })).toBe(true);
+    expect(hasOAuth({ token: PAIR })).toBe(false);
+    expect(hasTokenPair({ token: PAIR })).toBe(true);
+    expect(hasTokenPair({ oauth: OAUTH })).toBe(false);
+  });
+});
+
+describe('flagCredential', () => {
+  it('records the failure on the named block without touching the other', () => {
+    const flagged = flagCredential({ oauth: OAUTH, token: PAIR }, 'oauth', {
+      code: 'invalid_grant',
+      at: '2026-08-14T00:00:00Z',
+    });
+
+    expect(flagged.oauth?.lastError?.code).toBe('invalid_grant');
+    expect(flagged.token?.lastError).toBeUndefined();
+    // The credential itself is preserved: flagging is not deleting.
+    expect(flagged.oauth?.refreshToken).toBe('refresh_1');
+  });
+
+  it('is a no-op when the block is absent', () => {
+    const entry: Environment = { token: PAIR };
+
+    expect(flagCredential(entry, 'oauth', { code: 'x', at: 'now' })).toEqual(
+      entry,
+    );
+  });
+
+  it('clears a previous error when passed null', () => {
+    const flagged = flagCredential(
+      { oauth: { ...OAUTH, lastError: { code: 'invalid_grant', at: 'now' } } },
+      'oauth',
+      null,
+    );
+
+    expect(flagged.oauth?.lastError).toBeUndefined();
+  });
+});
+
+describe('summarizeEnvironment', () => {
+  it('lists every credential an environment holds, preferred first', () => {
+    const summary = summarizeEnvironment({ oauth: OAUTH, token: PAIR });
+
+    expect(summary.kinds).toEqual(['oauth', 'token']);
+    expect(summary.preferred).toBe('oauth');
+  });
+
+  it('reports the identity for display', () => {
+    const summary = summarizeEnvironment({
+      oauth: OAUTH,
+      organizationName: 'Acme Inc',
+      environmentName: 'Production',
+      environmentId: 'env_123',
+    });
+
+    expect(summary.identity).toBe('Acme Inc / Production');
+  });
+
+  it('falls back to the organization alone when there is no environment name', () => {
+    // Forward-looking: grants may eventually be scoped to an organization only.
+    const summary = summarizeEnvironment({
+      oauth: OAUTH,
+      organizationName: 'Acme Inc',
+    });
+
+    expect(summary.identity).toBe('Acme Inc');
+  });
+
+  it('falls back to the environment id when no names are stored', () => {
+    expect(
+      summarizeEnvironment({ token: PAIR, environmentId: 'env_123' }).identity,
+    ).toBe('env_123');
+  });
+
+  it('reports OAuth expiry in human terms', () => {
+    const soon = Math.floor(Date.now() / 1000) + 1800;
+    expect(
+      summarizeEnvironment({ oauth: { ...OAUTH, expiresAt: soon } }).expiry,
+    ).toBe('expires in 30m');
+  });
+
+  it('reports an expired token as refreshing on next use', () => {
+    const past = Math.floor(Date.now() / 1000) - 10;
+    expect(
+      summarizeEnvironment({ oauth: { ...OAUTH, expiresAt: past } }).expiry,
+    ).toMatch(/expired/i);
+  });
+
+  it('surfaces a flagged failure ahead of expiry', () => {
+    const summary = summarizeEnvironment({
+      oauth: {
+        ...OAUTH,
+        expiresAt: Math.floor(Date.now() / 1000) + 1800,
+        lastError: { code: 'invalid_grant', at: 'now' },
+      },
+    });
+
+    expect(summary.warning).toMatch(/invalid_grant|sign in again/i);
+  });
+
+  it('has no warning for healthy credentials', () => {
+    expect(summarizeEnvironment({ token: PAIR }).warning).toBeUndefined();
+  });
+});

--- a/src/lib/credentials.test.ts
+++ b/src/lib/credentials.test.ts
@@ -17,8 +17,8 @@ const OAUTH = {
 const PAIR = { tokenId: 'id_1', tokenSecret: 'secret_1' };
 
 describe('normalizeEnvironment', () => {
-  it('reads a pre-OAuth flat entry as a token block', () => {
-    // Configs written before any OAuth support: no discriminator at all.
+  it('reads a flat entry as a token block', () => {
+    // The layout every released version wrote: credentials at the top level.
     const normalized = normalizeEnvironment({
       tokenId: 'id_1',
       tokenSecret: 'secret_1',
@@ -75,7 +75,7 @@ describe('normalizeEnvironment', () => {
     expect(normalizeEnvironment(entry)).toEqual(entry);
   });
 
-  it('drops the legacy discriminator and flat credential fields', () => {
+  it('drops the discriminator and flat credential fields once nested', () => {
     const normalized = normalizeEnvironment({
       type: 'oauth',
       accessToken: 'access_1',

--- a/src/lib/credentials.test.ts
+++ b/src/lib/credentials.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'bun:test';
 import {
   type Environment,
+  environmentSettings,
   flagCredential,
   getPreferredCredential,
   hasOAuth,
@@ -113,6 +114,40 @@ describe('normalizeEnvironment', () => {
   it('ignores a partial token pair', () => {
     // Half a pair cannot authenticate anything, so it is not a credential.
     expect(normalizeEnvironment({ tokenId: 'id_1' }).token).toBeUndefined();
+  });
+});
+
+describe('environmentSettings', () => {
+  it('carries every setting that belongs to the environment', () => {
+    const settings = environmentSettings({
+      signingKeyId: 'key_1',
+      signingPrivateKey: 'private_1',
+      forwardUrl: 'http://localhost:3000/webhooks',
+      baseUrl: 'https://api.staging.example',
+      // Identity and credentials are not settings: they come from the grant or
+      // the credential itself.
+      environmentId: 'env_123',
+      organizationName: 'Acme Inc',
+      oauth: OAUTH,
+      token: PAIR,
+    });
+
+    expect(settings).toEqual({
+      signingKeyId: 'key_1',
+      signingPrivateKey: 'private_1',
+      forwardUrl: 'http://localhost:3000/webhooks',
+      baseUrl: 'https://api.staging.example',
+    });
+  });
+
+  it('includes the bound API host, which a re-login must not silently reset', () => {
+    expect(
+      environmentSettings({ baseUrl: 'https://mux-proxy.internal.example' }),
+    ).toEqual({ baseUrl: 'https://mux-proxy.internal.example' });
+  });
+
+  it('omits absent fields rather than writing undefined', () => {
+    expect(environmentSettings({ environmentId: 'env_123' })).toEqual({});
   });
 });
 

--- a/src/lib/credentials.ts
+++ b/src/lib/credentials.ts
@@ -194,20 +194,8 @@ export interface EnvironmentSummary {
   preferred: CredentialKind | null;
   /** "Organization / Environment", or the environment id, for display. */
   identity: string;
-  /** OAuth expiry in human terms, when an OAuth block is present. */
-  expiry?: string;
   /** A flagged failure worth showing the user. */
   warning?: string;
-}
-
-function describeExpiry(oauth: OAuthCredentials): string {
-  if (!oauth.expiresAt) return 'expiry unknown, refreshes on use';
-
-  const seconds = oauth.expiresAt - Math.floor(Date.now() / 1000);
-  if (seconds <= 0) return 'expired, refreshes on use';
-  if (seconds < 60) return `expires in ${seconds}s`;
-  if (seconds < 3600) return `expires in ${Math.floor(seconds / 60)}m`;
-  return `expires in ${Math.floor(seconds / 3600)}h`;
 }
 
 /** Everything `auth status` and `env list` need to render one environment. */
@@ -238,7 +226,6 @@ export function summarizeEnvironment(
     kinds,
     preferred: preferred?.kind ?? null,
     identity,
-    ...(environment.oauth && { expiry: describeExpiry(environment.oauth) }),
     ...(failure && {
       warning:
         failing === 'oauth'

--- a/src/lib/credentials.ts
+++ b/src/lib/credentials.ts
@@ -148,6 +148,27 @@ export function normalizeEnvironment(raw: unknown): Environment {
 }
 
 /**
+ * The settings that describe an *environment* rather than a credential: they
+ * survive re-login onto the same environment, and must never follow a name onto
+ * a different one.
+ *
+ * Defined once because both login paths rewrite whole entries, so a field missing
+ * from this list is silently dropped on save.
+ */
+export function environmentSettings(
+  environment: Environment,
+): Partial<Environment> {
+  return {
+    ...(environment.signingKeyId && { signingKeyId: environment.signingKeyId }),
+    ...(environment.signingPrivateKey && {
+      signingPrivateKey: environment.signingPrivateKey,
+    }),
+    ...(environment.forwardUrl && { forwardUrl: environment.forwardUrl }),
+    ...(environment.baseUrl && { baseUrl: environment.baseUrl }),
+  };
+}
+
+/**
  * The credential a request should use. OAuth wins, except when it is flagged as
  * failing and a token pair is available to fall back to. A flagged credential
  * that is the only one present is still returned: a real API error is more

--- a/src/lib/credentials.ts
+++ b/src/lib/credentials.ts
@@ -1,0 +1,244 @@
+/**
+ * The credential model for a stored Mux environment.
+ *
+ * One environment can be reachable more than one way: a Mux API access token
+ * pair saved for CI, and an OAuth login saved by `mux login`. Both are kept, in
+ * separate blocks, and OAuth is preferred when present — OAuth credentials go
+ * stale unless they are exercised and refreshed, so quietly living on the token
+ * pair would leave a rotting login behind.
+ *
+ * Credential shape is defined here rather than in config.ts so that reasoning
+ * about "which credential" stays separate from reading and writing files.
+ */
+
+/** Why a credential last failed in a way retrying will not fix. */
+export interface CredentialError {
+  /** OAuth error code, HTTP status, or another short machine-readable tag. */
+  code: string;
+  /** ISO 8601 timestamp. */
+  at: string;
+  message?: string;
+}
+
+/** An OAuth login: bearer access token plus the refresh token that renews it. */
+export interface OAuthCredentials {
+  accessToken: string;
+  refreshToken: string;
+  /** Absolute access token expiry, epoch seconds. */
+  expiresAt: number;
+  scope?: string;
+  tokenType?: 'Bearer';
+  lastError?: CredentialError;
+}
+
+/** A Mux API access token pair, sent as Basic auth. */
+export interface TokenCredentials {
+  tokenId: string;
+  tokenSecret: string;
+  lastError?: CredentialError;
+}
+
+/**
+ * A stored environment: identity and environment-bound settings, plus whichever
+ * credentials are held for it.
+ */
+export interface Environment {
+  /** Mux environment id, the key for environment-scoped local state. */
+  environmentId?: string;
+  environmentName?: string;
+  organizationId?: string;
+  organizationName?: string;
+  baseUrl?: string;
+  signingKeyId?: string;
+  signingPrivateKey?: string;
+  forwardUrl?: string;
+  oauth?: OAuthCredentials;
+  token?: TokenCredentials;
+}
+
+export type CredentialKind = 'oauth' | 'token';
+
+export type PreferredCredential =
+  | { kind: 'oauth'; oauth: OAuthCredentials }
+  | { kind: 'token'; token: TokenCredentials };
+
+/** Environment-level fields, i.e. everything that is not a credential block. */
+const ENVIRONMENT_FIELDS = [
+  'environmentId',
+  'environmentName',
+  'organizationId',
+  'organizationName',
+  'baseUrl',
+  'signingKeyId',
+  'signingPrivateKey',
+  'forwardUrl',
+] as const;
+
+export function hasOAuth(environment: Environment): boolean {
+  return Boolean(environment.oauth?.accessToken);
+}
+
+export function hasTokenPair(environment: Environment): boolean {
+  return Boolean(environment.token?.tokenId && environment.token?.tokenSecret);
+}
+
+/**
+ * Read any historical entry shape into the nested form.
+ *
+ * Three shapes exist in the wild: pre-OAuth flat entries with `tokenId` /
+ * `tokenSecret` and no discriminator, flat entries tagged `type: 'token'` or
+ * `type: 'oauth'`, and the current nested form. Normalizing on read means there
+ * is no migration step and no config version to track.
+ */
+export function normalizeEnvironment(raw: unknown): Environment {
+  const entry = (raw ?? {}) as Record<string, unknown>;
+  const normalized: Environment = {};
+
+  for (const field of ENVIRONMENT_FIELDS) {
+    const value = entry[field];
+    if (typeof value === 'string') {
+      normalized[field] = value;
+    }
+  }
+
+  // Already nested: trust the blocks as written.
+  if (entry.oauth && typeof entry.oauth === 'object') {
+    normalized.oauth = entry.oauth as OAuthCredentials;
+  }
+  if (entry.token && typeof entry.token === 'object') {
+    normalized.token = entry.token as TokenCredentials;
+  }
+
+  // Flat token pair. Half a pair authenticates nothing, so both are required.
+  if (
+    !normalized.token &&
+    typeof entry.tokenId === 'string' &&
+    typeof entry.tokenSecret === 'string'
+  ) {
+    normalized.token = {
+      tokenId: entry.tokenId,
+      tokenSecret: entry.tokenSecret,
+    };
+  }
+
+  // Flat OAuth credentials, as written by earlier builds of this feature.
+  if (
+    !normalized.oauth &&
+    typeof entry.accessToken === 'string' &&
+    typeof entry.refreshToken === 'string'
+  ) {
+    normalized.oauth = {
+      accessToken: entry.accessToken,
+      refreshToken: entry.refreshToken,
+      expiresAt: typeof entry.expiresAt === 'number' ? entry.expiresAt : 0,
+      ...(typeof entry.scope === 'string' && { scope: entry.scope }),
+      ...(entry.tokenType === 'Bearer' && { tokenType: 'Bearer' as const }),
+      ...(entry.lastError && typeof entry.lastError === 'object'
+        ? { lastError: entry.lastError as CredentialError }
+        : {}),
+    };
+  }
+
+  return normalized;
+}
+
+/**
+ * The credential a request should use. OAuth wins, except when it is flagged as
+ * failing and a token pair is available to fall back to. A flagged credential
+ * that is the only one present is still returned: a real API error is more
+ * useful than claiming there are no credentials.
+ */
+export function getPreferredCredential(
+  environment: Environment,
+): PreferredCredential | null {
+  const oauth = hasOAuth(environment) ? environment.oauth : undefined;
+  const token = hasTokenPair(environment) ? environment.token : undefined;
+
+  if (oauth && !(oauth.lastError && token)) {
+    return { kind: 'oauth', oauth };
+  }
+  if (token) {
+    return { kind: 'token', token };
+  }
+  return oauth ? { kind: 'oauth', oauth } : null;
+}
+
+/**
+ * Record or clear a credential failure. Flagging never deletes the credential:
+ * the user decides whether to remove it, and a flagged block still lets
+ * `mux auth status` explain what went wrong.
+ */
+export function flagCredential(
+  environment: Environment,
+  kind: CredentialKind,
+  error: CredentialError | null,
+): Environment {
+  const block = environment[kind];
+  if (!block) return environment;
+
+  const { lastError: _dropped, ...rest } = block;
+  return {
+    ...environment,
+    [kind]: error ? { ...rest, lastError: error } : rest,
+  };
+}
+
+export interface EnvironmentSummary {
+  /** Credential kinds held, preferred first. */
+  kinds: CredentialKind[];
+  preferred: CredentialKind | null;
+  /** "Organization / Environment", or the environment id, for display. */
+  identity: string;
+  /** OAuth expiry in human terms, when an OAuth block is present. */
+  expiry?: string;
+  /** A flagged failure worth showing the user. */
+  warning?: string;
+}
+
+function describeExpiry(oauth: OAuthCredentials): string {
+  if (!oauth.expiresAt) return 'expiry unknown, refreshes on use';
+
+  const seconds = oauth.expiresAt - Math.floor(Date.now() / 1000);
+  if (seconds <= 0) return 'expired, refreshes on use';
+  if (seconds < 60) return `expires in ${seconds}s`;
+  if (seconds < 3600) return `expires in ${Math.floor(seconds / 60)}m`;
+  return `expires in ${Math.floor(seconds / 3600)}h`;
+}
+
+/** Everything `auth status` and `env list` need to render one environment. */
+export function summarizeEnvironment(
+  environment: Environment,
+): EnvironmentSummary {
+  const preferred = getPreferredCredential(environment);
+  const kinds: CredentialKind[] = [];
+  if (preferred) kinds.push(preferred.kind);
+  for (const kind of ['oauth', 'token'] as const) {
+    const present = kind === 'oauth' ? hasOAuth : hasTokenPair;
+    if (present(environment) && !kinds.includes(kind)) kinds.push(kind);
+  }
+
+  const identity =
+    [environment.organizationName, environment.environmentName]
+      .filter(Boolean)
+      .join(' / ') ||
+    environment.environmentId ||
+    '';
+
+  const failing = (['oauth', 'token'] as const).find(
+    (kind) => environment[kind]?.lastError,
+  );
+  const failure = failing ? environment[failing]?.lastError : undefined;
+
+  return {
+    kinds,
+    preferred: preferred?.kind ?? null,
+    identity,
+    ...(environment.oauth && { expiry: describeExpiry(environment.oauth) }),
+    ...(failure && {
+      warning:
+        failing === 'oauth'
+          ? `OAuth login failed (${failure.code}) — run 'mux login' to sign in again`
+          : `Access token failed (${failure.code}) — run 'mux login --interactive' to replace it`,
+    }),
+  };
+}

--- a/src/lib/credentials.ts
+++ b/src/lib/credentials.ts
@@ -83,12 +83,17 @@ export function hasTokenPair(environment: Environment): boolean {
 }
 
 /**
- * Read any historical entry shape into the nested form.
+ * Read either stored layout into the nested form.
  *
- * Three shapes exist in the wild: pre-OAuth flat entries with `tokenId` /
- * `tokenSecret` and no discriminator, flat entries tagged `type: 'token'` or
- * `type: 'oauth'`, and the current nested form. Normalizing on read means there
- * is no migration step and no config version to track.
+ * Released versions wrote credentials flat (`tokenId` / `tokenSecret` at the top
+ * level); this version nests them under `token` so an environment can also hold
+ * an OAuth login. Normalizing on read means there is no migration step and no
+ * config version to track, and an access token pair keeps working either way —
+ * only where it sits in the file changed.
+ *
+ * The `type` discriminator and flat OAuth fields handled below never appeared in
+ * a released build; they are tolerated so that anyone running an intermediate
+ * build of this branch is not stranded.
  */
 export function normalizeEnvironment(raw: unknown): Environment {
   const entry = (raw ?? {}) as Record<string, unknown>;

--- a/src/lib/mux.test.ts
+++ b/src/lib/mux.test.ts
@@ -21,6 +21,7 @@ import {
   DEFAULT_BASE_URL,
   getAuthContext,
   getMuxBaseUrl,
+  refreshActiveOAuthCredentials,
   resetEnvCredentialNotice,
   resolveActiveEnvironment,
 } from './mux.ts';
@@ -839,6 +840,66 @@ describe('OAuth credentials', () => {
       expect(client.authorizationToken).toBeNull();
       expect((await getAuthContext()).headers.Authorization).toBe(
         `Basic ${btoa('stored_id:stored_secret')}`,
+      );
+    });
+  });
+
+  describe('refreshActiveOAuthCredentials', () => {
+    // This is what `webhooks listen` calls on a mid-stream 401 before deciding
+    // whether to reconnect or fail.
+    it('refreshes the active OAuth login and reports that it did', async () => {
+      await storeOAuthEnvironment();
+      fetchSpy = spyOn(globalThis, 'fetch').mockImplementation((async (
+        input: string,
+      ) => {
+        if (String(input).includes('/.well-known/')) {
+          return new Response('not found', { status: 404 });
+        }
+        return new Response(
+          JSON.stringify({ access_token: 'access_2', expires_in: 3600 }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }) as unknown as typeof fetch);
+
+      expect(await refreshActiveOAuthCredentials()).toBe(true);
+      expect((await getAuthContext()).headers.Authorization).toBe(
+        'Bearer access_2',
+      );
+    });
+
+    it('reports false for an access token environment, so the caller stops', async () => {
+      await setEnvironment('ci-token', {
+        token: { tokenId: 'stored_id', tokenSecret: 'stored_secret' },
+      });
+
+      expect(await refreshActiveOAuthCredentials()).toBe(false);
+    });
+
+    it('reports false when env var credentials are in play', async () => {
+      // Nothing stored is being used, so there is nothing to refresh.
+      await storeOAuthEnvironment();
+      process.env.MUX_TOKEN_ID = 'env_token_id';
+      process.env.MUX_TOKEN_SECRET = 'env_token_secret';
+
+      expect(await refreshActiveOAuthCredentials()).toBe(false);
+    });
+
+    it('propagates a terminal refresh failure instead of reporting success', async () => {
+      await storeOAuthEnvironment();
+      fetchSpy = spyOn(globalThis, 'fetch').mockImplementation((async (
+        input: string,
+      ) => {
+        if (String(input).includes('/.well-known/')) {
+          return new Response('not found', { status: 404 });
+        }
+        return new Response(JSON.stringify({ error: 'invalid_grant' }), {
+          status: 400,
+          headers: { 'content-type': 'application/json' },
+        });
+      }) as unknown as typeof fetch);
+
+      await expect(refreshActiveOAuthCredentials()).rejects.toThrow(
+        /no longer valid/i,
       );
     });
   });

--- a/src/lib/mux.test.ts
+++ b/src/lib/mux.test.ts
@@ -10,7 +10,11 @@ import {
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { getCurrentEnvironment, setEnvironment } from './config.ts';
+import {
+  type Environment,
+  getCurrentEnvironment,
+  setEnvironment,
+} from './config.ts';
 import { setAgentMode, setJsonFlag } from './context.ts';
 import {
   createAuthenticatedMuxClient,
@@ -56,8 +60,7 @@ describe('getMuxBaseUrl', () => {
   it('should prefer MUX_BASE_URL env var over everything', async () => {
     process.env.MUX_BASE_URL = 'https://env-var.example.com';
     await setEnvironment('default', {
-      tokenId: 'id',
-      tokenSecret: 'secret',
+      token: { tokenId: 'id', tokenSecret: 'secret' },
       baseUrl: 'https://config.example.com',
     });
 
@@ -67,8 +70,7 @@ describe('getMuxBaseUrl', () => {
 
   it('should use config baseUrl when no env var is set', async () => {
     await setEnvironment('default', {
-      tokenId: 'id',
-      tokenSecret: 'secret',
+      token: { tokenId: 'id', tokenSecret: 'secret' },
       baseUrl: 'https://config.example.com',
     });
 
@@ -78,8 +80,7 @@ describe('getMuxBaseUrl', () => {
 
   it('should fall back to default when config has no baseUrl', async () => {
     await setEnvironment('default', {
-      tokenId: 'id',
-      tokenSecret: 'secret',
+      token: { tokenId: 'id', tokenSecret: 'secret' },
     });
 
     const env = await getCurrentEnvironment();
@@ -138,8 +139,7 @@ describe('auth fallback to environment variables', () => {
 
     it('prefers env vars over stored config (consistent with MUX_BASE_URL)', async () => {
       await setEnvironment('default', {
-        tokenId: 'stored_id',
-        tokenSecret: 'stored_secret',
+        token: { tokenId: 'stored_id', tokenSecret: 'stored_secret' },
       });
       process.env.MUX_TOKEN_ID = 'env_token_id';
       process.env.MUX_TOKEN_SECRET = 'env_token_secret';
@@ -152,8 +152,7 @@ describe('auth fallback to environment variables', () => {
 
     it('uses stored config when env vars are absent', async () => {
       await setEnvironment('default', {
-        tokenId: 'stored_id',
-        tokenSecret: 'stored_secret',
+        token: { tokenId: 'stored_id', tokenSecret: 'stored_secret' },
       });
 
       const { headers } = await getAuthContext();
@@ -164,8 +163,7 @@ describe('auth fallback to environment variables', () => {
 
     it('prints a one-time stderr notice when env vars shadow a stored login', async () => {
       await setEnvironment('default', {
-        tokenId: 'stored_id',
-        tokenSecret: 'stored_secret',
+        token: { tokenId: 'stored_id', tokenSecret: 'stored_secret' },
       });
       process.env.MUX_TOKEN_ID = 'env_token_id';
       process.env.MUX_TOKEN_SECRET = 'env_token_secret';
@@ -188,8 +186,7 @@ describe('auth fallback to environment variables', () => {
 
     it('suppresses the notice in agent mode', async () => {
       await setEnvironment('default', {
-        tokenId: 'stored_id',
-        tokenSecret: 'stored_secret',
+        token: { tokenId: 'stored_id', tokenSecret: 'stored_secret' },
       });
       process.env.MUX_TOKEN_ID = 'env_token_id';
       process.env.MUX_TOKEN_SECRET = 'env_token_secret';
@@ -209,8 +206,7 @@ describe('auth fallback to environment variables', () => {
 
     it('suppresses the notice when --json was passed', async () => {
       await setEnvironment('default', {
-        tokenId: 'stored_id',
-        tokenSecret: 'stored_secret',
+        token: { tokenId: 'stored_id', tokenSecret: 'stored_secret' },
       });
       process.env.MUX_TOKEN_ID = 'env_token_id';
       process.env.MUX_TOKEN_SECRET = 'env_token_secret';
@@ -246,8 +242,7 @@ describe('auth fallback to environment variables', () => {
 
     it('does not inherit the stored config baseUrl when credentials come from env vars', async () => {
       await setEnvironment('default', {
-        tokenId: 'stored_id',
-        tokenSecret: 'stored_secret',
+        token: { tokenId: 'stored_id', tokenSecret: 'stored_secret' },
         baseUrl: 'https://stored.example.com',
       });
       process.env.MUX_TOKEN_ID = 'env_token_id';
@@ -259,8 +254,7 @@ describe('auth fallback to environment variables', () => {
 
     it('uses the stored config baseUrl when credentials come from config', async () => {
       await setEnvironment('default', {
-        tokenId: 'stored_id',
-        tokenSecret: 'stored_secret',
+        token: { tokenId: 'stored_id', tokenSecret: 'stored_secret' },
         baseUrl: 'https://stored.example.com',
       });
 
@@ -321,8 +315,7 @@ describe('auth fallback to environment variables', () => {
 
     it('uses the stored environment without calling the API when env vars are absent', async () => {
       await setEnvironment('default', {
-        tokenId: 'stored_id',
-        tokenSecret: 'stored_secret',
+        token: { tokenId: 'stored_id', tokenSecret: 'stored_secret' },
         environmentId: 'env_stored_123',
       });
       fetchSpy = spyOn(globalThis, 'fetch').mockImplementation((async () => {
@@ -339,8 +332,7 @@ describe('auth fallback to environment variables', () => {
 
     it('falls back to the environment name when stored config has no environmentId', async () => {
       await setEnvironment('legacy', {
-        tokenId: 'stored_id',
-        tokenSecret: 'stored_secret',
+        token: { tokenId: 'stored_id', tokenSecret: 'stored_secret' },
       });
 
       const active = await resolveActiveEnvironment();
@@ -364,8 +356,7 @@ describe('auth fallback to environment variables', () => {
 
     it('returns the stored environment when env var credentials match it', async () => {
       await setEnvironment('default', {
-        tokenId: 'stored_id',
-        tokenSecret: 'stored_secret',
+        token: { tokenId: 'stored_id', tokenSecret: 'stored_secret' },
         environmentId: 'env_same_123',
       });
       process.env.MUX_TOKEN_ID = 'env_token_id';
@@ -381,13 +372,11 @@ describe('auth fallback to environment variables', () => {
 
     it('matches env var credentials against non-default stored environments', async () => {
       await setEnvironment('production', {
-        tokenId: 'prod_id',
-        tokenSecret: 'prod_secret',
+        token: { tokenId: 'prod_id', tokenSecret: 'prod_secret' },
         environmentId: 'env_prod_123',
       });
       await setEnvironment('staging', {
-        tokenId: 'staging_id',
-        tokenSecret: 'staging_secret',
+        token: { tokenId: 'staging_id', tokenSecret: 'staging_secret' },
         environmentId: 'env_staging_456',
       });
       process.env.MUX_TOKEN_ID = 'env_token_id';
@@ -403,13 +392,11 @@ describe('auth fallback to environment variables', () => {
 
     it('prefers the current environment when multiple stored environments match', async () => {
       await setEnvironment('prod-copy', {
-        tokenId: 'a_id',
-        tokenSecret: 'a_secret',
+        token: { tokenId: 'a_id', tokenSecret: 'a_secret' },
         environmentId: 'env_same_123',
       });
       await setEnvironment('prod', {
-        tokenId: 'b_id',
-        tokenSecret: 'b_secret',
+        token: { tokenId: 'b_id', tokenSecret: 'b_secret' },
         environmentId: 'env_same_123',
       });
       // prod-copy was added first, so it is the default/current environment
@@ -424,8 +411,7 @@ describe('auth fallback to environment variables', () => {
 
     it('drops the stored environment when env var credentials point elsewhere', async () => {
       await setEnvironment('default', {
-        tokenId: 'stored_id',
-        tokenSecret: 'stored_secret',
+        token: { tokenId: 'stored_id', tokenSecret: 'stored_secret' },
         environmentId: 'env_stored_123',
       });
       process.env.MUX_TOKEN_ID = 'env_token_id';
@@ -441,8 +427,7 @@ describe('auth fallback to environment variables', () => {
 
     it('drops the stored environment when it has no environmentId to compare', async () => {
       await setEnvironment('default', {
-        tokenId: 'stored_id',
-        tokenSecret: 'stored_secret',
+        token: { tokenId: 'stored_id', tokenSecret: 'stored_secret' },
       });
       process.env.MUX_TOKEN_ID = 'env_token_id';
       process.env.MUX_TOKEN_SECRET = 'env_token_secret';
@@ -455,8 +440,7 @@ describe('auth fallback to environment variables', () => {
 
     it('prints the shadow notice when env vars redirect away from a stored login', async () => {
       await setEnvironment('default', {
-        tokenId: 'stored_id',
-        tokenSecret: 'stored_secret',
+        token: { tokenId: 'stored_id', tokenSecret: 'stored_secret' },
         environmentId: 'env_stored_123',
       });
       process.env.MUX_TOKEN_ID = 'env_token_id';
@@ -496,8 +480,7 @@ describe('auth fallback to environment variables', () => {
 
     it('resolves the base URL from the credential source, not the stored config', async () => {
       await setEnvironment('default', {
-        tokenId: 'stored_id',
-        tokenSecret: 'stored_secret',
+        token: { tokenId: 'stored_id', tokenSecret: 'stored_secret' },
         environmentId: 'env_stored_123',
         baseUrl: 'https://stored.example.com',
       });
@@ -514,8 +497,7 @@ describe('auth fallback to environment variables', () => {
 
     it('returns the stored baseUrl when credentials come from config', async () => {
       await setEnvironment('default', {
-        tokenId: 'stored_id',
-        tokenSecret: 'stored_secret',
+        token: { tokenId: 'stored_id', tokenSecret: 'stored_secret' },
         environmentId: 'env_stored_123',
         baseUrl: 'https://stored.example.com',
       });
@@ -527,8 +509,7 @@ describe('auth fallback to environment variables', () => {
 
     it('skips whoami when env credentials byte-match a stored environment', async () => {
       await setEnvironment('default', {
-        tokenId: 'same_id',
-        tokenSecret: 'same_secret',
+        token: { tokenId: 'same_id', tokenSecret: 'same_secret' },
         environmentId: 'env_same_123',
       });
       process.env.MUX_TOKEN_ID = 'same_id';
@@ -547,13 +528,11 @@ describe('auth fallback to environment variables', () => {
 
     it('skips whoami when env credentials byte-match a non-default stored environment', async () => {
       await setEnvironment('production', {
-        tokenId: 'prod_id',
-        tokenSecret: 'prod_secret',
+        token: { tokenId: 'prod_id', tokenSecret: 'prod_secret' },
         environmentId: 'env_prod_123',
       });
       await setEnvironment('staging', {
-        tokenId: 'staging_id',
-        tokenSecret: 'staging_secret',
+        token: { tokenId: 'staging_id', tokenSecret: 'staging_secret' },
         environmentId: 'env_staging_456',
       });
       process.env.MUX_TOKEN_ID = 'staging_id';
@@ -571,8 +550,7 @@ describe('auth fallback to environment variables', () => {
 
     it('verifies a legacy byte-matching environment via whoami and still binds it', async () => {
       await setEnvironment('legacy', {
-        tokenId: 'same_id',
-        tokenSecret: 'same_secret',
+        token: { tokenId: 'same_id', tokenSecret: 'same_secret' },
       });
       process.env.MUX_TOKEN_ID = 'same_id';
       process.env.MUX_TOKEN_SECRET = 'same_secret';
@@ -622,6 +600,275 @@ describe('auth fallback to environment variables', () => {
 
     it('throws when no credentials are available anywhere', async () => {
       expect(resolveActiveEnvironment()).rejects.toThrow(/MUX_TOKEN_ID/);
+    });
+  });
+});
+
+describe('OAuth credentials', () => {
+  let testConfigDir: string;
+  let originalXdgConfigHome: string | undefined;
+  let savedEnv: Record<string, string | undefined>;
+  let fetchSpy: Mock<typeof fetch> | undefined;
+
+  const TOUCHED_ENV = [
+    'MUX_TOKEN_ID',
+    'MUX_TOKEN_SECRET',
+    'MUX_BASE_URL',
+    'MUX_AUTHORIZATION_TOKEN',
+    'MUX_OAUTH_CLIENT_ID',
+    'MUX_OAUTH_TOKEN_URL',
+  ] as const;
+
+  function nowSeconds(): number {
+    return Math.floor(Date.now() / 1000);
+  }
+
+  /** Store an OAuth login; overrides apply to the entry, not just the token. */
+  async function storeOAuthEnvironment(overrides: Partial<Environment> = {}) {
+    const { oauth, ...environmentFields } = overrides;
+    await setEnvironment('acme-production', {
+      oauth: {
+        accessToken: 'access_1',
+        refreshToken: 'refresh_1',
+        expiresAt: nowSeconds() + 3600,
+        tokenType: 'Bearer',
+        ...oauth,
+      },
+      environmentId: 'env_123',
+      environmentName: 'Production',
+      organizationId: 'org_123',
+      organizationName: 'Acme Inc',
+      ...environmentFields,
+    });
+  }
+
+  beforeEach(async () => {
+    testConfigDir = await mkdtemp(join(tmpdir(), 'mux-cli-oauth-mux-'));
+    originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
+    process.env.XDG_CONFIG_HOME = testConfigDir;
+
+    savedEnv = {};
+    for (const key of TOUCHED_ENV) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+    process.env.MUX_OAUTH_CLIENT_ID = 'test_client';
+    process.env.MUX_OAUTH_TOKEN_URL = 'https://api.test/oauth/token';
+    // Keep discovery's cache out of the real ~/.cache/mux.
+    process.env.XDG_CACHE_HOME = testConfigDir;
+
+    resetEnvCredentialNotice();
+    setAgentMode(false);
+    setJsonFlag(false);
+  });
+
+  afterEach(async () => {
+    if (originalXdgConfigHome === undefined) {
+      delete process.env.XDG_CONFIG_HOME;
+    } else {
+      process.env.XDG_CONFIG_HOME = originalXdgConfigHome;
+    }
+    for (const key of TOUCHED_ENV) {
+      if (savedEnv[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = savedEnv[key];
+      }
+    }
+    fetchSpy?.mockRestore();
+    fetchSpy = undefined;
+    resetEnvCredentialNotice();
+    setAgentMode(false);
+    setJsonFlag(false);
+    await rm(testConfigDir, { recursive: true, force: true });
+  });
+
+  describe('getAuthContext', () => {
+    it('sends the access token as a bearer credential', async () => {
+      await storeOAuthEnvironment();
+
+      const { headers } = await getAuthContext();
+
+      expect(headers.Authorization).toBe('Bearer access_1');
+    });
+
+    it('still sends Basic auth for access token environments', async () => {
+      await setEnvironment('ci-token', {
+        token: { tokenId: 'stored_id', tokenSecret: 'stored_secret' },
+      });
+
+      const { headers } = await getAuthContext();
+
+      expect(headers.Authorization).toBe(
+        `Basic ${btoa('stored_id:stored_secret')}`,
+      );
+    });
+
+    it('uses the stored base URL of an OAuth environment', async () => {
+      await storeOAuthEnvironment({ baseUrl: 'https://api.staging.test' });
+
+      expect((await getAuthContext()).baseUrl).toBe('https://api.staging.test');
+    });
+
+    it('lets MUX_TOKEN_ID/MUX_TOKEN_SECRET shadow an OAuth login', async () => {
+      await storeOAuthEnvironment();
+      process.env.MUX_TOKEN_ID = 'env_token_id';
+      process.env.MUX_TOKEN_SECRET = 'env_token_secret';
+
+      const { headers } = await getAuthContext();
+
+      expect(headers.Authorization).toBe(
+        `Basic ${btoa('env_token_id:env_token_secret')}`,
+      );
+    });
+
+    it('names the shadowed OAuth login once on stderr', async () => {
+      await storeOAuthEnvironment();
+      process.env.MUX_TOKEN_ID = 'env_token_id';
+      process.env.MUX_TOKEN_SECRET = 'env_token_secret';
+      const errorSpy = spyOn(console, 'error').mockImplementation(() => {});
+
+      try {
+        await getAuthContext();
+        await getAuthContext();
+
+        expect(errorSpy).toHaveBeenCalledTimes(1);
+        const message = String(errorSpy.mock.calls[0]?.[0]);
+        expect(message).toContain('acme-production');
+        expect(message).toContain('mux auth status');
+      } finally {
+        errorSpy.mockRestore();
+      }
+    });
+
+    it('suppresses the shadowing notice in agent mode', async () => {
+      await storeOAuthEnvironment();
+      process.env.MUX_TOKEN_ID = 'env_token_id';
+      process.env.MUX_TOKEN_SECRET = 'env_token_secret';
+      setAgentMode(true);
+      const errorSpy = spyOn(console, 'error').mockImplementation(() => {});
+
+      try {
+        await getAuthContext();
+
+        expect(errorSpy).not.toHaveBeenCalled();
+      } finally {
+        errorSpy.mockRestore();
+      }
+    });
+
+    it('refreshes an expiring access token before issuing the request', async () => {
+      await storeOAuthEnvironment({
+        oauth: { expiresAt: nowSeconds() + 30 } as never,
+      });
+      fetchSpy = spyOn(globalThis, 'fetch').mockImplementation((async (
+        input: string,
+      ) => {
+        // Discovery 404s, so endpoint resolution falls back to the configured
+        // defaults and the only other request is the refresh grant itself.
+        if (String(input).includes('/.well-known/')) {
+          return new Response('not found', { status: 404 });
+        }
+        return new Response(
+          JSON.stringify({
+            access_token: 'access_2',
+            refresh_token: 'refresh_2',
+            expires_in: 3600,
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }) as unknown as typeof fetch);
+
+      const { headers } = await getAuthContext();
+
+      expect(headers.Authorization).toBe('Bearer access_2');
+      const grantCalls = (fetchSpy?.mock.calls ?? []).filter(
+        (call) => !String(call[0]).includes('/.well-known/'),
+      );
+      expect(grantCalls).toHaveLength(1);
+    });
+
+    it('does not refresh a token that is still fresh', async () => {
+      await storeOAuthEnvironment({
+        oauth: { expiresAt: nowSeconds() + 3600 } as never,
+      });
+      fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(
+        (async () =>
+          new Response('{}', { status: 200 })) as unknown as typeof fetch,
+      );
+
+      await getAuthContext();
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('createAuthenticatedMuxClient', () => {
+    it('passes the access token as the SDK authorization token', async () => {
+      await storeOAuthEnvironment();
+
+      const client = await createAuthenticatedMuxClient();
+
+      expect(client.authorizationToken).toBe('access_1');
+      expect(client.tokenId).toBeNull();
+      expect(client.tokenSecret).toBeNull();
+    });
+
+    it('never passes both credential kinds to one client', async () => {
+      await setEnvironment('ci-token', {
+        token: { tokenId: 'stored_id', tokenSecret: 'stored_secret' },
+      });
+
+      const client = await createAuthenticatedMuxClient();
+
+      expect(client.tokenId).toBe('stored_id');
+      expect(client.tokenSecret).toBe('stored_secret');
+      // Left unset, the SDK would fall back to MUX_AUTHORIZATION_TOKEN and its
+      // bearer header would override the Basic credentials above.
+      expect(client.authorizationToken).toBeNull();
+    });
+
+    it('ignores an ambient MUX_AUTHORIZATION_TOKEN for a token pair login', async () => {
+      process.env.MUX_AUTHORIZATION_TOKEN = 'ambient_bearer';
+      await setEnvironment('ci-token', {
+        token: { tokenId: 'stored_id', tokenSecret: 'stored_secret' },
+      });
+
+      const client = await createAuthenticatedMuxClient();
+
+      expect(client.authorizationToken).toBeNull();
+      expect((await getAuthContext()).headers.Authorization).toBe(
+        `Basic ${btoa('stored_id:stored_secret')}`,
+      );
+    });
+  });
+
+  describe('resolveActiveEnvironment', () => {
+    it('resolves an OAuth environment without any network call', async () => {
+      await storeOAuthEnvironment();
+      fetchSpy = spyOn(globalThis, 'fetch').mockImplementation((async () => {
+        throw new Error('network should not be reached');
+      }) as unknown as typeof fetch);
+
+      const active = await resolveActiveEnvironment();
+
+      expect(active.environmentId).toBe('env_123');
+      expect(active.source).toBe('config');
+      expect(active.kind).toBe('oauth');
+      expect(active.stored?.name).toBe('acme-production');
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('reports the token kind for access token environments', async () => {
+      await setEnvironment('ci-token', {
+        token: { tokenId: 'stored_id', tokenSecret: 'stored_secret' },
+        environmentId: 'env_456',
+      });
+
+      const active = await resolveActiveEnvironment();
+
+      expect(active.kind).toBe('token');
+      expect(active.environmentId).toBe('env_456');
     });
   });
 });

--- a/src/lib/mux.test.ts
+++ b/src/lib/mux.test.ts
@@ -706,9 +706,9 @@ describe('OAuth credentials', () => {
     });
 
     it('uses the stored base URL of an OAuth environment', async () => {
-      await storeOAuthEnvironment({ baseUrl: 'https://api.staging.test' });
+      await storeOAuthEnvironment({ baseUrl: 'https://api.custom.test' });
 
-      expect((await getAuthContext()).baseUrl).toBe('https://api.staging.test');
+      expect((await getAuthContext()).baseUrl).toBe('https://api.custom.test');
     });
 
     it('lets MUX_TOKEN_ID/MUX_TOKEN_SECRET shadow an OAuth login', async () => {

--- a/src/lib/mux.ts
+++ b/src/lib/mux.ts
@@ -1,11 +1,19 @@
 import Mux from '@mux/mux-node';
 import pkg from '../../package.json';
+import { createBearerRetryFetch } from './bearer-retry.ts';
 import {
   type Environment,
   getCurrentEnvironment,
+  getEnvironment,
+  getEnvironmentAuthType,
   readConfig,
 } from './config.ts';
 import { hasJsonFlag, isAgentMode } from './context.ts';
+import { getPreferredCredential, hasTokenPair } from './credentials.ts';
+import {
+  ensureFreshAccessToken,
+  refreshEnvironmentTokens,
+} from './token-refresh.ts';
 
 export const DEFAULT_BASE_URL = 'https://api.mux.com';
 
@@ -43,39 +51,63 @@ export function resetEnvCredentialNotice(): void {
  * in agent mode and when --json was passed, where output (including stderr
  * errors) must stay machine-readable.
  */
-function noticeEnvCredentialsShadowStoredLogin(): void {
+function noticeEnvCredentialsShadowStoredLogin(storedName?: string): void {
   if (envCredentialNoticeShown || isAgentMode() || hasJsonFlag()) return;
   envCredentialNoticeShown = true;
+  const target = storedName ? ` "${storedName}"` : '';
   console.error(
-    'Using MUX_TOKEN_ID/MUX_TOKEN_SECRET from environment variables; they take precedence over the stored login.',
+    `Using MUX_TOKEN_ID/MUX_TOKEN_SECRET from environment variables; they take precedence over the stored login${target}. Run 'mux auth status' for details.`,
   );
 }
+
+/**
+ * The credentials a request should carry. Discriminated so that the two
+ * supported authentication schemes — Basic for Mux API access tokens, Bearer for
+ * OAuth logins — flow through one resolution path.
+ */
+export type ResolvedCredentials =
+  | {
+      kind: 'token';
+      tokenId: string;
+      tokenSecret: string;
+      baseUrl: string;
+      source: 'env' | 'config';
+    }
+  | {
+      kind: 'oauth';
+      accessToken: string;
+      baseUrl: string;
+      source: 'config';
+      /** The stored environment name, for error messages. */
+      environmentName: string;
+    };
 
 /**
  * Resolve API credentials.
  * Priority: MUX_TOKEN_ID/MUX_TOKEN_SECRET env vars > stored config
  * (consistent with how MUX_BASE_URL takes precedence over config).
  * Env vars are only used when both are set and non-empty.
+ *
+ * An expiring OAuth access token is refreshed here, so no caller needs to know
+ * that access tokens have a lifetime.
  */
-async function resolveCredentials(): Promise<{
-  tokenId: string;
-  tokenSecret: string;
-  baseUrl: string;
-}> {
+async function resolveCredentials(): Promise<ResolvedCredentials> {
   const env = await getCurrentEnvironment();
 
   const envTokenId = process.env.MUX_TOKEN_ID;
   const envTokenSecret = process.env.MUX_TOKEN_SECRET;
   if (envTokenId && envTokenSecret) {
     if (env) {
-      noticeEnvCredentialsShadowStoredLogin();
+      noticeEnvCredentialsShadowStoredLogin(env.name);
     }
     return {
+      kind: 'token',
       tokenId: envTokenId,
       tokenSecret: envTokenSecret,
       // The base URL follows the credential source: env var credentials
       // never inherit a stored environment's host (MUX_BASE_URL or default).
       baseUrl: getMuxBaseUrl(null),
+      source: 'env',
     };
   }
 
@@ -83,11 +115,75 @@ async function resolveCredentials(): Promise<{
     throw new Error(NOT_LOGGED_IN_MESSAGE);
   }
 
+  // OAuth is preferred when an environment holds both, and the token pair is
+  // the fallback when an OAuth login has been flagged as failing.
+  const preferred = getPreferredCredential(env.environment);
+  if (!preferred) {
+    throw new Error(
+      `Environment "${env.name}" has no usable credentials. Run 'mux login' to sign in again.`,
+    );
+  }
+
+  if (preferred.kind === 'oauth') {
+    const fresh = await ensureFreshAccessToken(env.name, preferred.oauth);
+    return {
+      kind: 'oauth',
+      accessToken: fresh.accessToken,
+      baseUrl: getMuxBaseUrl(env),
+      source: 'config',
+      environmentName: env.name,
+    };
+  }
+
   return {
-    tokenId: env.environment.tokenId,
-    tokenSecret: env.environment.tokenSecret,
+    kind: 'token',
+    tokenId: preferred.token.tokenId,
+    tokenSecret: preferred.token.tokenSecret,
     baseUrl: getMuxBaseUrl(env),
+    source: 'config',
   };
+}
+
+/**
+ * Force-refresh the stored OAuth login for `name` and return the new access
+ * token. Used by the reactive 401 path, where the stored expiry looked fine.
+ */
+async function refreshActiveAccessToken(name: string): Promise<string> {
+  const environment = await getEnvironment(name);
+  if (!environment?.oauth) {
+    throw new Error(`Environment "${name}" has no OAuth login to refresh.`);
+  }
+  const refreshed = await refreshEnvironmentTokens(name, environment.oauth);
+  return refreshed.accessToken;
+}
+
+/**
+ * Force-refresh the active stored OAuth login, if there is one. Returns false
+ * when the active credentials are not an OAuth login, so callers can tell
+ * "nothing to refresh" from "refreshed".
+ *
+ * Long-lived commands (`webhooks listen`) use this on a mid-stream 401: the
+ * server has invalidated a token the CLI still considered fresh.
+ */
+export async function refreshActiveOAuthCredentials(): Promise<boolean> {
+  if (process.env.MUX_TOKEN_ID && process.env.MUX_TOKEN_SECRET) {
+    return false;
+  }
+
+  const current = await getCurrentEnvironment();
+  if (!current?.environment.oauth) {
+    return false;
+  }
+
+  await refreshEnvironmentTokens(current.name, current.environment.oauth);
+  return true;
+}
+
+/** The Authorization header value for resolved credentials. */
+function authorizationHeader(credentials: ResolvedCredentials): string {
+  return credentials.kind === 'oauth'
+    ? `Bearer ${credentials.accessToken}`
+    : `Basic ${btoa(`${credentials.tokenId}:${credentials.tokenSecret}`)}`;
 }
 
 export interface ActiveEnvironment {
@@ -95,6 +191,8 @@ export interface ActiveEnvironment {
   environmentId: string;
   /** Where the active credentials came from. */
   source: 'env' | 'config';
+  /** Which authentication scheme the active credentials use. */
+  kind: 'oauth' | 'token';
   /** API host, resolved from the same source as the credentials. */
   baseUrl: string;
   /**
@@ -145,8 +243,12 @@ async function findStoredEnvironmentByCredentials(
   tokenSecret: string,
   current: { name: string; environment: Environment } | null,
 ): Promise<{ name: string; environment: Environment } | null> {
+  // Matches the token pair wherever it is stored, including on an environment
+  // that also holds an OAuth login.
   const matches = (environment: Environment) =>
-    environment.tokenId === tokenId && environment.tokenSecret === tokenSecret;
+    hasTokenPair(environment) &&
+    environment.token?.tokenId === tokenId &&
+    environment.token?.tokenSecret === tokenSecret;
 
   if (current && matches(current.environment)) {
     return current;
@@ -178,16 +280,20 @@ export async function resolveActiveEnvironment(): Promise<ActiveEnvironment> {
     if (!stored) {
       throw new Error(NOT_LOGGED_IN_MESSAGE);
     }
+    // An OAuth login already knows its own environment (the authorization
+    // server bound the token to one), so this resolves with no /whoami
+    // round-trip and local-only commands keep working offline.
     return {
       environmentId: stored.environment.environmentId ?? stored.name,
       source: 'config',
+      kind: getEnvironmentAuthType(stored.environment),
       baseUrl: getMuxBaseUrl(stored),
       stored,
     };
   }
 
   if (stored) {
-    noticeEnvCredentialsShadowStoredLogin();
+    noticeEnvCredentialsShadowStoredLogin(stored.name);
   }
 
   // The base URL follows the credential source: env var credentials never
@@ -207,6 +313,7 @@ export async function resolveActiveEnvironment(): Promise<ActiveEnvironment> {
     return {
       environmentId: sameCredentials.environment.environmentId,
       source: 'env',
+      kind: 'token',
       baseUrl,
       stored: sameCredentials,
     };
@@ -256,6 +363,7 @@ export async function resolveActiveEnvironment(): Promise<ActiveEnvironment> {
   return {
     environmentId,
     source: 'env',
+    kind: 'token',
     baseUrl,
     stored: storedMatch,
   };
@@ -268,15 +376,14 @@ export async function getAuthContext(): Promise<{
   headers: Record<string, string>;
   baseUrl: string;
 }> {
-  const { tokenId, tokenSecret, baseUrl } = await resolveCredentials();
+  const credentials = await resolveCredentials();
 
-  const credentials = btoa(`${tokenId}:${tokenSecret}`);
   return {
     headers: {
-      Authorization: `Basic ${credentials}`,
+      Authorization: authorizationHeader(credentials),
       'User-Agent': getUserAgent(),
     },
-    baseUrl,
+    baseUrl: credentials.baseUrl,
   };
 }
 
@@ -292,14 +399,131 @@ export async function getAuthHeaders(): Promise<Record<string, string>> {
  * Throws an error when no credentials are available.
  */
 export async function createAuthenticatedMuxClient(): Promise<Mux> {
-  const { tokenId, tokenSecret, baseUrl } = await resolveCredentials();
+  const credentials = await resolveCredentials();
+
+  // Exactly one credential kind is passed, and the other is explicitly null.
+  // Leaving a field undefined lets the SDK fall back to its own environment
+  // variable (MUX_TOKEN_ID/MUX_TOKEN_SECRET, MUX_AUTHORIZATION_TOKEN), and
+  // because the SDK builds the bearer header after the Basic one, an unrelated
+  // MUX_AUTHORIZATION_TOKEN in the shell would silently override the
+  // credentials resolved here.
+  const auth =
+    credentials.kind === 'oauth'
+      ? {
+          authorizationToken: credentials.accessToken,
+          tokenId: null,
+          tokenSecret: null,
+          // A token can be revoked server-side while the CLI still considers it
+          // fresh; this refreshes once on a 401 and retries.
+          fetch: createBearerRetryFetch({
+            refresh: () =>
+              refreshActiveAccessToken(credentials.environmentName),
+          }),
+        }
+      : {
+          tokenId: credentials.tokenId,
+          tokenSecret: credentials.tokenSecret,
+          authorizationToken: null,
+        };
 
   return new Mux({
-    tokenId,
-    tokenSecret,
-    ...(baseUrl !== DEFAULT_BASE_URL && { baseURL: baseUrl }),
+    ...auth,
+    ...(credentials.baseUrl !== DEFAULT_BASE_URL && {
+      baseURL: credentials.baseUrl,
+    }),
     defaultHeaders: { 'User-Agent': getUserAgent() },
   });
+}
+
+/** Identity of the organization and environment a credential is bound to. */
+export interface CredentialIdentity {
+  environmentId?: string;
+  environmentName?: string;
+  environmentType?: string;
+  organizationId?: string;
+  organizationName?: string;
+  permissions?: string[];
+}
+
+interface WhoAmIIdentityResponse {
+  data?: {
+    environment_id?: string;
+    environment_name?: string;
+    environment_type?: string;
+    organization_id?: string;
+    organization_name?: string;
+    permissions?: string[];
+  };
+}
+
+/**
+ * Confirm an OAuth access token and resolve the identity it is bound to.
+ * Called immediately after a token exchange so a login is never stored for an
+ * environment the CLI could not verify.
+ */
+export async function validateAccessToken(
+  accessToken: string,
+  overrideBaseUrl?: string,
+): Promise<
+  | { valid: true; identity: CredentialIdentity }
+  | { valid: false; error: string }
+> {
+  const baseUrl = overrideBaseUrl || getMuxBaseUrl(null);
+
+  let response: Response;
+  try {
+    response = await fetch(`${baseUrl}/system/v1/whoami`, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'User-Agent': getUserAgent(),
+      },
+    });
+  } catch (error) {
+    return {
+      valid: false,
+      error: `Could not verify the access token: failed to reach ${baseUrl} (${
+        error instanceof Error ? error.message : String(error)
+      }). Check your network connection and MUX_BASE_URL.`,
+    };
+  }
+
+  if (!response.ok) {
+    return {
+      valid: false,
+      error: `Could not verify the access token: ${response.status} ${response.statusText}.`,
+    };
+  }
+
+  let body: WhoAmIIdentityResponse;
+  try {
+    body = (await response.json()) as WhoAmIIdentityResponse;
+  } catch {
+    return {
+      valid: false,
+      error: `Could not verify the access token: ${baseUrl} returned a non-JSON response. Check MUX_BASE_URL.`,
+    };
+  }
+
+  const data = body.data;
+  if (!data?.environment_id) {
+    return {
+      valid: false,
+      error:
+        'Could not determine which Mux environment the access token belongs to.',
+    };
+  }
+
+  return {
+    valid: true,
+    identity: {
+      environmentId: data.environment_id,
+      environmentName: data.environment_name,
+      environmentType: data.environment_type,
+      organizationId: data.organization_id,
+      organizationName: data.organization_name,
+      permissions: data.permissions,
+    },
+  };
 }
 
 /**

--- a/src/lib/oauth-callback.html
+++ b/src/lib/oauth-callback.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>{{title}}</title>
+    <title>__MUX_TITLE__</title>
     <!--
       Deliberately self-contained: no scripts, no external stylesheets, fonts,
       or images. This page is served by a short-lived loopback server during
@@ -65,8 +65,8 @@
   </head>
   <body>
     <main>
-      <h1>{{title}}</h1>
-      <p>{{message}}</p>
+      <h1>__MUX_TITLE__</h1>
+      <p>__MUX_MESSAGE__</p>
     </main>
   </body>
 </html>

--- a/src/lib/oauth-callback.html
+++ b/src/lib/oauth-callback.html
@@ -1,0 +1,72 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{{title}}</title>
+    <!--
+      Deliberately self-contained: no scripts, no external stylesheets, fonts,
+      or images. This page is served by a short-lived loopback server during
+      `mux login`, and a page holding an authorization code must not be able to
+      talk to anything else. Keep it that way.
+    -->
+    <style>
+      :root {
+        color-scheme: light dark;
+        --fg: #111111;
+        --fg-muted: #555555;
+        --bg: #ffffff;
+        --border: #e4e4e7;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --fg: #f4f4f5;
+          --fg-muted: #a1a1aa;
+          --bg: #18181b;
+          --border: #3f3f46;
+        }
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        padding: 1.5rem;
+        background: var(--bg);
+        color: var(--fg);
+        font-family:
+          system-ui,
+          -apple-system,
+          'Segoe UI',
+          sans-serif;
+        line-height: 1.5;
+      }
+
+      main {
+        max-width: 26rem;
+        border: 1px solid var(--border);
+        border-radius: 12px;
+        padding: 2rem;
+      }
+
+      h1 {
+        margin: 0 0 0.5rem;
+        font-size: 1.125rem;
+        font-weight: 600;
+      }
+
+      p {
+        margin: 0;
+        color: var(--fg-muted);
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>{{title}}</h1>
+      <p>{{message}}</p>
+    </main>
+  </body>
+</html>

--- a/src/lib/oauth-discovery.test.ts
+++ b/src/lib/oauth-discovery.test.ts
@@ -291,20 +291,20 @@ describe('discoverEndpoints', () => {
       expect(spy.mock.calls.length).toBeGreaterThan(callsAfterFirst);
     });
 
-    it('keys the cache by base URL, so staging does not serve production', async () => {
+    it('keys the cache by base URL, so one host does not serve another', async () => {
       mockDiscovery({ '/.well-known/oauth-authorization-server': OAUTH_DOC });
       await discoverEndpoints('https://api.mux.com');
 
       const spy = mockDiscovery({
         '/.well-known/oauth-authorization-server': {
           ...OAUTH_DOC,
-          token_endpoint: 'https://api.staging.mux.com/oauth/token',
+          token_endpoint: 'https://api.example.com/oauth/token',
         },
       });
-      const result = await discoverEndpoints('https://api.staging.mux.com');
+      const result = await discoverEndpoints('https://api.example.com');
 
       expect(spy.mock.calls.length).toBeGreaterThan(0);
-      expect(result?.tokenUrl).toBe('https://api.staging.mux.com/oauth/token');
+      expect(result?.tokenUrl).toBe('https://api.example.com/oauth/token');
     });
 
     it('ignores an unreadable cache and refetches', async () => {

--- a/src/lib/oauth-discovery.test.ts
+++ b/src/lib/oauth-discovery.test.ts
@@ -1,0 +1,335 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type Mock,
+  spyOn,
+} from 'bun:test';
+import { existsSync } from 'node:fs';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  clearDiscoveryCache,
+  DISCOVERY_CACHE_TTL_MS,
+  discoverEndpoints,
+  getDiscoveryCachePath,
+  getDiscoveryUrls,
+  validateEndpoint,
+} from './oauth-discovery.ts';
+
+let testCacheDir: string;
+let originalXdgCacheHome: string | undefined;
+let fetchSpy: Mock<typeof fetch> | undefined;
+
+const OAUTH_DOC = {
+  issuer: 'https://api.mux.com',
+  authorization_endpoint: 'https://dashboard.mux.com/oauth/authorize',
+  token_endpoint: 'https://api.mux.com/oauth/token',
+  revocation_endpoint: 'https://api.mux.com/oauth/revoke',
+  grant_types_supported: ['authorization_code', 'refresh_token'],
+  code_challenge_methods_supported: ['S256'],
+  scopes_supported: ['video:read', 'video:write'],
+};
+
+/** Serve the given body for the first discovery path, 404 for the rest. */
+function mockDiscovery(
+  bodyByPath: Record<string, unknown>,
+  status = 200,
+): Mock<typeof fetch> {
+  fetchSpy = spyOn(globalThis, 'fetch').mockImplementation((async (
+    input: string,
+  ) => {
+    const url = new URL(String(input));
+    const body = bodyByPath[url.pathname];
+    if (!body) return new Response('not found', { status: 404 });
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as unknown as typeof fetch);
+  return fetchSpy;
+}
+
+beforeEach(async () => {
+  testCacheDir = await mkdtemp(join(tmpdir(), 'mux-cli-discovery-'));
+  originalXdgCacheHome = process.env.XDG_CACHE_HOME;
+  process.env.XDG_CACHE_HOME = testCacheDir;
+});
+
+afterEach(async () => {
+  if (originalXdgCacheHome === undefined) {
+    delete process.env.XDG_CACHE_HOME;
+  } else {
+    process.env.XDG_CACHE_HOME = originalXdgCacheHome;
+  }
+  fetchSpy?.mockRestore();
+  fetchSpy = undefined;
+  await rm(testCacheDir, { recursive: true, force: true });
+});
+
+describe('getDiscoveryUrls', () => {
+  it('derives both well-known paths from the API base URL', () => {
+    const urls = getDiscoveryUrls('https://api.mux.com');
+
+    expect(urls).toEqual([
+      'https://api.mux.com/.well-known/oauth-authorization-server',
+      'https://api.mux.com/.well-known/openid-configuration',
+    ]);
+  });
+
+  it('tries the OAuth document before the OIDC one', () => {
+    // RFC 8414 defines revocation_endpoint; OIDC Core does not.
+    expect(getDiscoveryUrls('https://api.mux.com')[0]).toContain(
+      'oauth-authorization-server',
+    );
+  });
+
+  it('does not double up slashes on a base URL with a trailing slash', () => {
+    expect(getDiscoveryUrls('https://api.mux.com/')[0]).toBe(
+      'https://api.mux.com/.well-known/oauth-authorization-server',
+    );
+  });
+});
+
+describe('validateEndpoint', () => {
+  const from = 'https://api.mux.com/.well-known/oauth-authorization-server';
+
+  it('accepts https endpoints on mux.com', () => {
+    expect(
+      validateEndpoint('https://dashboard.mux.com/oauth/authorize', from),
+    ).toBe('https://dashboard.mux.com/oauth/authorize');
+  });
+
+  it('accepts mux.com itself', () => {
+    expect(
+      validateEndpoint('https://mux.com/oauth/authorize', from),
+    ).toBeTruthy();
+  });
+
+  it('rejects a foreign host', () => {
+    // A document that could repoint the token endpoint elsewhere would turn the
+    // authorization code and refresh token into an exfiltration.
+    expect(validateEndpoint('https://evil.example.com/token', from)).toBeNull();
+  });
+
+  it('rejects a host that merely ends with the brand', () => {
+    expect(validateEndpoint('https://notmux.com/token', from)).toBeNull();
+    expect(
+      validateEndpoint('https://mux.com.evil.test/token', from),
+    ).toBeNull();
+  });
+
+  it('rejects plaintext http on a remote host', () => {
+    expect(validateEndpoint('http://api.mux.com/oauth/token', from)).toBeNull();
+  });
+
+  it('rejects a non-URL', () => {
+    expect(validateEndpoint('not a url', from)).toBeNull();
+    expect(validateEndpoint('', from)).toBeNull();
+  });
+
+  it('accepts an endpoint sharing the origin of the discovery document', () => {
+    // Lets a local or staging server be driven entirely by MUX_BASE_URL: the
+    // document is only as trustworthy as the host it came from anyway.
+    expect(
+      validateEndpoint(
+        'http://127.0.0.1:8410/oauth/token',
+        'http://127.0.0.1:8410/.well-known/oauth-authorization-server',
+      ),
+    ).toBe('http://127.0.0.1:8410/oauth/token');
+  });
+
+  it('rejects a different loopback port than the document came from', () => {
+    expect(
+      validateEndpoint(
+        'http://127.0.0.1:9999/oauth/token',
+        'http://127.0.0.1:8410/.well-known/oauth-authorization-server',
+      ),
+    ).toBeNull();
+  });
+});
+
+describe('discoverEndpoints', () => {
+  it('returns the endpoints from the OAuth document', async () => {
+    mockDiscovery({
+      '/.well-known/oauth-authorization-server': OAUTH_DOC,
+    });
+
+    const result = await discoverEndpoints('https://api.mux.com');
+
+    expect(result?.authorizationUrl).toBe(
+      'https://dashboard.mux.com/oauth/authorize',
+    );
+    expect(result?.tokenUrl).toBe('https://api.mux.com/oauth/token');
+    expect(result?.revocationUrl).toBe('https://api.mux.com/oauth/revoke');
+    expect(result?.grantTypes).toContain('refresh_token');
+    expect(result?.codeChallengeMethods).toContain('S256');
+    expect(result?.scopes).toContain('video:read');
+  });
+
+  it('falls back to the OIDC document when the OAuth one is absent', async () => {
+    const spy = mockDiscovery({
+      '/.well-known/openid-configuration': {
+        authorization_endpoint: 'https://dashboard.mux.com/oauth/authorize',
+        token_endpoint: 'https://api.mux.com/oauth/token',
+      },
+    });
+
+    const result = await discoverEndpoints('https://api.mux.com');
+
+    expect(result?.tokenUrl).toBe('https://api.mux.com/oauth/token');
+    // Both paths attempted, in order.
+    expect(spy.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('omits an endpoint the document does not define', async () => {
+    // OIDC Core has no revocation_endpoint; callers fall back per field.
+    mockDiscovery({
+      '/.well-known/openid-configuration': {
+        authorization_endpoint: 'https://dashboard.mux.com/oauth/authorize',
+        token_endpoint: 'https://api.mux.com/oauth/token',
+      },
+    });
+
+    const result = await discoverEndpoints('https://api.mux.com');
+
+    expect(result?.revocationUrl).toBeUndefined();
+  });
+
+  it('drops an endpoint that fails validation, keeping the rest', async () => {
+    mockDiscovery({
+      '/.well-known/oauth-authorization-server': {
+        ...OAUTH_DOC,
+        token_endpoint: 'https://evil.example.com/token',
+      },
+    });
+
+    const result = await discoverEndpoints('https://api.mux.com');
+
+    expect(result?.tokenUrl).toBeUndefined();
+    expect(result?.authorizationUrl).toBe(
+      'https://dashboard.mux.com/oauth/authorize',
+    );
+  });
+
+  it('returns null when no document is reachable', async () => {
+    mockDiscovery({});
+
+    expect(await discoverEndpoints('https://api.mux.com')).toBeNull();
+  });
+
+  it('returns null rather than throwing when the network fails', async () => {
+    fetchSpy = spyOn(globalThis, 'fetch').mockImplementation((async () => {
+      throw new TypeError('fetch failed');
+    }) as unknown as typeof fetch);
+
+    // Discovery is an upgrade path, never a hard dependency: callers fall back
+    // to their built-in defaults.
+    expect(await discoverEndpoints('https://api.mux.com')).toBeNull();
+  });
+
+  it('returns null on a malformed document', async () => {
+    fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(
+      (async () =>
+        new Response('<html>nope</html>', {
+          status: 200,
+        })) as unknown as typeof fetch,
+    );
+
+    expect(await discoverEndpoints('https://api.mux.com')).toBeNull();
+  });
+
+  it('returns null on a document with no usable endpoints', async () => {
+    mockDiscovery({
+      '/.well-known/oauth-authorization-server': {
+        issuer: 'https://api.mux.com',
+      },
+    });
+
+    expect(await discoverEndpoints('https://api.mux.com')).toBeNull();
+  });
+
+  describe('caching', () => {
+    it('writes the result to the cache', async () => {
+      mockDiscovery({ '/.well-known/oauth-authorization-server': OAUTH_DOC });
+
+      await discoverEndpoints('https://api.mux.com');
+
+      expect(existsSync(getDiscoveryCachePath())).toBe(true);
+    });
+
+    it('serves a second call from the cache without fetching', async () => {
+      const spy = mockDiscovery({
+        '/.well-known/oauth-authorization-server': OAUTH_DOC,
+      });
+      await discoverEndpoints('https://api.mux.com');
+      const callsAfterFirst = spy.mock.calls.length;
+
+      const result = await discoverEndpoints('https://api.mux.com');
+
+      expect(spy.mock.calls.length).toBe(callsAfterFirst);
+      expect(result?.tokenUrl).toBe('https://api.mux.com/oauth/token');
+    });
+
+    it('refetches once the cache is older than the TTL', async () => {
+      const spy = mockDiscovery({
+        '/.well-known/oauth-authorization-server': OAUTH_DOC,
+      });
+      await discoverEndpoints('https://api.mux.com');
+      const callsAfterFirst = spy.mock.calls.length;
+
+      // Backdate the cache past its TTL.
+      const cached = JSON.parse(await Bun.file(getDiscoveryCachePath()).text());
+      cached.fetchedAt = Date.now() - DISCOVERY_CACHE_TTL_MS - 1000;
+      await Bun.write(getDiscoveryCachePath(), JSON.stringify(cached));
+
+      await discoverEndpoints('https://api.mux.com');
+
+      expect(spy.mock.calls.length).toBeGreaterThan(callsAfterFirst);
+    });
+
+    it('keys the cache by base URL, so staging does not serve production', async () => {
+      mockDiscovery({ '/.well-known/oauth-authorization-server': OAUTH_DOC });
+      await discoverEndpoints('https://api.mux.com');
+
+      const spy = mockDiscovery({
+        '/.well-known/oauth-authorization-server': {
+          ...OAUTH_DOC,
+          token_endpoint: 'https://api.staging.mux.com/oauth/token',
+        },
+      });
+      const result = await discoverEndpoints('https://api.staging.mux.com');
+
+      expect(spy.mock.calls.length).toBeGreaterThan(0);
+      expect(result?.tokenUrl).toBe('https://api.staging.mux.com/oauth/token');
+    });
+
+    it('ignores an unreadable cache and refetches', async () => {
+      await Bun.write(getDiscoveryCachePath(), 'not json');
+      const spy = mockDiscovery({
+        '/.well-known/oauth-authorization-server': OAUTH_DOC,
+      });
+
+      const result = await discoverEndpoints('https://api.mux.com');
+
+      expect(spy.mock.calls.length).toBeGreaterThan(0);
+      expect(result?.tokenUrl).toBe('https://api.mux.com/oauth/token');
+    });
+
+    it('clearDiscoveryCache forces the next call to refetch', async () => {
+      const spy = mockDiscovery({
+        '/.well-known/oauth-authorization-server': OAUTH_DOC,
+      });
+      await discoverEndpoints('https://api.mux.com');
+      const callsAfterFirst = spy.mock.calls.length;
+
+      await clearDiscoveryCache();
+      await discoverEndpoints('https://api.mux.com');
+
+      expect(spy.mock.calls.length).toBeGreaterThan(callsAfterFirst);
+    });
+  });
+});

--- a/src/lib/oauth-discovery.ts
+++ b/src/lib/oauth-discovery.ts
@@ -132,10 +132,13 @@ async function writeCache(
   endpoints: DiscoveredEndpoints,
 ): Promise<void> {
   try {
-    await mkdir(getCacheDir(), { recursive: true });
+    // Endpoint URLs are not secret, but this stays consistent with how the rest
+    // of the CLI's state is written rather than inheriting the umask.
+    await mkdir(getCacheDir(), { recursive: true, mode: 0o700 });
     await writeFile(
       getDiscoveryCachePath(),
       JSON.stringify({ fetchedAt: Date.now(), baseUrl, endpoints }, null, 2),
+      { mode: 0o600 },
     );
   } catch {
     // A cache we cannot write is not a reason to fail a login.

--- a/src/lib/oauth-discovery.ts
+++ b/src/lib/oauth-discovery.ts
@@ -1,0 +1,226 @@
+import { mkdir, readFile, unlink, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { getCacheDir } from './xdg.ts';
+
+/**
+ * Authorization server metadata discovery (RFC 8414, and the OIDC discovery
+ * document as a fallback).
+ *
+ * A CLI binary can sit on a machine for years. Endpoints compiled into it break
+ * permanently if they ever move — and worse for refresh than for login, since
+ * refresh runs long after install. Discovery lets the server move without
+ * stranding old installs.
+ *
+ * It is deliberately an *upgrade path, never a dependency*: any failure here
+ * returns null and callers keep their built-in defaults. A discovery outage must
+ * not stop anyone from logging in.
+ */
+
+/** Tried in order. RFC 8414 defines revocation_endpoint; OIDC Core does not. */
+const WELL_KNOWN_PATHS = [
+  '/.well-known/oauth-authorization-server',
+  '/.well-known/openid-configuration',
+];
+
+/** Hosts whose endpoints are trusted, besides the discovery document's own origin. */
+const TRUSTED_HOST_SUFFIX = 'mux.com';
+
+export const DISCOVERY_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+
+const FETCH_TIMEOUT_MS = 5000;
+
+export interface DiscoveredEndpoints {
+  authorizationUrl?: string;
+  tokenUrl?: string;
+  revocationUrl?: string;
+  grantTypes?: string[];
+  codeChallengeMethods?: string[];
+  scopes?: string[];
+  /** Where this came from, for diagnostics. */
+  discoveredFrom: string;
+}
+
+interface DiscoveryDocument {
+  issuer?: string;
+  authorization_endpoint?: string;
+  token_endpoint?: string;
+  revocation_endpoint?: string;
+  grant_types_supported?: string[];
+  code_challenge_methods_supported?: string[];
+  scopes_supported?: string[];
+}
+
+interface CacheEntry {
+  fetchedAt: number;
+  baseUrl: string;
+  endpoints: DiscoveredEndpoints;
+}
+
+export function getDiscoveryCachePath(): string {
+  return join(getCacheDir(), 'oauth-discovery.json');
+}
+
+/** The well-known URLs for an API base, in the order they should be tried. */
+export function getDiscoveryUrls(baseUrl: string): string[] {
+  const trimmed = baseUrl.replace(/\/+$/, '');
+  return WELL_KNOWN_PATHS.map((path) => `${trimmed}${path}`);
+}
+
+/**
+ * Accept an endpoint only if it is trustworthy: https on a Mux host, or on the
+ * exact origin the discovery document itself came from.
+ *
+ * Without this, a compromised or misconfigured document could repoint the token
+ * endpoint and collect authorization codes and refresh tokens.
+ */
+export function validateEndpoint(
+  endpoint: string,
+  discoveredFrom: string,
+): string | null {
+  let url: URL;
+  try {
+    url = new URL(endpoint);
+  } catch {
+    return null;
+  }
+
+  // Same origin as the document: it is exactly as trustworthy as the host the
+  // document came from, which is also what makes local and staging servers work
+  // through MUX_BASE_URL alone.
+  try {
+    if (url.origin === new URL(discoveredFrom).origin) {
+      return url.toString();
+    }
+  } catch {
+    return null;
+  }
+
+  if (url.protocol !== 'https:') return null;
+
+  const host = url.hostname.toLowerCase();
+  // Suffix match on a dot boundary: `notmux.com` and `mux.com.evil.test` must
+  // not pass.
+  if (
+    host !== TRUSTED_HOST_SUFFIX &&
+    !host.endsWith(`.${TRUSTED_HOST_SUFFIX}`)
+  ) {
+    return null;
+  }
+
+  return url.toString();
+}
+
+async function readCache(baseUrl: string): Promise<DiscoveredEndpoints | null> {
+  try {
+    const entry = JSON.parse(
+      await readFile(getDiscoveryCachePath(), 'utf-8'),
+    ) as CacheEntry;
+
+    if (entry.baseUrl !== baseUrl) return null;
+    if (Date.now() - entry.fetchedAt > DISCOVERY_CACHE_TTL_MS) return null;
+    if (!entry.endpoints) return null;
+
+    return entry.endpoints;
+  } catch {
+    // Missing, unreadable, or malformed: just refetch.
+    return null;
+  }
+}
+
+async function writeCache(
+  baseUrl: string,
+  endpoints: DiscoveredEndpoints,
+): Promise<void> {
+  try {
+    await mkdir(getCacheDir(), { recursive: true });
+    await writeFile(
+      getDiscoveryCachePath(),
+      JSON.stringify({ fetchedAt: Date.now(), baseUrl, endpoints }, null, 2),
+    );
+  } catch {
+    // A cache we cannot write is not a reason to fail a login.
+  }
+}
+
+export async function clearDiscoveryCache(): Promise<void> {
+  await unlink(getDiscoveryCachePath()).catch(() => {});
+}
+
+/** Map a document onto endpoints, dropping any that fail validation. */
+function endpointsFrom(
+  document: DiscoveryDocument,
+  discoveredFrom: string,
+): DiscoveredEndpoints | null {
+  const authorizationUrl = document.authorization_endpoint
+    ? validateEndpoint(document.authorization_endpoint, discoveredFrom)
+    : null;
+  const tokenUrl = document.token_endpoint
+    ? validateEndpoint(document.token_endpoint, discoveredFrom)
+    : null;
+  const revocationUrl = document.revocation_endpoint
+    ? validateEndpoint(document.revocation_endpoint, discoveredFrom)
+    : null;
+
+  // A document that yields no usable endpoint is worse than useless: treat it as
+  // absent so the caller's defaults apply.
+  if (!authorizationUrl && !tokenUrl && !revocationUrl) {
+    return null;
+  }
+
+  return {
+    ...(authorizationUrl && { authorizationUrl }),
+    ...(tokenUrl && { tokenUrl }),
+    ...(revocationUrl && { revocationUrl }),
+    ...(Array.isArray(document.grant_types_supported) && {
+      grantTypes: document.grant_types_supported,
+    }),
+    ...(Array.isArray(document.code_challenge_methods_supported) && {
+      codeChallengeMethods: document.code_challenge_methods_supported,
+    }),
+    ...(Array.isArray(document.scopes_supported) && {
+      scopes: document.scopes_supported,
+    }),
+    discoveredFrom,
+  };
+}
+
+/**
+ * Resolve authorization server endpoints for an API base URL, using a cached
+ * document when one is fresh. Returns null when discovery is unavailable for any
+ * reason, which callers treat as "use the built-in defaults".
+ */
+export async function discoverEndpoints(
+  baseUrl: string,
+): Promise<DiscoveredEndpoints | null> {
+  const cached = await readCache(baseUrl);
+  if (cached) return cached;
+
+  for (const url of getDiscoveryUrls(baseUrl)) {
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        headers: { Accept: 'application/json' },
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      });
+    } catch {
+      continue;
+    }
+
+    if (!response.ok) continue;
+
+    let document: DiscoveryDocument;
+    try {
+      document = (await response.json()) as DiscoveryDocument;
+    } catch {
+      continue;
+    }
+
+    const endpoints = endpointsFrom(document, url);
+    if (endpoints) {
+      await writeCache(baseUrl, endpoints);
+      return endpoints;
+    }
+  }
+
+  return null;
+}

--- a/src/lib/oauth-login.test.ts
+++ b/src/lib/oauth-login.test.ts
@@ -59,7 +59,7 @@ function fakeDeps(overrides: Partial<OAuthLoginDeps> = {}): OAuthLoginDeps {
       authorizationUrl: 'https://dash.test/oauth/authorize',
       tokenUrl: 'https://api.test/oauth/token',
       revocationUrl: 'https://api.test/oauth/revoke',
-      scopes: [],
+      scopes: ['video:read', 'system:read'],
     },
     exchange: async () => TOKENS,
     validate: async () => ({
@@ -141,6 +141,41 @@ describe('performOAuthLogin', () => {
     expect(stored.environmentId).toBe('env_123');
     expect(stored.organizationName).toBe('Acme Inc');
     expect(stored.environmentName).toBe('Production');
+  });
+
+  it('sends the requested scopes on the authorization request', async () => {
+    // The Mux server rejects an authorization request with no scope parameter.
+    let authorizationUrl = '';
+
+    await performOAuthLogin(
+      {},
+      fakeDeps({
+        openBrowser: async (url: string) => {
+          authorizationUrl = url;
+          return true;
+        },
+      }),
+    );
+
+    expect(new URL(authorizationUrl).searchParams.get('scope')).toBe(
+      'video:read system:read',
+    );
+  });
+
+  it('refuses to start a login with no scopes rather than being rejected', async () => {
+    const noScopes = fakeDeps({
+      endpoints: {
+        clientId: 'test_client',
+        authorizationUrl: 'https://dash.test/oauth/authorize',
+        tokenUrl: 'https://api.test/oauth/token',
+        revocationUrl: 'https://api.test/oauth/revoke',
+        scopes: [],
+      },
+    });
+
+    await expect(performOAuthLogin({}, noScopes)).rejects.toThrow(
+      /no oauth scopes/i,
+    );
   });
 
   it('sends a PKCE S256 challenge and the loopback redirect URI', async () => {

--- a/src/lib/oauth-login.test.ts
+++ b/src/lib/oauth-login.test.ts
@@ -414,13 +414,13 @@ describe('performOAuthLogin', () => {
     await setEnvironment('old-name', {
       token: { tokenId: 'id', tokenSecret: 'secret' },
       environmentId: 'env_123',
-      baseUrl: 'https://api.staging.example.com',
+      baseUrl: 'https://api.custom.example',
     });
 
     await performOAuthLogin({ name: 'new-name' }, fakeDeps());
 
     expect((await getEnvironment('new-name'))?.baseUrl).toBe(
-      'https://api.staging.example.com',
+      'https://api.custom.example',
     );
   });
 

--- a/src/lib/oauth-login.test.ts
+++ b/src/lib/oauth-login.test.ts
@@ -517,6 +517,48 @@ describe('performOAuthLogin', () => {
     expect(stopped).toBeGreaterThan(before);
   });
 
+  it('passes an explicit timeout through to the loopback server', async () => {
+    let requestedTimeoutMs: number | undefined;
+
+    await performOAuthLogin(
+      { timeoutMs: 600_000 },
+      fakeDeps({
+        startServer: async (options) => {
+          requestedTimeoutMs = options.timeoutMs;
+          return {
+            port: 51372,
+            redirectUri: 'http://127.0.0.1:51372/callback',
+            waitForCode: async () => 'auth_code',
+            stop: () => {},
+          };
+        },
+      }),
+    );
+
+    expect(requestedTimeoutMs).toBe(600_000);
+  });
+
+  it('leaves the loopback timeout to its default when none is given', async () => {
+    let requestedTimeoutMs: number | undefined = -1;
+
+    await performOAuthLogin(
+      {},
+      fakeDeps({
+        startServer: async (options) => {
+          requestedTimeoutMs = options.timeoutMs;
+          return {
+            port: 51372,
+            redirectUri: 'http://127.0.0.1:51372/callback',
+            waitForCode: async () => 'auth_code',
+            stop: () => {},
+          };
+        },
+      }),
+    );
+
+    expect(requestedTimeoutMs).toBeUndefined();
+  });
+
   it('passes an explicit port through to the loopback server', async () => {
     let requestedPort: number | undefined;
 

--- a/src/lib/oauth-login.test.ts
+++ b/src/lib/oauth-login.test.ts
@@ -7,6 +7,7 @@ import {
   getCurrentEnvironment,
   getEnvironment,
   getEnvironmentAuthType,
+  setCurrentEnvironment,
   setEnvironment,
 } from './config.ts';
 import type { OAuthTokens } from './oauth.ts';
@@ -308,6 +309,103 @@ describe('performOAuthLogin', () => {
     expect(stored.token).toEqual({ tokenId: 'id', tokenSecret: 'secret' });
     expect(stored.signingKeyId).toBe('key_1');
     expect(await getEnvironment('old-name')).toBeNull();
+  });
+
+  it("does not attach another environment's state to the granted identity", async () => {
+    // Regression: --name merged into whatever held that name, so one
+    // environment's signing key and token pair ended up on another's identity —
+    // invalid playback tokens, and a fallback to the wrong account.
+    await setEnvironment('staging', {
+      environmentId: 'env_OTHER',
+      environmentName: 'Other',
+      organizationName: 'Org A',
+      signingKeyId: 'KEY_FOR_OTHER',
+      signingPrivateKey: 'PRIV_FOR_OTHER',
+      forwardUrl: 'http://localhost:3000/other',
+      token: { tokenId: 'TOKEN_FOR_OTHER', tokenSecret: 'SECRET_FOR_OTHER' },
+    });
+
+    const result = await performOAuthLogin({ name: 'staging' }, fakeDeps());
+
+    const stored = (await getEnvironment('staging')) as Environment;
+    expect(stored.environmentId).toBe('env_123');
+    expect(stored.signingKeyId).toBeUndefined();
+    expect(stored.signingPrivateKey).toBeUndefined();
+    expect(stored.forwardUrl).toBeUndefined();
+    expect(stored.token).toBeUndefined();
+    expect(stored.organizationName).toBe('Acme Inc');
+    // Reported rather than dropped silently: a token secret cannot be recovered.
+    expect(result.dropped).toEqual([
+      'signingKeyId',
+      'signingPrivateKey',
+      'forwardUrl',
+      'token',
+    ]);
+  });
+
+  it("carries the granted environment's own state across a --name collision", async () => {
+    // The name holds environment A; the grant is for B, already saved elsewhere.
+    // B's state should follow B, and A's should not come along.
+    await setEnvironment('staging', {
+      environmentId: 'env_OTHER',
+      signingKeyId: 'KEY_FOR_OTHER',
+      token: { tokenId: 'TOKEN_FOR_OTHER', tokenSecret: 'SECRET_FOR_OTHER' },
+    });
+    await setEnvironment('granted-elsewhere', {
+      environmentId: 'env_123',
+      forwardUrl: 'http://localhost:4000/granted',
+      signingKeyId: 'KEY_FOR_GRANTED',
+    });
+
+    await performOAuthLogin({ name: 'staging' }, fakeDeps());
+
+    const stored = (await getEnvironment('staging')) as Environment;
+    expect(stored.forwardUrl).toBe('http://localhost:4000/granted');
+    expect(stored.signingKeyId).toBe('KEY_FOR_GRANTED');
+    expect(stored.token).toBeUndefined();
+    // One environment, one entry: the duplicate under the old name is gone.
+    expect(await getEnvironment('granted-elsewhere')).toBeNull();
+  });
+
+  it('leaves unrelated environments untouched', async () => {
+    await setEnvironment('unrelated', {
+      environmentId: 'env_UNRELATED',
+      signingKeyId: 'KEY_UNRELATED',
+      token: { tokenId: 'u', tokenSecret: 'u' },
+    });
+
+    await performOAuthLogin({ name: 'fresh' }, fakeDeps());
+
+    const untouched = (await getEnvironment('unrelated')) as Environment;
+    expect(untouched.signingKeyId).toBe('KEY_UNRELATED');
+    expect(untouched.token).toEqual({ tokenId: 'u', tokenSecret: 'u' });
+  });
+
+  it('reports nothing dropped for a fresh name or the same environment', async () => {
+    const fresh = await performOAuthLogin({ name: 'brand-new' }, fakeDeps());
+    expect(fresh.dropped).toEqual([]);
+
+    const again = await performOAuthLogin({ name: 'brand-new' }, fakeDeps());
+    expect(again.dropped).toEqual([]);
+  });
+
+  it('keeps the renamed entry active when --name moves the current one', async () => {
+    // Regression: removing the old entry reassigned defaultEnvironment, so a
+    // rename of the active environment could silently select an unrelated one.
+    await setEnvironment('old-name', {
+      token: { tokenId: 'id', tokenSecret: 'secret' },
+      environmentId: 'env_123',
+    });
+    await setEnvironment('unrelated', {
+      token: { tokenId: 'u', tokenSecret: 'u' },
+      environmentId: 'env_other',
+    });
+    await setCurrentEnvironment('old-name');
+
+    // --keep-current: activation is declined, so nothing else would fix this up.
+    await performOAuthLogin({ name: 'new-name', activate: false }, fakeDeps());
+
+    expect((await getCurrentEnvironment())?.name).toBe('new-name');
   });
 
   it('carries a custom base URL across when --name moves the entry', async () => {

--- a/src/lib/oauth-login.test.ts
+++ b/src/lib/oauth-login.test.ts
@@ -1,0 +1,391 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  type Environment,
+  getCurrentEnvironment,
+  getEnvironment,
+  getEnvironmentAuthType,
+  setEnvironment,
+} from './config.ts';
+import type { OAuthTokens } from './oauth.ts';
+import {
+  deriveEnvironmentName,
+  type OAuthLoginDeps,
+  performOAuthLogin,
+} from './oauth-login.ts';
+
+let testConfigDir: string;
+let originalXdgConfigHome: string | undefined;
+
+beforeEach(async () => {
+  testConfigDir = await mkdtemp(join(tmpdir(), 'mux-cli-oauth-login-'));
+  originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
+  process.env.XDG_CONFIG_HOME = testConfigDir;
+});
+
+afterEach(async () => {
+  if (originalXdgConfigHome === undefined) {
+    delete process.env.XDG_CONFIG_HOME;
+  } else {
+    process.env.XDG_CONFIG_HOME = originalXdgConfigHome;
+  }
+  await rm(testConfigDir, { recursive: true, force: true });
+});
+
+const TOKENS: OAuthTokens = {
+  accessToken: 'access_1',
+  refreshToken: 'refresh_1',
+  expiresAt: Math.floor(Date.now() / 1000) + 3600,
+  tokenType: 'Bearer',
+};
+
+/**
+ * A login where every external step is stubbed: a fake loopback server, a fake
+ * browser, a fixed token exchange, and a fixed identity.
+ */
+function fakeDeps(overrides: Partial<OAuthLoginDeps> = {}): OAuthLoginDeps {
+  return {
+    startServer: async () => ({
+      port: 51372,
+      redirectUri: 'http://127.0.0.1:51372/callback',
+      waitForCode: async () => 'auth_code',
+      stop: () => {},
+    }),
+    openBrowser: async () => true,
+    endpoints: {
+      clientId: 'test_client',
+      authorizationUrl: 'https://dash.test/oauth/authorize',
+      tokenUrl: 'https://api.test/oauth/token',
+      revocationUrl: 'https://api.test/oauth/revoke',
+      scopes: [],
+    },
+    exchange: async () => TOKENS,
+    validate: async () => ({
+      valid: true as const,
+      identity: {
+        environmentId: 'env_123',
+        environmentName: 'Production',
+        organizationId: 'org_123',
+        organizationName: 'Acme Inc',
+        permissions: ['video'],
+      },
+    }),
+    ...overrides,
+  };
+}
+
+describe('deriveEnvironmentName', () => {
+  it('slugifies the organization and environment names', () => {
+    expect(
+      deriveEnvironmentName({
+        organizationName: 'Acme Inc',
+        environmentName: 'Production',
+        taken: [],
+      }),
+    ).toBe('acme-inc-production');
+  });
+
+  it('collapses punctuation and repeated separators', () => {
+    expect(
+      deriveEnvironmentName({
+        organizationName: 'Foo, Bar & Baz!',
+        environmentName: 'Staging // EU',
+        taken: [],
+      }),
+    ).toBe('foo-bar-baz-staging-eu');
+  });
+
+  it('suffixes on collision rather than overwriting another environment', () => {
+    expect(
+      deriveEnvironmentName({
+        organizationName: 'Acme Inc',
+        environmentName: 'Production',
+        taken: ['acme-inc-production'],
+      }),
+    ).toBe('acme-inc-production-2');
+  });
+
+  it('keeps counting past the first collision', () => {
+    expect(
+      deriveEnvironmentName({
+        organizationName: 'Acme Inc',
+        environmentName: 'Production',
+        taken: ['acme-inc-production', 'acme-inc-production-2'],
+      }),
+    ).toBe('acme-inc-production-3');
+  });
+
+  it('falls back to the environment id when names are missing', () => {
+    expect(deriveEnvironmentName({ environmentId: 'env_abc', taken: [] })).toBe(
+      'env_abc',
+    );
+  });
+
+  it('falls back to a generic name when nothing identifies the environment', () => {
+    expect(deriveEnvironmentName({ taken: [] })).toBe('default');
+  });
+});
+
+describe('performOAuthLogin', () => {
+  it('stores the login under a derived name and returns a summary', async () => {
+    const result = await performOAuthLogin({}, fakeDeps());
+
+    expect(result.name).toBe('acme-inc-production');
+    expect(result.identity.environmentId).toBe('env_123');
+
+    const stored = (await getEnvironment('acme-inc-production')) as Environment;
+    expect(stored.oauth?.accessToken).toBe('access_1');
+    expect(stored.oauth?.refreshToken).toBe('refresh_1');
+    expect(stored.environmentId).toBe('env_123');
+    expect(stored.organizationName).toBe('Acme Inc');
+    expect(stored.environmentName).toBe('Production');
+  });
+
+  it('sends a PKCE S256 challenge and the loopback redirect URI', async () => {
+    let authorizationUrl = '';
+    let exchanged: { codeVerifier: string; redirectUri: string } | undefined;
+
+    await performOAuthLogin(
+      {},
+      fakeDeps({
+        openBrowser: async (url: string) => {
+          authorizationUrl = url;
+          return true;
+        },
+        exchange: async (params) => {
+          exchanged = params;
+          return TOKENS;
+        },
+      }),
+    );
+
+    const url = new URL(authorizationUrl);
+    expect(url.searchParams.get('code_challenge_method')).toBe('S256');
+    expect(url.searchParams.get('redirect_uri')).toBe(
+      'http://127.0.0.1:51372/callback',
+    );
+    expect(url.searchParams.get('code_challenge')).toBeTruthy();
+    // The verifier is what proves the exchange belongs to this attempt, and it
+    // must never appear on the authorization request.
+    expect(authorizationUrl).not.toContain(exchanged?.codeVerifier ?? 'absent');
+    expect(exchanged?.redirectUri).toBe('http://127.0.0.1:51372/callback');
+  });
+
+  it('honors an explicit environment name', async () => {
+    const result = await performOAuthLogin({ name: 'my-env' }, fakeDeps());
+
+    expect(result.name).toBe('my-env');
+    expect(await getEnvironment('my-env')).not.toBeNull();
+  });
+
+  it('activates the new login by default', async () => {
+    await performOAuthLogin({}, fakeDeps());
+
+    expect((await getCurrentEnvironment())?.name).toBe('acme-inc-production');
+  });
+
+  it('leaves the active selection alone when activation is declined', async () => {
+    await setEnvironment('existing', {
+      token: { tokenId: 'id', tokenSecret: 'secret' },
+    });
+
+    await performOAuthLogin({ activate: false }, fakeDeps());
+
+    expect((await getCurrentEnvironment())?.name).toBe('existing');
+    expect(await getEnvironment('acme-inc-production')).not.toBeNull();
+  });
+
+  it('replaces tokens in place when logging in to an already stored environment', async () => {
+    await setEnvironment('previous-name', {
+      oauth: {
+        accessToken: 'old_access',
+        refreshToken: 'old_refresh',
+        expiresAt: 1,
+      },
+      environmentId: 'env_123',
+      signingKeyId: 'key_1',
+      signingPrivateKey: 'private_1',
+      forwardUrl: 'http://localhost:3000/webhooks',
+    });
+
+    const result = await performOAuthLogin({}, fakeDeps());
+
+    // Matched by environment id, not by name: the existing entry is updated
+    // rather than a duplicate being created.
+    expect(result.name).toBe('previous-name');
+    const stored = (await getEnvironment('previous-name')) as Environment;
+    expect(stored.oauth?.accessToken).toBe('access_1');
+    expect(stored.signingKeyId).toBe('key_1');
+    expect(stored.signingPrivateKey).toBe('private_1');
+    expect(stored.forwardUrl).toBe('http://localhost:3000/webhooks');
+    expect(await getEnvironment('acme-inc-production')).toBeNull();
+  });
+
+  it('adds an entry when logging in to a different environment', async () => {
+    await setEnvironment('acme-inc-staging', {
+      oauth: {
+        accessToken: 'staging_access',
+        refreshToken: 'staging_refresh',
+        expiresAt: 1,
+      },
+      environmentId: 'env_staging',
+    });
+
+    await performOAuthLogin({}, fakeDeps());
+
+    // Re-login must never clobber a different environment's credentials.
+    const staging = (await getEnvironment('acme-inc-staging')) as Environment;
+    expect(staging.oauth?.accessToken).toBe('staging_access');
+    expect(await getEnvironment('acme-inc-production')).not.toBeNull();
+  });
+
+  it('keeps an existing access token pair alongside the new OAuth login', async () => {
+    await setEnvironment('ci-token', {
+      token: { tokenId: 'id', tokenSecret: 'secret' },
+      environmentId: 'env_123',
+      forwardUrl: 'http://localhost:3000/webhooks',
+    });
+
+    const result = await performOAuthLogin({}, fakeDeps());
+
+    expect(result.name).toBe('ci-token');
+    const stored = (await getEnvironment('ci-token')) as Environment;
+    expect(stored.oauth?.accessToken).toBe('access_1');
+    expect(stored.forwardUrl).toBe('http://localhost:3000/webhooks');
+    // One environment, two ways in: signing in with OAuth must not throw away
+    // a token pair that CI or a script may depend on.
+    expect(stored.token).toEqual({ tokenId: 'id', tokenSecret: 'secret' });
+    expect(getEnvironmentAuthType(stored)).toBe('oauth');
+  });
+
+  it('carries a token pair across when --name moves the entry', async () => {
+    await setEnvironment('old-name', {
+      token: { tokenId: 'id', tokenSecret: 'secret' },
+      environmentId: 'env_123',
+      signingKeyId: 'key_1',
+    });
+
+    await performOAuthLogin({ name: 'new-name' }, fakeDeps());
+
+    const stored = (await getEnvironment('new-name')) as Environment;
+    expect(stored.token).toEqual({ tokenId: 'id', tokenSecret: 'secret' });
+    expect(stored.signingKeyId).toBe('key_1');
+    expect(await getEnvironment('old-name')).toBeNull();
+  });
+
+  it('reports the authorization URL when no browser could be opened', async () => {
+    let reported: { url: string; opened: boolean } | undefined;
+
+    await performOAuthLogin(
+      { noBrowser: true },
+      fakeDeps({
+        openBrowser: async () => false,
+        onAuthorizationUrl: (url, opened) => {
+          reported = { url, opened };
+        },
+      }),
+    );
+
+    expect(reported?.opened).toBe(false);
+    expect(reported?.url).toContain('code_challenge');
+  });
+
+  it('does not open a browser when asked not to', async () => {
+    let opened = false;
+
+    await performOAuthLogin(
+      { noBrowser: true },
+      fakeDeps({
+        openBrowser: async () => {
+          opened = true;
+          return true;
+        },
+      }),
+    );
+
+    expect(opened).toBe(false);
+  });
+
+  it('stores nothing when the token could not be verified', async () => {
+    const failing = fakeDeps({
+      validate: async () => ({
+        valid: false as const,
+        error: 'Could not verify the access token: 401 Unauthorized.',
+      }),
+    });
+
+    await expect(performOAuthLogin({}, failing)).rejects.toThrow(
+      /could not verify/i,
+    );
+
+    expect(await getCurrentEnvironment()).toBeNull();
+  });
+
+  it('stores nothing when the redirect never arrives', async () => {
+    const failing = fakeDeps({
+      startServer: async () => ({
+        port: 51372,
+        redirectUri: 'http://127.0.0.1:51372/callback',
+        waitForCode: async () => {
+          throw new Error('Login timed out after 300s');
+        },
+        stop: () => {},
+      }),
+    });
+
+    await expect(performOAuthLogin({}, failing)).rejects.toThrow(/timed out/);
+
+    expect(await getCurrentEnvironment()).toBeNull();
+  });
+
+  it('closes the loopback server whether the login succeeds or fails', async () => {
+    let stopped = 0;
+    const server = {
+      port: 51372,
+      redirectUri: 'http://127.0.0.1:51372/callback',
+      waitForCode: async () => 'auth_code',
+      stop: () => {
+        stopped += 1;
+      },
+    };
+
+    await performOAuthLogin({}, fakeDeps({ startServer: async () => server }));
+    expect(stopped).toBeGreaterThan(0);
+
+    const before = stopped;
+    await performOAuthLogin(
+      {},
+      fakeDeps({
+        startServer: async () => server,
+        exchange: async () => {
+          throw new Error('exchange failed');
+        },
+      }),
+    ).catch(() => undefined);
+
+    expect(stopped).toBeGreaterThan(before);
+  });
+
+  it('passes an explicit port through to the loopback server', async () => {
+    let requestedPort: number | undefined;
+
+    await performOAuthLogin(
+      { port: 9999 },
+      fakeDeps({
+        startServer: async (options) => {
+          requestedPort = options.port;
+          return {
+            port: options.port ?? 51372,
+            redirectUri: `http://127.0.0.1:${options.port}/callback`,
+            waitForCode: async () => 'auth_code',
+            stop: () => {},
+          };
+        },
+      }),
+    );
+
+    expect(requestedPort).toBe(9999);
+  });
+});

--- a/src/lib/oauth-login.test.ts
+++ b/src/lib/oauth-login.test.ts
@@ -275,6 +275,22 @@ describe('performOAuthLogin', () => {
     expect(await getEnvironment('old-name')).toBeNull();
   });
 
+  it('carries a custom base URL across when --name moves the entry', async () => {
+    // Otherwise a staging or self-hosted environment silently reverts to the
+    // default API host on rename.
+    await setEnvironment('old-name', {
+      token: { tokenId: 'id', tokenSecret: 'secret' },
+      environmentId: 'env_123',
+      baseUrl: 'https://api.staging.example.com',
+    });
+
+    await performOAuthLogin({ name: 'new-name' }, fakeDeps());
+
+    expect((await getEnvironment('new-name'))?.baseUrl).toBe(
+      'https://api.staging.example.com',
+    );
+  });
+
   it('reports the authorization URL when no browser could be opened', async () => {
     let reported: { url: string; opened: boolean } | undefined;
 

--- a/src/lib/oauth-login.ts
+++ b/src/lib/oauth-login.ts
@@ -1,0 +1,293 @@
+import { openBrowser as defaultOpenBrowser } from './browser.ts';
+import {
+  type Environment,
+  findEnvironmentByEnvironmentId,
+  getEnvironment,
+  listEnvironments,
+  type OAuthCredentials,
+  removeEnvironment,
+  setCredential,
+  setCurrentEnvironment,
+  updateEnvironment,
+} from './config.ts';
+import {
+  type CredentialIdentity,
+  validateAccessToken as defaultValidateAccessToken,
+  getMuxBaseUrl,
+} from './mux.ts';
+import {
+  buildAuthorizationUrl,
+  exchangeCodeForTokens as defaultExchange,
+  getServerCapabilities,
+  type OAuthEndpoints,
+  OAuthError,
+  type OAuthTokens,
+  resolveOAuthEndpoints,
+} from './oauth.ts';
+import {
+  startLoopbackServer as defaultStartServer,
+  type LoopbackServer,
+  type StartLoopbackOptions,
+} from './oauth-loopback.ts';
+import {
+  computeCodeChallenge,
+  generateCodeVerifier,
+  generateState,
+} from './pkce.ts';
+
+/**
+ * Orchestration for a browser-based login: PKCE, loopback redirect, token
+ * exchange, identity verification, and storage.
+ *
+ * Every external step is injectable so the flow can be tested without a browser
+ * or a network, and so the command layer owns all terminal output.
+ */
+
+export interface OAuthLoginOptions {
+  /** Override the derived environment name. */
+  name?: string;
+  /** Force a specific loopback port. */
+  port?: number;
+  /** Print the authorization URL instead of opening a browser. */
+  noBrowser?: boolean;
+  /** Make this the active environment. Defaults to true. */
+  activate?: boolean;
+  /** API host for identity verification. Defaults to the resolved Mux base URL. */
+  baseUrl?: string;
+}
+
+export interface OAuthLoginDeps {
+  startServer?: (options: StartLoopbackOptions) => Promise<LoopbackServer>;
+  openBrowser?: (url: string) => Promise<boolean>;
+  exchange?: (params: {
+    code: string;
+    codeVerifier: string;
+    redirectUri: string;
+    endpoints?: OAuthEndpoints;
+  }) => Promise<OAuthTokens>;
+  /** Skip endpoint resolution (and therefore discovery) entirely. */
+  endpoints?: OAuthEndpoints;
+  validate?: (
+    accessToken: string,
+    baseUrl?: string,
+  ) => Promise<
+    | { valid: true; identity: CredentialIdentity }
+    | { valid: false; error: string }
+  >;
+  /**
+   * Called once the authorization URL is known, with whether a browser was
+   * opened. The command layer prints it.
+   */
+  onAuthorizationUrl?: (url: string, opened: boolean) => void;
+}
+
+export interface OAuthLoginResult {
+  /** The environment name the login was stored under. */
+  name: string;
+  /** The stored entry as it now stands, including any access token pair kept. */
+  environment: Environment;
+  identity: CredentialIdentity;
+  /** Whether this login became the active environment. */
+  activated: boolean;
+  /** True when an existing entry for the same environment was updated. */
+  replacedExisting: boolean;
+}
+
+/**
+ * Check what the authorization server advertises, when discovery told us.
+ *
+ * Both checks fail (or warn) at login, where the user can act on it, rather than
+ * surfacing as a confusing error at exchange time or hours later on the first
+ * refresh. Silence here means discovery was unavailable — nothing is asserted
+ * about a server we could not ask.
+ */
+function assertServerSupportsFlow(): void {
+  const { codeChallengeMethods, grantTypes } = getServerCapabilities();
+
+  if (codeChallengeMethods && !codeChallengeMethods.includes('S256')) {
+    throw new OAuthError(
+      `The Mux authorization server does not advertise support for PKCE S256 (only ${codeChallengeMethods.join(
+        ', ',
+      )}). This CLI will not fall back to a weaker method; please report this.`,
+      { terminal: true, code: 'pkce_unsupported' },
+    );
+  }
+
+  if (grantTypes && !grantTypes.includes('refresh_token')) {
+    // Not fatal: the login still works, it just will not renew itself.
+    console.error(
+      'Warning: the Mux authorization server does not advertise the refresh_token grant. This login will stop working when its access token expires, and you will need to run `mux login` again.',
+    );
+  }
+}
+
+function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+/**
+ * Derive a local name for a login. Collisions get a numeric suffix: two
+ * different Mux environments must never share one config entry.
+ */
+export function deriveEnvironmentName(params: {
+  organizationName?: string;
+  environmentName?: string;
+  environmentId?: string;
+  taken: string[];
+}): string {
+  const parts = [params.organizationName, params.environmentName]
+    .filter((part): part is string => Boolean(part?.trim()))
+    .map(slugify)
+    .filter(Boolean);
+
+  const base =
+    parts.join('-') || slugify(params.environmentId ?? '') || 'default';
+  // Preserve the environment id verbatim when it is the only identifier: it is
+  // already unique and slugifying would mangle it.
+  const candidate =
+    parts.length === 0 && params.environmentId ? params.environmentId : base;
+
+  const taken = new Set(params.taken);
+  if (!taken.has(candidate)) return candidate;
+
+  let suffix = 2;
+  while (taken.has(`${candidate}-${suffix}`)) {
+    suffix += 1;
+  }
+  return `${candidate}-${suffix}`;
+}
+
+export async function performOAuthLogin(
+  options: OAuthLoginOptions,
+  deps: OAuthLoginDeps = {},
+): Promise<OAuthLoginResult> {
+  const startServer = deps.startServer ?? defaultStartServer;
+  const openBrowser = deps.openBrowser ?? defaultOpenBrowser;
+  const exchange = deps.exchange ?? defaultExchange;
+  const validate = deps.validate ?? defaultValidateAccessToken;
+
+  const codeVerifier = generateCodeVerifier();
+  const codeChallenge = computeCodeChallenge(codeVerifier);
+  const state = generateState();
+
+  const server = await startServer({
+    state,
+    ...(options.port !== undefined && { port: options.port }),
+  });
+
+  let tokens: OAuthTokens;
+  try {
+    // Resolved once, then used for both legs: the authorization request and the
+    // token exchange must agree, and the server may have moved an endpoint.
+    const endpoints =
+      deps.endpoints ?? (await resolveOAuthEndpoints(options.baseUrl));
+    assertServerSupportsFlow();
+
+    const authorizationUrl = buildAuthorizationUrl({
+      codeChallenge,
+      state,
+      redirectUri: server.redirectUri,
+      endpoints,
+    });
+
+    const opened = options.noBrowser
+      ? false
+      : await openBrowser(authorizationUrl).catch(() => false);
+    deps.onAuthorizationUrl?.(authorizationUrl, opened);
+
+    const code = await server.waitForCode();
+    tokens = await exchange({
+      code,
+      codeVerifier,
+      redirectUri: server.redirectUri,
+      endpoints,
+    });
+  } finally {
+    // The listener holds an authorization code path open; close it on every
+    // exit, not just the successful one.
+    server.stop();
+  }
+
+  const baseUrl = options.baseUrl ?? getMuxBaseUrl(null);
+  const verification = await validate(tokens.accessToken, baseUrl);
+  if (!verification.valid) {
+    // Nothing is written: a login stored for an unverified environment would
+    // desync the config from the credential it holds.
+    throw new Error(verification.error);
+  }
+  const identity = verification.identity;
+
+  const existing = identity.environmentId
+    ? await findEnvironmentByEnvironmentId(identity.environmentId)
+    : null;
+
+  const name =
+    options.name ??
+    existing?.name ??
+    deriveEnvironmentName({
+      organizationName: identity.organizationName,
+      environmentName: identity.environmentName,
+      environmentId: identity.environmentId,
+      taken: await listEnvironments(),
+    });
+
+  const oauth: OAuthCredentials = {
+    accessToken: tokens.accessToken,
+    refreshToken: tokens.refreshToken,
+    expiresAt: tokens.expiresAt,
+    tokenType: tokens.tokenType,
+    ...(tokens.scope && { scope: tokens.scope }),
+  };
+
+  // Identity comes from the grant; the rest of the entry — signing keys, forward
+  // URL, base URL, and any access token pair saved for this same environment —
+  // is left exactly as it was. An environment can be reachable both ways.
+  await setCredential(name, 'oauth', oauth, {
+    ...(identity.environmentId && { environmentId: identity.environmentId }),
+    ...(identity.environmentName && {
+      environmentName: identity.environmentName,
+    }),
+    ...(identity.organizationId && { organizationId: identity.organizationId }),
+    ...(identity.organizationName && {
+      organizationName: identity.organizationName,
+    }),
+    ...(options.baseUrl && { baseUrl: options.baseUrl }),
+  });
+
+  // An explicit --name that points somewhere else would leave a second entry for
+  // the same environment behind. Move the old entry's environment-bound state
+  // and credentials across, then drop it, so one environment maps to one entry.
+  if (existing && existing.name !== name) {
+    await updateEnvironment(name, {
+      ...(existing.environment.signingKeyId && {
+        signingKeyId: existing.environment.signingKeyId,
+      }),
+      ...(existing.environment.signingPrivateKey && {
+        signingPrivateKey: existing.environment.signingPrivateKey,
+      }),
+      ...(existing.environment.forwardUrl && {
+        forwardUrl: existing.environment.forwardUrl,
+      }),
+      ...(existing.environment.token && { token: existing.environment.token }),
+    });
+    await removeEnvironment(existing.name);
+  }
+
+  const environment = (await getEnvironment(name)) ?? { oauth };
+
+  const activate = options.activate !== false;
+  if (activate) {
+    await setCurrentEnvironment(name);
+  }
+
+  return {
+    name,
+    environment,
+    identity,
+    activated: activate,
+    replacedExisting: Boolean(existing),
+  };
+}

--- a/src/lib/oauth-login.ts
+++ b/src/lib/oauth-login.ts
@@ -101,8 +101,31 @@ export interface OAuthLoginResult {
  * refresh. Silence here means discovery was unavailable — nothing is asserted
  * about a server we could not ask.
  */
-function assertServerSupportsFlow(): void {
-  const { codeChallengeMethods, grantTypes } = getServerCapabilities();
+function assertServerSupportsFlow(requestedScopes: string[]): void {
+  const { codeChallengeMethods, grantTypes, scopes } = getServerCapabilities();
+
+  if (requestedScopes.length === 0) {
+    throw new OAuthError(
+      'No OAuth scopes are configured, and the Mux authorization server requires at least one. Set MUX_OAUTH_SCOPES, or report this as a bug in the CLI.',
+      { terminal: true, code: 'no_scopes' },
+    );
+  }
+
+  if (scopes) {
+    // A scope the server does not offer is either a typo or drift between the
+    // CLI and the server. Warn rather than fail: the server decides what to
+    // grant, and refusing to log in over an extra scope would be worse.
+    const unsupported = requestedScopes.filter(
+      (scope) => !scopes.includes(scope),
+    );
+    if (unsupported.length > 0) {
+      console.error(
+        `Warning: requesting ${unsupported.join(
+          ', ',
+        )}, which the Mux authorization server does not list as supported. The login may be rejected, or granted fewer permissions than expected.`,
+      );
+    }
+  }
 
   if (codeChallengeMethods && !codeChallengeMethods.includes('S256')) {
     throw new OAuthError(
@@ -184,7 +207,7 @@ export async function performOAuthLogin(
     // token exchange must agree, and the server may have moved an endpoint.
     const endpoints =
       deps.endpoints ?? (await resolveOAuthEndpoints(options.baseUrl));
-    assertServerSupportsFlow();
+    assertServerSupportsFlow(endpoints.scopes);
 
     const authorizationUrl = buildAuthorizationUrl({
       codeChallenge,

--- a/src/lib/oauth-login.ts
+++ b/src/lib/oauth-login.ts
@@ -53,6 +53,8 @@ export interface OAuthLoginOptions {
   noBrowser?: boolean;
   /** Make this the active environment. Defaults to true. */
   activate?: boolean;
+  /** How long to wait for the browser redirect. Defaults to the loopback server's own timeout. */
+  timeoutMs?: number;
   /** API host for identity verification. Defaults to the resolved Mux base URL. */
   baseUrl?: string;
 }
@@ -218,6 +220,7 @@ export async function performOAuthLogin(
   const server = await startServer({
     state,
     ...(options.port !== undefined && { port: options.port }),
+    ...(options.timeoutMs !== undefined && { timeoutMs: options.timeoutMs }),
   });
 
   let tokens: OAuthTokens;

--- a/src/lib/oauth-login.ts
+++ b/src/lib/oauth-login.ts
@@ -271,6 +271,11 @@ export async function performOAuthLogin(
       ...(existing.environment.forwardUrl && {
         forwardUrl: existing.environment.forwardUrl,
       }),
+      // The host binding is environment-bound too: dropping it would silently
+      // revert a staging or self-hosted environment to the default API host.
+      ...(existing.environment.baseUrl && {
+        baseUrl: existing.environment.baseUrl,
+      }),
       ...(existing.environment.token && { token: existing.environment.token }),
     });
     await removeEnvironment(existing.name);

--- a/src/lib/oauth-login.ts
+++ b/src/lib/oauth-login.ts
@@ -10,6 +10,7 @@ import {
   setCurrentEnvironment,
   setEnvironment,
 } from './config.ts';
+import { environmentSettings } from './credentials.ts';
 import {
   type CredentialIdentity,
   validateAccessToken as defaultValidateAccessToken,
@@ -151,19 +152,13 @@ function assertServerSupportsFlow(requestedScopes: string[]): void {
 }
 
 /**
- * The parts of an entry that describe the *environment* rather than a credential:
- * they survive re-login, but only onto the same environment.
+ * Environment settings plus the access token pair: everything that should follow
+ * an environment across a re-login or a rename, but never follow a *name* onto a
+ * different environment.
  */
 function environmentBoundState(environment: Environment) {
   return {
-    ...(environment.signingKeyId && {
-      signingKeyId: environment.signingKeyId,
-    }),
-    ...(environment.signingPrivateKey && {
-      signingPrivateKey: environment.signingPrivateKey,
-    }),
-    ...(environment.forwardUrl && { forwardUrl: environment.forwardUrl }),
-    ...(environment.baseUrl && { baseUrl: environment.baseUrl }),
+    ...environmentSettings(environment),
     ...(environment.token && { token: environment.token }),
   };
 }

--- a/src/lib/oauth-login.ts
+++ b/src/lib/oauth-login.ts
@@ -5,10 +5,10 @@ import {
   getEnvironment,
   listEnvironments,
   type OAuthCredentials,
+  readConfig,
   removeEnvironment,
-  setCredential,
   setCurrentEnvironment,
-  updateEnvironment,
+  setEnvironment,
 } from './config.ts';
 import {
   type CredentialIdentity,
@@ -91,6 +91,12 @@ export interface OAuthLoginResult {
   activated: boolean;
   /** True when an existing entry for the same environment was updated. */
   replacedExisting: boolean;
+  /**
+   * Environment-bound fields discarded because the requested name held a
+   * different Mux environment. Reported so the command layer can say so rather
+   * than dropping a signing key or token pair silently.
+   */
+  dropped: string[];
 }
 
 /**
@@ -142,6 +148,24 @@ function assertServerSupportsFlow(requestedScopes: string[]): void {
       'Warning: the Mux authorization server does not advertise the refresh_token grant. This login will stop working when its access token expires, and you will need to run `mux login` again.',
     );
   }
+}
+
+/**
+ * The parts of an entry that describe the *environment* rather than a credential:
+ * they survive re-login, but only onto the same environment.
+ */
+function environmentBoundState(environment: Environment) {
+  return {
+    ...(environment.signingKeyId && {
+      signingKeyId: environment.signingKeyId,
+    }),
+    ...(environment.signingPrivateKey && {
+      signingPrivateKey: environment.signingPrivateKey,
+    }),
+    ...(environment.forwardUrl && { forwardUrl: environment.forwardUrl }),
+    ...(environment.baseUrl && { baseUrl: environment.baseUrl }),
+    ...(environment.token && { token: environment.token }),
+  };
 }
 
 function slugify(value: string): string {
@@ -265,10 +289,30 @@ export async function performOAuthLogin(
     ...(tokens.scope && { scope: tokens.scope }),
   };
 
-  // Identity comes from the grant; the rest of the entry — signing keys, forward
-  // URL, base URL, and any access token pair saved for this same environment —
-  // is left exactly as it was. An environment can be reachable both ways.
-  await setCredential(name, 'oauth', oauth, {
+  // The entry that already represents this Mux environment, under whatever name,
+  // versus whatever currently occupies the name being written to. They are only
+  // the same thing when no explicit --name repointed it.
+  const target = await getEnvironment(name);
+  const targetIsThisEnvironment = Boolean(
+    target?.environmentId && target.environmentId === identity.environmentId,
+  );
+
+  // Signing keys, forward URL, host binding, and an access token pair belong to
+  // an *environment*, not to a name. They carry over only from an entry that
+  // provably represents the granted environment — otherwise `--name` would leave
+  // one environment's signing key and token pair attached to another's identity,
+  // which mints invalid playback tokens and silently falls back to the wrong
+  // account.
+  const source =
+    existing?.environment ?? (targetIsThisEnvironment ? target : undefined);
+  const dropped =
+    target && !targetIsThisEnvironment && target !== source
+      ? Object.keys(environmentBoundState(target))
+      : [];
+
+  // Written as one whole entry rather than merged into whatever was there.
+  await setEnvironment(name, {
+    ...(source ? environmentBoundState(source) : {}),
     ...(identity.environmentId && { environmentId: identity.environmentId }),
     ...(identity.environmentName && {
       environmentName: identity.environmentName,
@@ -278,30 +322,23 @@ export async function performOAuthLogin(
       organizationName: identity.organizationName,
     }),
     ...(options.baseUrl && { baseUrl: options.baseUrl }),
+    oauth,
   });
 
   // An explicit --name that points somewhere else would leave a second entry for
-  // the same environment behind. Move the old entry's environment-bound state
-  // and credentials across, then drop it, so one environment maps to one entry.
+  // the same environment behind, so the old one goes. Its state was already
+  // carried across above.
   if (existing && existing.name !== name) {
-    await updateEnvironment(name, {
-      ...(existing.environment.signingKeyId && {
-        signingKeyId: existing.environment.signingKeyId,
-      }),
-      ...(existing.environment.signingPrivateKey && {
-        signingPrivateKey: existing.environment.signingPrivateKey,
-      }),
-      ...(existing.environment.forwardUrl && {
-        forwardUrl: existing.environment.forwardUrl,
-      }),
-      // The host binding is environment-bound too: dropping it would silently
-      // revert a staging or self-hosted environment to the default API host.
-      ...(existing.environment.baseUrl && {
-        baseUrl: existing.environment.baseUrl,
-      }),
-      ...(existing.environment.token && { token: existing.environment.token }),
-    });
+    // Removing an entry reassigns `defaultEnvironment` when it was the active
+    // one, which would silently switch the user to an unrelated environment.
+    // A rename is the same environment under a new name, so the selection
+    // follows it.
+    const wasActive =
+      (await readConfig())?.defaultEnvironment === existing.name;
     await removeEnvironment(existing.name);
+    if (wasActive) {
+      await setCurrentEnvironment(name);
+    }
   }
 
   const environment = (await getEnvironment(name)) ?? { oauth };
@@ -314,6 +351,7 @@ export async function performOAuthLogin(
   return {
     name,
     environment,
+    dropped,
     identity,
     activated: activate,
     replacedExisting: Boolean(existing),

--- a/src/lib/oauth-loopback.test.ts
+++ b/src/lib/oauth-loopback.test.ts
@@ -84,7 +84,7 @@ describe('startLoopbackServer', () => {
   });
 
   it('renders the page template with no placeholders left behind', async () => {
-    // Guards against a renamed placeholder silently shipping `{{title}}` to a
+    // Guards against a renamed marker silently shipping `__MUX_TITLE__` to a
     // user's browser.
     const server = await startTestServer();
     try {
@@ -96,7 +96,7 @@ describe('startLoopbackServer', () => {
 
       expect(body).toContain('Login complete');
       expect(body).toContain('Return to your terminal');
-      expect(body).not.toContain('{{');
+      expect(body).not.toContain('__MUX_');
     } finally {
       server.stop();
     }

--- a/src/lib/oauth-loopback.test.ts
+++ b/src/lib/oauth-loopback.test.ts
@@ -83,6 +83,25 @@ describe('startLoopbackServer', () => {
     }
   });
 
+  it('renders the page template with no placeholders left behind', async () => {
+    // Guards against a renamed placeholder silently shipping `{{title}}` to a
+    // user's browser.
+    const server = await startTestServer();
+    try {
+      const waiting = server.waitForCode();
+      const body = await (
+        await callback(server.port, `code=c&state=${STATE}`)
+      ).text();
+      await waiting;
+
+      expect(body).toContain('Login complete');
+      expect(body).toContain('Return to your terminal');
+      expect(body).not.toContain('{{');
+    } finally {
+      server.stop();
+    }
+  });
+
   it('rejects without resolving a code when state does not match', async () => {
     const server = await startTestServer();
     try {

--- a/src/lib/oauth-loopback.test.ts
+++ b/src/lib/oauth-loopback.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, it } from 'bun:test';
+import { startLoopbackServer } from './oauth-loopback.ts';
+
+const STATE = 'test-state-value';
+
+/**
+ * Start a server on an OS-assigned port. Tests must not share the default
+ * candidate port: a browser keep-alive connection can hold a just-stopped
+ * listener open, and a second server on the same port would then split traffic
+ * with it.
+ */
+function startTestServer(
+  options: Partial<Parameters<typeof startLoopbackServer>[0]> = {},
+) {
+  return startLoopbackServer({ state: STATE, ports: [0], ...options });
+}
+
+/** Fetch the callback path on the server's own port. */
+function callback(port: number, query: string): Promise<Response> {
+  return fetch(`http://127.0.0.1:${port}/callback?${query}`);
+}
+
+describe('startLoopbackServer', () => {
+  it('exposes a loopback redirect URI on the bound port', async () => {
+    const server = await startTestServer();
+    try {
+      expect(server.redirectUri).toBe(
+        `http://127.0.0.1:${server.port}/callback`,
+      );
+      expect(server.port).toBeGreaterThan(0);
+    } finally {
+      server.stop();
+    }
+  });
+
+  it('resolves with the authorization code when state matches', async () => {
+    const server = await startTestServer();
+    try {
+      const waiting = server.waitForCode();
+      const response = await callback(
+        server.port,
+        `code=auth_code_123&state=${STATE}`,
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get('content-type')).toContain('text/html');
+      expect(await waiting).toBe('auth_code_123');
+    } finally {
+      server.stop();
+    }
+  });
+
+  it('does not leak the authorization code into the success page', async () => {
+    const server = await startTestServer();
+    try {
+      const waiting = server.waitForCode();
+      const response = await callback(
+        server.port,
+        `code=secret_code_abc&state=${STATE}`,
+      );
+      const body = await response.text();
+      await waiting;
+
+      expect(body).not.toContain('secret_code_abc');
+    } finally {
+      server.stop();
+    }
+  });
+
+  it('serves a self-contained page with no external requests', async () => {
+    const server = await startTestServer();
+    try {
+      const waiting = server.waitForCode();
+      const body = await (
+        await callback(server.port, `code=c&state=${STATE}`)
+      ).text();
+      await waiting;
+
+      expect(body).not.toMatch(/https?:\/\//);
+      expect(body).not.toContain('<script');
+    } finally {
+      server.stop();
+    }
+  });
+
+  it('rejects without resolving a code when state does not match', async () => {
+    const server = await startTestServer();
+    try {
+      const waiting = server.waitForCode();
+      const response = await callback(
+        server.port,
+        'code=auth_code_123&state=wrong-state',
+      );
+
+      expect(response.status).toBe(400);
+      await expect(waiting).rejects.toThrow(/state/i);
+    } finally {
+      server.stop();
+    }
+  });
+
+  it('rejects when the provider returns an error instead of a code', async () => {
+    const server = await startTestServer();
+    try {
+      const waiting = server.waitForCode();
+      await callback(
+        server.port,
+        `error=access_denied&error_description=User%20said%20no&state=${STATE}`,
+      );
+
+      await expect(waiting).rejects.toThrow(/User said no/);
+    } finally {
+      server.stop();
+    }
+  });
+
+  it('rejects when the callback carries neither a code nor an error', async () => {
+    const server = await startTestServer();
+    try {
+      const waiting = server.waitForCode();
+      await callback(server.port, `state=${STATE}`);
+
+      await expect(waiting).rejects.toThrow();
+    } finally {
+      server.stop();
+    }
+  });
+
+  it('returns 404 for any path other than the callback', async () => {
+    const server = await startTestServer();
+    try {
+      const response = await fetch(`http://127.0.0.1:${server.port}/`);
+
+      expect(response.status).toBe(404);
+    } finally {
+      server.stop();
+    }
+  });
+
+  it('ignores a second callback after the first has been accepted', async () => {
+    const server = await startTestServer();
+    try {
+      const waiting = server.waitForCode();
+      await callback(server.port, `code=first&state=${STATE}`);
+      expect(await waiting).toBe('first');
+
+      // A replayed or refreshed callback is refused and cannot change the
+      // accepted code.
+      const second = await callback(
+        server.port,
+        `code=second&state=${STATE}`,
+      ).catch(() => null);
+      if (second) {
+        expect(second.status).toBe(410);
+      }
+      expect(await waiting).toBe('first');
+    } finally {
+      server.stop();
+    }
+  });
+
+  it('rejects when no callback arrives before the timeout', async () => {
+    const server = await startTestServer({ timeoutMs: 50 });
+    try {
+      await expect(server.waitForCode()).rejects.toThrow(/timed out|timeout/i);
+    } finally {
+      server.stop();
+    }
+  });
+
+  it('defaults to an OS-assigned port, so concurrent logins never collide', async () => {
+    // No `ports` override here: this exercises the real default.
+    const first = await startLoopbackServer({ state: STATE });
+    const second = await startLoopbackServer({ state: STATE });
+    try {
+      expect(first.port).toBeGreaterThan(0);
+      expect(second.port).toBeGreaterThan(0);
+      expect(second.port).not.toBe(first.port);
+    } finally {
+      first.stop();
+      second.stop();
+    }
+  });
+
+  it('binds the requested port when one is given', async () => {
+    const probe = await startTestServer();
+    const port = probe.port;
+    probe.stop();
+
+    const server = await startLoopbackServer({ state: STATE, port });
+    try {
+      expect(server.port).toBe(port);
+    } finally {
+      server.stop();
+    }
+  });
+
+  it('frees the port on stop so it can be rebound', async () => {
+    const first = await startTestServer();
+    const port = first.port;
+    first.stop();
+
+    const second = await startLoopbackServer({ state: STATE, port });
+    try {
+      expect(second.port).toBe(port);
+    } finally {
+      second.stop();
+    }
+  });
+
+  it('falls back to another port when the preferred candidates are taken', async () => {
+    const blocker = await startTestServer();
+    try {
+      const server = await startLoopbackServer({
+        state: STATE,
+        ports: [blocker.port],
+      });
+      try {
+        expect(server.port).not.toBe(blocker.port);
+        expect(server.port).toBeGreaterThan(0);
+      } finally {
+        server.stop();
+      }
+    } finally {
+      blocker.stop();
+    }
+  });
+
+  it('fails loudly when an explicitly requested port is unavailable', async () => {
+    const blocker = await startTestServer();
+    try {
+      await expect(
+        startLoopbackServer({ state: STATE, port: blocker.port }),
+      ).rejects.toThrow(/port/i);
+    } finally {
+      blocker.stop();
+    }
+  });
+
+  it('rejects the pending wait when the server is stopped (cancellation)', async () => {
+    const server = await startTestServer();
+    const waiting = server.waitForCode();
+    server.stop();
+
+    await expect(waiting).rejects.toThrow(/cancel/i);
+  });
+});

--- a/src/lib/oauth-loopback.ts
+++ b/src/lib/oauth-loopback.ts
@@ -1,5 +1,15 @@
 import { timingSafeEqual } from 'node:crypto';
 import { OAuthError } from './oauth.ts';
+// Imported as text, so the page lives in a real .html file and gets inlined at
+// build time — including into the compiled binary, which has no filesystem to
+// read from. Bun's types declare every .html import as its full-stack
+// HTMLBundle, ignoring the `type: 'text'` attribute, so the string this actually
+// evaluates to has to be asserted.
+import callbackTemplateModule from './oauth-callback.html' with {
+  type: 'text',
+};
+
+const callbackTemplate = callbackTemplateModule as unknown as string;
 
 /**
  * Loopback redirect receiver for the OAuth authorization code flow (RFC 8252).
@@ -55,12 +65,23 @@ export interface StartLoopbackOptions {
   timeoutMs?: number;
 }
 
-function page(title: string, body: string, status = 200): Response {
-  // Self-contained: no external requests, no scripts, no token material.
-  return new Response(
-    `<!doctype html><html lang="en"><head><meta charset="utf-8"><title>${title}</title><style>body{font-family:system-ui,-apple-system,sans-serif;max-width:32rem;margin:6rem auto;padding:0 1.5rem;color:#111}h1{font-size:1.25rem}p{color:#444;line-height:1.5}</style></head><body><h1>${title}</h1><p>${body}</p></body></html>`,
-    { status, headers: { 'Content-Type': 'text/html; charset=utf-8' } },
-  );
+/**
+ * Render the browser-facing page from the template in oauth-callback.html.
+ *
+ * Only literal strings defined in this file are substituted — never anything
+ * from the redirect — so there is nothing to escape and no way for a provider
+ * response to reach the markup. Keep it that way: if a caller ever needs to show
+ * provider text, escape it here first.
+ */
+function page(title: string, message: string, status = 200): Response {
+  const html = callbackTemplate
+    .replaceAll('{{title}}', title)
+    .replaceAll('{{message}}', message);
+
+  return new Response(html, {
+    status,
+    headers: { 'Content-Type': 'text/html; charset=utf-8' },
+  });
 }
 
 /** Compare state values without leaking length or content through timing. */

--- a/src/lib/oauth-loopback.ts
+++ b/src/lib/oauth-loopback.ts
@@ -1,0 +1,276 @@
+import { timingSafeEqual } from 'node:crypto';
+import { OAuthError } from './oauth.ts';
+
+/**
+ * Loopback redirect receiver for the OAuth authorization code flow (RFC 8252).
+ *
+ * The server binds 127.0.0.1 only — a redirect listener holding an
+ * authorization code must not be reachable from off-host — serves exactly one
+ * path, accepts exactly one successful callback, and then closes.
+ */
+
+/**
+ * An OS-assigned ephemeral port is the default, per RFC 8252 section 7.3: the
+ * Mux authorization server accepts `http://127.0.0.1:<any port>/callback`, so
+ * there is nothing to gain from a fixed port and two things to lose — a
+ * collision with whatever else holds that port, and two concurrent logins
+ * fighting over it. `--port` remains for cases that need a predictable port,
+ * notably SSH port forwarding.
+ */
+const EPHEMERAL_PORT = [0];
+
+export const CALLBACK_PATH = '/callback';
+
+/** How long to wait for the user to finish authorizing in the browser. */
+export const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000;
+
+/**
+ * Grace period between accepting a callback and closing the listener, so the
+ * browser receives the complete success page. Callers that finish earlier call
+ * `stop()` themselves.
+ */
+const CLOSE_GRACE_MS = 250;
+
+export interface LoopbackServer {
+  /** The bound port. */
+  port: number;
+  /** The redirect URI to send on the authorization request. */
+  redirectUri: string;
+  /**
+   * Resolve with the authorization code, or reject: state mismatch, provider
+   * error, timeout, or cancellation via `stop()`.
+   */
+  waitForCode(): Promise<string>;
+  /** Close the listener. Rejects a still-pending wait as canceled. */
+  stop(): void;
+}
+
+export interface StartLoopbackOptions {
+  /** The `state` value this login attempt expects back. */
+  state: string;
+  /** Bind this exact port, failing if it is unavailable. */
+  port?: number;
+  /** Candidate ports to try before falling back to an ephemeral one. */
+  ports?: number[];
+  timeoutMs?: number;
+}
+
+function page(title: string, body: string, status = 200): Response {
+  // Self-contained: no external requests, no scripts, no token material.
+  return new Response(
+    `<!doctype html><html lang="en"><head><meta charset="utf-8"><title>${title}</title><style>body{font-family:system-ui,-apple-system,sans-serif;max-width:32rem;margin:6rem auto;padding:0 1.5rem;color:#111}h1{font-size:1.25rem}p{color:#444;line-height:1.5}</style></head><body><h1>${title}</h1><p>${body}</p></body></html>`,
+    { status, headers: { 'Content-Type': 'text/html; charset=utf-8' } },
+  );
+}
+
+/** Compare state values without leaking length or content through timing. */
+function statesMatch(expected: string, received: string): boolean {
+  const a = Buffer.from(expected, 'utf8');
+  const b = Buffer.from(received, 'utf8');
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}
+
+export async function startLoopbackServer(
+  options: StartLoopbackOptions,
+): Promise<LoopbackServer> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  let settle: ((code: string) => void) | undefined;
+  let fail: ((error: Error) => void) | undefined;
+  let done = false;
+
+  const codePromise = new Promise<string>((resolve, reject) => {
+    settle = (code) => {
+      if (done) return;
+      done = true;
+      resolve(code);
+    };
+    fail = (error) => {
+      if (done) return;
+      done = true;
+      reject(error);
+    };
+  });
+  // The caller may never call waitForCode() (an early failure elsewhere in
+  // login, for example). Attaching a handler here keeps that from surfacing as
+  // an unhandled rejection; the original promise still rejects for the caller.
+  codePromise.catch(() => {});
+
+  const handle = (request: Request): Response => {
+    const url = new URL(request.url);
+
+    if (done) {
+      // The login is already settled. A later callback — a refreshed tab, a
+      // replayed URL — must not reopen it or change the accepted code.
+      return page(
+        'Login already completed',
+        'This login has already finished. Return to your terminal.',
+        410,
+      );
+    }
+
+    if (url.pathname !== CALLBACK_PATH) {
+      return page(
+        'Not found',
+        'This address is not part of the Mux CLI login.',
+        404,
+      );
+    }
+
+    const state = url.searchParams.get('state') ?? '';
+    if (!statesMatch(options.state, state)) {
+      fail?.(
+        new OAuthError(
+          'The login response carried an unexpected state value and was rejected. Run `mux login` again.',
+          { terminal: true, code: 'state_mismatch' },
+        ),
+      );
+      return page(
+        'Login failed',
+        'Unexpected state value. Return to your terminal.',
+        400,
+      );
+    }
+
+    const error = url.searchParams.get('error');
+    if (error) {
+      const description =
+        url.searchParams.get('error_description') ?? undefined;
+      fail?.(
+        new OAuthError(
+          description
+            ? `Login was not completed: ${description}`
+            : `Login was not completed: ${error}`,
+          { terminal: true, code: error },
+        ),
+      );
+      return page('Login failed', 'Return to your terminal for details.');
+    }
+
+    const code = url.searchParams.get('code');
+    if (!code) {
+      fail?.(
+        new OAuthError(
+          'The login response contained neither an authorization code nor an error.',
+          { terminal: true },
+        ),
+      );
+      return page('Login failed', 'Return to your terminal for details.');
+    }
+
+    settle?.(code);
+    // One successful callback is all a login needs, and a lingering listener is
+    // attack surface — but the success page still has to reach the browser, so
+    // the close is scheduled rather than immediate. Further callbacks are
+    // refused in the meantime (see the `done` check above).
+    const closing = setTimeout(() => stop(), CLOSE_GRACE_MS);
+    closing.unref?.();
+    return page(
+      'Login complete',
+      'You are signed in to the Mux CLI. Return to your terminal.',
+    );
+  };
+
+  const server = await bind(options, handle);
+
+  const timer = setTimeout(() => {
+    fail?.(
+      new OAuthError(
+        `Login timed out after ${Math.round(
+          timeoutMs / 1000,
+        )}s waiting for the browser redirect.`,
+        { terminal: true, code: 'timeout' },
+      ),
+    );
+    stop();
+  }, timeoutMs);
+  // Never hold the process open on the timer alone.
+  timer.unref?.();
+
+  let stopped = false;
+  function stop(): void {
+    if (stopped) return;
+    stopped = true;
+    clearTimeout(timer);
+    // Force active connections closed. The success page has already flushed by
+    // the time the post-callback close fires (CLOSE_GRACE_MS), and a browser
+    // keep-alive connection would otherwise hold the listening socket open —
+    // leaving a redirect receiver alive after the login it served.
+    server.stop(true);
+    fail?.(
+      new OAuthError('Login canceled.', { terminal: true, code: 'canceled' }),
+    );
+  }
+
+  return {
+    port: server.port,
+    redirectUri: `http://127.0.0.1:${server.port}${CALLBACK_PATH}`,
+    waitForCode: () => codePromise,
+    stop,
+  };
+}
+
+interface BoundServer {
+  port: number;
+  stop(closeActiveConnections: boolean): void;
+}
+
+/**
+ * Bind the first available candidate port, falling back to an ephemeral port.
+ * An explicitly requested port is never substituted — silently moving would
+ * break a redirect URI the user configured deliberately.
+ */
+async function bind(
+  options: StartLoopbackOptions,
+  handle: (request: Request) => Response,
+): Promise<BoundServer> {
+  const serve = (port: number): BoundServer => {
+    const server = Bun.serve({ hostname: '127.0.0.1', port, fetch: handle });
+    if (server.port === undefined) {
+      server.stop(true);
+      throw new Error('the local login server reported no listening port');
+    }
+    return { port: server.port, stop: (force) => server.stop(force) };
+  };
+
+  if (options.port !== undefined) {
+    try {
+      return serve(options.port);
+    } catch (error) {
+      throw new OAuthError(
+        `Could not listen on port ${options.port} for the login redirect (${
+          error instanceof Error ? error.message : String(error)
+        }). Choose another port with --port.`,
+        { terminal: true, code: 'port_unavailable' },
+      );
+    }
+  }
+
+  const candidates = options.ports ?? EPHEMERAL_PORT;
+  const failures: number[] = [];
+  for (const candidate of candidates) {
+    try {
+      return serve(candidate);
+    } catch {
+      failures.push(candidate);
+    }
+  }
+
+  try {
+    // Port 0: let the OS pick. Reached when an explicit `ports` list was given
+    // and every entry was taken; the default list is already [0].
+    return serve(0);
+  } catch (error) {
+    throw new OAuthError(
+      `Could not start the local login server${
+        failures.length > 0
+          ? ` (ports ${failures.join(', ')} are in use and no ephemeral port was available)`
+          : ''
+      }: ${
+        error instanceof Error ? error.message : String(error)
+      }. Free a port or pass --port.`,
+      { terminal: true, code: 'port_unavailable' },
+    );
+  }
+}

--- a/src/lib/oauth-loopback.ts
+++ b/src/lib/oauth-loopback.ts
@@ -74,9 +74,11 @@ export interface StartLoopbackOptions {
  * provider text, escape it here first.
  */
 function page(title: string, message: string, status = 200): Response {
+  // Plain-text markers rather than `{{ }}`: Biome parses this file as HTML, and
+  // rejects mustache-style interpolation as a syntax error.
   const html = callbackTemplate
-    .replaceAll('{{title}}', title)
-    .replaceAll('{{message}}', message);
+    .replaceAll('__MUX_TITLE__', title)
+    .replaceAll('__MUX_MESSAGE__', message);
 
   return new Response(html, {
     status,

--- a/src/lib/oauth.test.ts
+++ b/src/lib/oauth.test.ts
@@ -174,6 +174,19 @@ describe('exchangeCodeForTokens', () => {
     expect(body.get('client_secret')).toBeNull();
   });
 
+  it('bounds the request so a half-open connection cannot hang a login', async () => {
+    mockJsonResponse({
+      access_token: 'at',
+      refresh_token: 'rt',
+      expires_in: 3600,
+    });
+
+    await exchangeCodeForTokens(params);
+
+    const init = fetchSpy?.mock.calls[0]?.[1] as RequestInit;
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+
   it('converts expires_in into an absolute expiry', async () => {
     mockJsonResponse({
       access_token: 'at',

--- a/src/lib/oauth.test.ts
+++ b/src/lib/oauth.test.ts
@@ -22,6 +22,7 @@ import {
 } from './oauth.ts';
 
 const ENV_KEYS = [
+  'MUX_OAUTH_SCOPES',
   'MUX_OAUTH_CLIENT_ID',
   'MUX_OAUTH_AUTHORIZE_URL',
   'MUX_OAUTH_TOKEN_URL',
@@ -73,6 +74,45 @@ afterEach(() => {
 });
 
 describe('getOAuthEndpoints', () => {
+  it('derives every endpoint from one API base', async () => {
+    // A single MUX_BASE_URL moves the whole flow, so the token endpoint can
+    // never end up on a different host than the authorization endpoint.
+    for (const key of ENV_KEYS) delete process.env[key];
+    process.env.MUX_BASE_URL = 'https://api.staging.mux.com';
+
+    const endpoints = getOAuthEndpoints();
+
+    // Authorization is a UI-layer route; the grants are on the auth service.
+    expect(endpoints.authorizationUrl).toBe(
+      'https://api.staging.mux.com/ui/v1/oauth/authorize',
+    );
+    expect(endpoints.tokenUrl).toBe(
+      'https://api.staging.mux.com/auth/v1/oauth/token',
+    );
+    expect(endpoints.revocationUrl).toBe(
+      'https://api.staging.mux.com/auth/v1/oauth/revoke',
+    );
+  });
+
+  it('does not double the slash on a base URL that ends in one', () => {
+    for (const key of ENV_KEYS) delete process.env[key];
+    process.env.MUX_BASE_URL = 'https://api.staging.mux.com/';
+
+    expect(getOAuthEndpoints().tokenUrl).toBe(
+      'https://api.staging.mux.com/auth/v1/oauth/token',
+    );
+  });
+
+  it('puts all three endpoints on the same host', () => {
+    for (const key of ENV_KEYS) delete process.env[key];
+
+    const { authorizationUrl, tokenUrl, revocationUrl } = getOAuthEndpoints();
+    const host = (u: string) => new URL(u).host;
+
+    expect(host(tokenUrl)).toBe(host(authorizationUrl));
+    expect(host(revocationUrl)).toBe(host(authorizationUrl));
+  });
+
   it('reads overrides from the environment', () => {
     const endpoints = getOAuthEndpoints();
 
@@ -233,6 +273,70 @@ describe('exchangeCodeForTokens', () => {
     expect(error.terminal).toBe(true);
     expect(error.code).toBe('invalid_grant');
     expect(error.message).toContain('Code already used');
+  });
+
+  it('names the endpoint it called, so a wrong URL is obvious', async () => {
+    // A 404 from a misconfigured endpoint is otherwise indistinguishable from a
+    // rejected credential.
+    mockJsonResponse({ error: { type: 'not_found', messages: ['nope'] } }, 404);
+
+    const error = (await exchangeCodeForTokens(params).catch(
+      (e) => e,
+    )) as OAuthError;
+
+    expect(error.message).toContain('https://api.test/oauth/token');
+  });
+
+  it('renders the Mux API error envelope instead of [object Object]', async () => {
+    // Endpoints that are not OAuth-aware (or a wrong token URL) answer with
+    // Mux's envelope, where `error` is an object rather than RFC 6749's string.
+    mockJsonResponse(
+      {
+        error: {
+          type: 'not_found',
+          messages: [
+            "The requested resource either doesn't exist or you don't have access to it.",
+          ],
+        },
+      },
+      404,
+    );
+
+    const error = (await exchangeCodeForTokens(params).catch(
+      (e) => e,
+    )) as OAuthError;
+
+    expect(error.message).toContain("doesn't exist");
+    expect(error.message).not.toContain('[object Object]');
+    expect(error.code).toBe('not_found');
+  });
+
+  it('falls back to the envelope type when it carries no messages', async () => {
+    mockJsonResponse({ error: { type: 'forbidden' } }, 403);
+
+    const error = (await exchangeCodeForTokens(params).catch(
+      (e) => e,
+    )) as OAuthError;
+
+    expect(error.message).toContain('forbidden');
+    expect(error.code).toBe('forbidden');
+  });
+
+  it('shows a snippet of an unrecognized body so the failure is diagnosable', async () => {
+    // A proxy or CDN error page, or a path that is not the token endpoint.
+    fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(
+      (async () =>
+        new Response('<html><body><h1>502 Bad Gateway</h1></body></html>', {
+          status: 502,
+        })) as unknown as typeof fetch,
+    );
+
+    const error = (await exchangeCodeForTokens(params).catch(
+      (e) => e,
+    )) as OAuthError;
+
+    expect(error.message).toContain('502 Bad Gateway');
+    expect(error.message).not.toContain('[object Object]');
   });
 
   it('includes the HTTP status when the provider sends no error body', async () => {
@@ -444,7 +548,63 @@ describe('resolveOAuthEndpoints', () => {
     const endpoints = await resolveOAuthEndpoints();
 
     expect(endpoints.tokenUrl).toBe('https://api.mux.com/oauth/v2/token');
-    expect(endpoints.revocationUrl).toBe('https://api.mux.com/oauth/revoke');
+    // Asserted against the built-in default rather than a literal, so pointing
+    // the defaults at another environment does not break this.
+    expect(endpoints.revocationUrl).toBe(getOAuthEndpoints().revocationUrl);
+  });
+
+  it('does not widen its scopes to whatever the server advertises', async () => {
+    // scopes_supported is everything the server offers. Adopting it would mean
+    // silently requesting any scope Mux adds later, growing the consent screen
+    // with no code change.
+    delete process.env.MUX_OAUTH_SCOPES;
+    mockDiscoveryDocument({
+      authorization_endpoint: 'https://dashboard.mux.com/oauth/authorize',
+      token_endpoint: 'https://api.mux.com/oauth/token',
+      scopes_supported: ['video:read', 'billing:write', 'admin:everything'],
+    });
+
+    const { scopes } = await resolveOAuthEndpoints();
+
+    expect(scopes).toEqual(getOAuthEndpoints().scopes);
+    expect(scopes).not.toContain('billing:write');
+    expect(scopes).not.toContain('admin:everything');
+  });
+
+  it('requests read and write across the API families the CLI covers', async () => {
+    delete process.env.MUX_OAUTH_SCOPES;
+
+    const { scopes } = getOAuthEndpoints();
+
+    for (const family of ['video', 'data', 'robots', 'system']) {
+      expect(scopes).toContain(`${family}:read`);
+      expect(scopes).toContain(`${family}:write`);
+    }
+  });
+
+  it('does not request OIDC scopes, since no id_token is consumed', async () => {
+    delete process.env.MUX_OAUTH_SCOPES;
+
+    const { scopes } = getOAuthEndpoints();
+
+    expect(scopes).not.toContain('openid');
+    expect(scopes).not.toContain('profile');
+    expect(scopes).not.toContain('email');
+  });
+
+  it('lets MUX_OAUTH_SCOPES narrow the request', async () => {
+    process.env.MUX_OAUTH_SCOPES = 'video:read';
+    mockDiscoveryDocument({
+      authorization_endpoint: 'https://dashboard.mux.com/oauth/authorize',
+      token_endpoint: 'https://api.mux.com/oauth/token',
+      scopes_supported: ['video:read', 'video:write', 'data:read'],
+    });
+
+    try {
+      expect((await resolveOAuthEndpoints()).scopes).toEqual(['video:read']);
+    } finally {
+      delete process.env.MUX_OAUTH_SCOPES;
+    }
   });
 
   it('ignores an endpoint pointing off-domain', async () => {
@@ -456,7 +616,7 @@ describe('resolveOAuthEndpoints', () => {
 
     // Falls back rather than sending an authorization code somewhere else.
     expect((await resolveOAuthEndpoints()).tokenUrl).toBe(
-      'https://api.mux.com/oauth/token',
+      getOAuthEndpoints().tokenUrl,
     );
   });
 });

--- a/src/lib/oauth.test.ts
+++ b/src/lib/oauth.test.ts
@@ -1,0 +1,449 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type Mock,
+  spyOn,
+} from 'bun:test';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  buildAuthorizationUrl,
+  exchangeCodeForTokens,
+  getOAuthEndpoints,
+  getServerCapabilities,
+  OAuthError,
+  refreshAccessToken,
+  resolveOAuthEndpoints,
+  revokeRefreshToken,
+} from './oauth.ts';
+
+const ENV_KEYS = [
+  'MUX_OAUTH_CLIENT_ID',
+  'MUX_OAUTH_AUTHORIZE_URL',
+  'MUX_OAUTH_TOKEN_URL',
+  'MUX_OAUTH_REVOKE_URL',
+  'MUX_BASE_URL',
+] as const;
+
+let saved: Record<string, string | undefined>;
+let fetchSpy: Mock<typeof fetch> | undefined;
+
+function mockJsonResponse(body: unknown, status = 200) {
+  fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(
+    (async () =>
+      new Response(JSON.stringify(body), {
+        status,
+        headers: { 'content-type': 'application/json' },
+      })) as unknown as typeof fetch,
+  );
+  return fetchSpy;
+}
+
+/** Parse the form-encoded body of the single recorded fetch call. */
+function recordedBody(): URLSearchParams {
+  const init = fetchSpy?.mock.calls[0]?.[1] as RequestInit;
+  return new URLSearchParams(String(init.body));
+}
+
+beforeEach(() => {
+  saved = {};
+  for (const key of ENV_KEYS) {
+    saved[key] = process.env[key];
+  }
+  process.env.MUX_OAUTH_CLIENT_ID = 'test_client';
+  process.env.MUX_OAUTH_AUTHORIZE_URL = 'https://dash.test/oauth/authorize';
+  process.env.MUX_OAUTH_TOKEN_URL = 'https://api.test/oauth/token';
+  process.env.MUX_OAUTH_REVOKE_URL = 'https://api.test/oauth/revoke';
+});
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    if (saved[key] === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = saved[key];
+    }
+  }
+  fetchSpy?.mockRestore();
+  fetchSpy = undefined;
+});
+
+describe('getOAuthEndpoints', () => {
+  it('reads overrides from the environment', () => {
+    const endpoints = getOAuthEndpoints();
+
+    expect(endpoints.clientId).toBe('test_client');
+    expect(endpoints.authorizationUrl).toBe(
+      'https://dash.test/oauth/authorize',
+    );
+    expect(endpoints.tokenUrl).toBe('https://api.test/oauth/token');
+    expect(endpoints.revocationUrl).toBe('https://api.test/oauth/revoke');
+  });
+
+  it('falls back to built-in defaults when unset', () => {
+    for (const key of ENV_KEYS) {
+      delete process.env[key];
+    }
+
+    const endpoints = getOAuthEndpoints();
+
+    expect(endpoints.clientId).toBeTruthy();
+    expect(endpoints.authorizationUrl).toStartWith('https://');
+    expect(endpoints.tokenUrl).toStartWith('https://');
+  });
+});
+
+describe('buildAuthorizationUrl', () => {
+  it('includes the PKCE challenge, state, and redirect URI', () => {
+    const url = new URL(
+      buildAuthorizationUrl({
+        codeChallenge: 'challenge-value',
+        state: 'state-value',
+        redirectUri: 'http://127.0.0.1:51372/callback',
+      }),
+    );
+
+    expect(url.origin + url.pathname).toBe('https://dash.test/oauth/authorize');
+    expect(url.searchParams.get('response_type')).toBe('code');
+    expect(url.searchParams.get('client_id')).toBe('test_client');
+    expect(url.searchParams.get('code_challenge')).toBe('challenge-value');
+    expect(url.searchParams.get('code_challenge_method')).toBe('S256');
+    expect(url.searchParams.get('state')).toBe('state-value');
+    expect(url.searchParams.get('redirect_uri')).toBe(
+      'http://127.0.0.1:51372/callback',
+    );
+  });
+
+  it('never sends the plain PKCE method', () => {
+    const url = buildAuthorizationUrl({
+      codeChallenge: 'c',
+      state: 's',
+      redirectUri: 'http://127.0.0.1:1/callback',
+    });
+
+    expect(url).not.toContain('plain');
+  });
+
+  it('never carries a client secret', () => {
+    const url = buildAuthorizationUrl({
+      codeChallenge: 'c',
+      state: 's',
+      redirectUri: 'http://127.0.0.1:1/callback',
+    });
+
+    expect(url).not.toContain('client_secret');
+  });
+});
+
+describe('exchangeCodeForTokens', () => {
+  // Endpoints passed explicitly: these cases assert the grant request, and
+  // resolution (including discovery) is covered separately below.
+  const params = {
+    code: 'auth_code',
+    codeVerifier: 'verifier_value',
+    redirectUri: 'http://127.0.0.1:51372/callback',
+    get endpoints() {
+      return getOAuthEndpoints();
+    },
+  };
+
+  it('posts the authorization code grant with the PKCE verifier', async () => {
+    mockJsonResponse({
+      access_token: 'at',
+      refresh_token: 'rt',
+      expires_in: 3600,
+      token_type: 'Bearer',
+    });
+
+    await exchangeCodeForTokens(params);
+
+    const [url, init] = fetchSpy?.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://api.test/oauth/token');
+    expect(init.method).toBe('POST');
+
+    const body = recordedBody();
+    expect(body.get('grant_type')).toBe('authorization_code');
+    expect(body.get('code')).toBe('auth_code');
+    expect(body.get('code_verifier')).toBe('verifier_value');
+    expect(body.get('client_id')).toBe('test_client');
+    expect(body.get('redirect_uri')).toBe('http://127.0.0.1:51372/callback');
+    expect(body.get('client_secret')).toBeNull();
+  });
+
+  it('converts expires_in into an absolute expiry', async () => {
+    mockJsonResponse({
+      access_token: 'at',
+      refresh_token: 'rt',
+      expires_in: 3600,
+      token_type: 'Bearer',
+    });
+
+    const before = Math.floor(Date.now() / 1000);
+    const tokens = await exchangeCodeForTokens(params);
+    const after = Math.floor(Date.now() / 1000);
+
+    expect(tokens.accessToken).toBe('at');
+    expect(tokens.refreshToken).toBe('rt');
+    expect(tokens.tokenType).toBe('Bearer');
+    expect(tokens.expiresAt).toBeGreaterThanOrEqual(before + 3600);
+    expect(tokens.expiresAt).toBeLessThanOrEqual(after + 3600);
+  });
+
+  it('preserves the granted scope when present', async () => {
+    mockJsonResponse({
+      access_token: 'at',
+      refresh_token: 'rt',
+      expires_in: 60,
+      scope: 'video:read video:write',
+    });
+
+    const tokens = await exchangeCodeForTokens(params);
+
+    expect(tokens.scope).toBe('video:read video:write');
+  });
+
+  it('raises a terminal error carrying the provider error description', async () => {
+    mockJsonResponse(
+      { error: 'invalid_grant', error_description: 'Code already used' },
+      400,
+    );
+
+    const error = (await exchangeCodeForTokens(params).catch(
+      (e) => e,
+    )) as OAuthError;
+
+    expect(error).toBeInstanceOf(OAuthError);
+    expect(error.terminal).toBe(true);
+    expect(error.code).toBe('invalid_grant');
+    expect(error.message).toContain('Code already used');
+  });
+
+  it('includes the HTTP status when the provider sends no error body', async () => {
+    fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(
+      (async () =>
+        new Response('gateway blew up', {
+          status: 502,
+        })) as unknown as typeof fetch,
+    );
+
+    const error = (await exchangeCodeForTokens(params).catch(
+      (e) => e,
+    )) as OAuthError;
+
+    expect(error).toBeInstanceOf(OAuthError);
+    expect(error.message).toContain('502');
+  });
+
+  it('treats a network failure as retryable', async () => {
+    fetchSpy = spyOn(globalThis, 'fetch').mockImplementation((async () => {
+      throw new TypeError('fetch failed');
+    }) as unknown as typeof fetch);
+
+    const error = (await exchangeCodeForTokens(params).catch(
+      (e) => e,
+    )) as OAuthError;
+
+    expect(error).toBeInstanceOf(OAuthError);
+    expect(error.terminal).toBe(false);
+  });
+
+  it('rejects a success response that omits an access token', async () => {
+    mockJsonResponse({ refresh_token: 'rt', expires_in: 60 });
+
+    expect(exchangeCodeForTokens(params)).rejects.toThrow(/access token/i);
+  });
+});
+
+describe('refreshAccessToken', () => {
+  it('posts the refresh_token grant', async () => {
+    mockJsonResponse({
+      access_token: 'at2',
+      refresh_token: 'rt2',
+      expires_in: 3600,
+    });
+
+    const tokens = await refreshAccessToken('rt1', getOAuthEndpoints());
+
+    const body = recordedBody();
+    expect(body.get('grant_type')).toBe('refresh_token');
+    expect(body.get('refresh_token')).toBe('rt1');
+    expect(body.get('client_id')).toBe('test_client');
+    expect(tokens.accessToken).toBe('at2');
+  });
+
+  it('adopts a rotated refresh token', async () => {
+    mockJsonResponse({
+      access_token: 'at2',
+      refresh_token: 'rotated',
+      expires_in: 60,
+    });
+
+    expect(
+      (await refreshAccessToken('rt1', getOAuthEndpoints())).refreshToken,
+    ).toBe('rotated');
+  });
+
+  it('reuses the presented refresh token when the response omits one', async () => {
+    mockJsonResponse({ access_token: 'at2', expires_in: 60 });
+
+    expect(
+      (await refreshAccessToken('rt1', getOAuthEndpoints())).refreshToken,
+    ).toBe('rt1');
+  });
+
+  it('marks invalid_grant as terminal', async () => {
+    mockJsonResponse({ error: 'invalid_grant' }, 400);
+
+    const error = (await refreshAccessToken('rt1', getOAuthEndpoints()).catch(
+      (e) => e,
+    )) as OAuthError;
+
+    expect(error.terminal).toBe(true);
+    expect(error.code).toBe('invalid_grant');
+  });
+
+  it('marks a server error as retryable', async () => {
+    mockJsonResponse({ error: 'temporarily_unavailable' }, 503);
+
+    const error = (await refreshAccessToken('rt1', getOAuthEndpoints()).catch(
+      (e) => e,
+    )) as OAuthError;
+
+    expect(error.terminal).toBe(false);
+  });
+});
+
+describe('revokeRefreshToken', () => {
+  it('posts the token to the revocation endpoint', async () => {
+    mockJsonResponse({}, 200);
+
+    await revokeRefreshToken('rt1', getOAuthEndpoints());
+
+    const [url] = fetchSpy?.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://api.test/oauth/revoke');
+    expect(recordedBody().get('token')).toBe('rt1');
+  });
+
+  it('raises so callers can warn, without throwing on 200', async () => {
+    mockJsonResponse({ error: 'server_error' }, 500);
+
+    expect(revokeRefreshToken('rt1', getOAuthEndpoints())).rejects.toThrow();
+  });
+});
+
+describe('resolveOAuthEndpoints', () => {
+  let cacheDir: string;
+  let originalCacheHome: string | undefined;
+
+  beforeEach(async () => {
+    cacheDir = await mkdtemp(join(tmpdir(), 'mux-cli-oauth-endpoints-'));
+    originalCacheHome = process.env.XDG_CACHE_HOME;
+    process.env.XDG_CACHE_HOME = cacheDir;
+    // Discovery is keyed off the API base URL.
+    process.env.MUX_BASE_URL = 'https://api.mux.com';
+  });
+
+  afterEach(async () => {
+    if (originalCacheHome === undefined) {
+      delete process.env.XDG_CACHE_HOME;
+    } else {
+      process.env.XDG_CACHE_HOME = originalCacheHome;
+    }
+    await rm(cacheDir, { recursive: true, force: true });
+  });
+
+  function mockDiscoveryDocument(document: unknown) {
+    fetchSpy = spyOn(globalThis, 'fetch').mockImplementation((async (
+      input: string,
+    ) => {
+      if (String(input).includes('/.well-known/')) {
+        return new Response(JSON.stringify(document), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      return new Response('{}', { status: 404 });
+    }) as unknown as typeof fetch);
+    return fetchSpy;
+  }
+
+  it('prefers endpoints published by the authorization server', async () => {
+    // Clear the overrides so discovery is what supplies the endpoints.
+    delete process.env.MUX_OAUTH_AUTHORIZE_URL;
+    delete process.env.MUX_OAUTH_TOKEN_URL;
+    delete process.env.MUX_OAUTH_REVOKE_URL;
+    mockDiscoveryDocument({
+      authorization_endpoint: 'https://dashboard.mux.com/oauth/v2/authorize',
+      token_endpoint: 'https://api.mux.com/oauth/v2/token',
+      revocation_endpoint: 'https://api.mux.com/oauth/v2/revoke',
+      grant_types_supported: ['authorization_code', 'refresh_token'],
+      code_challenge_methods_supported: ['S256'],
+    });
+
+    const endpoints = await resolveOAuthEndpoints();
+
+    expect(endpoints.tokenUrl).toBe('https://api.mux.com/oauth/v2/token');
+    expect(endpoints.authorizationUrl).toBe(
+      'https://dashboard.mux.com/oauth/v2/authorize',
+    );
+    expect(getServerCapabilities().grantTypes).toContain('refresh_token');
+  });
+
+  it('lets an explicit environment override beat discovery', async () => {
+    // Overrides are how staging is pinned; a discovery document must not win.
+    process.env.MUX_OAUTH_TOKEN_URL = 'https://api.test/oauth/token';
+    mockDiscoveryDocument({
+      token_endpoint: 'https://api.mux.com/oauth/v2/token',
+      authorization_endpoint: 'https://dashboard.mux.com/oauth/v2/authorize',
+    });
+
+    expect((await resolveOAuthEndpoints()).tokenUrl).toBe(
+      'https://api.test/oauth/token',
+    );
+  });
+
+  it('falls back to built-in defaults when discovery is unreachable', async () => {
+    delete process.env.MUX_OAUTH_TOKEN_URL;
+    fetchSpy = spyOn(globalThis, 'fetch').mockImplementation((async () => {
+      throw new TypeError('fetch failed');
+    }) as unknown as typeof fetch);
+
+    // Discovery must never be load-bearing: an outage cannot block login.
+    const endpoints = await resolveOAuthEndpoints();
+
+    expect(endpoints.tokenUrl).toStartWith('https://');
+    expect(getServerCapabilities().grantTypes).toBeUndefined();
+  });
+
+  it('keeps defaults for fields the document omits', async () => {
+    delete process.env.MUX_OAUTH_REVOKE_URL;
+    delete process.env.MUX_OAUTH_TOKEN_URL;
+    // OIDC documents have no revocation_endpoint.
+    mockDiscoveryDocument({
+      authorization_endpoint: 'https://dashboard.mux.com/oauth/v2/authorize',
+      token_endpoint: 'https://api.mux.com/oauth/v2/token',
+    });
+
+    const endpoints = await resolveOAuthEndpoints();
+
+    expect(endpoints.tokenUrl).toBe('https://api.mux.com/oauth/v2/token');
+    expect(endpoints.revocationUrl).toBe('https://api.mux.com/oauth/revoke');
+  });
+
+  it('ignores an endpoint pointing off-domain', async () => {
+    delete process.env.MUX_OAUTH_TOKEN_URL;
+    mockDiscoveryDocument({
+      authorization_endpoint: 'https://dashboard.mux.com/oauth/v2/authorize',
+      token_endpoint: 'https://evil.example.com/token',
+    });
+
+    // Falls back rather than sending an authorization code somewhere else.
+    expect((await resolveOAuthEndpoints()).tokenUrl).toBe(
+      'https://api.mux.com/oauth/token',
+    );
+  });
+});

--- a/src/lib/oauth.test.ts
+++ b/src/lib/oauth.test.ts
@@ -78,28 +78,28 @@ describe('getOAuthEndpoints', () => {
     // A single MUX_BASE_URL moves the whole flow, so the token endpoint can
     // never end up on a different host than the authorization endpoint.
     for (const key of ENV_KEYS) delete process.env[key];
-    process.env.MUX_BASE_URL = 'https://api.staging.mux.com';
+    process.env.MUX_BASE_URL = 'https://api.example.com';
 
     const endpoints = getOAuthEndpoints();
 
     // Authorization is a UI-layer route; the grants are on the auth service.
     expect(endpoints.authorizationUrl).toBe(
-      'https://api.staging.mux.com/ui/v1/oauth/authorize',
+      'https://api.example.com/ui/v1/oauth/authorize',
     );
     expect(endpoints.tokenUrl).toBe(
-      'https://api.staging.mux.com/auth/v1/oauth/token',
+      'https://api.example.com/auth/v1/oauth/token',
     );
     expect(endpoints.revocationUrl).toBe(
-      'https://api.staging.mux.com/auth/v1/oauth/revoke',
+      'https://api.example.com/auth/v1/oauth/revoke',
     );
   });
 
   it('does not double the slash on a base URL that ends in one', () => {
     for (const key of ENV_KEYS) delete process.env[key];
-    process.env.MUX_BASE_URL = 'https://api.staging.mux.com/';
+    process.env.MUX_BASE_URL = 'https://api.example.com/';
 
     expect(getOAuthEndpoints().tokenUrl).toBe(
-      'https://api.staging.mux.com/auth/v1/oauth/token',
+      'https://api.example.com/auth/v1/oauth/token',
     );
   });
 

--- a/src/lib/oauth.ts
+++ b/src/lib/oauth.ts
@@ -30,6 +30,12 @@ const DEFAULT_REVOCATION_URL = 'https://api.mux.com/oauth/revoke';
 const DEFAULT_ACCESS_TOKEN_TTL_SECONDS = 3600;
 
 /**
+ * Timeout for token endpoint requests. Must stay well under the refresh lock's
+ * staleness window (refresh-lock.ts) so a holder cannot outlive its own lock.
+ */
+const GRANT_TIMEOUT_MS = 10_000;
+
+/**
  * OAuth error codes that no amount of retrying will fix. Everything else —
  * transport failures, 5xx, throttling — is reported as retryable so callers can
  * distinguish "try again" from "log in again".
@@ -229,6 +235,9 @@ async function postForm(
         Accept: 'application/json',
       },
       body: new URLSearchParams(form).toString(),
+      // Bounded so a half-open connection cannot hang a login, and so a refresh
+      // always finishes well inside the lock's staleness window.
+      signal: AbortSignal.timeout(GRANT_TIMEOUT_MS),
     });
   } catch (error) {
     throw new OAuthError(

--- a/src/lib/oauth.ts
+++ b/src/lib/oauth.ts
@@ -10,17 +10,71 @@
 import { discoverEndpoints } from './oauth-discovery.ts';
 
 /**
- * Fallbacks used when discovery is unavailable and nothing is overridden.
+ * Every OAuth endpoint is on the Mux API host, so all three are derived from a
+ * single base: pointing `MUX_BASE_URL` at another environment moves the API
+ * calls, discovery, and the whole OAuth flow together, and the token endpoint
+ * can never end up on a different host than the authorization endpoint.
  *
- * TODO: confirm against the Mux authorization server before release. Tracked as
- * the endpoint table in OAUTH_LOGIN_SPEC.md section 8. Once the discovery
- * document is deployed these matter only offline, or if it ever stops resolving.
+ * The paths are not a common prefix, though. Authorization is a browser-facing
+ * route served by the dashboard UI layer (`/ui/v1/oauth`), while the
+ * back-channel grants are served by the auth service (`/auth/v1/oauth`).
+ *
+ * Individual `MUX_OAUTH_*_URL` overrides remain for the case where one endpoint
+ * moves on its own.
  */
 const DEFAULT_API_BASE_URL = 'https://api.mux.com';
+
+/** Browser-facing consent page: the only endpoint the user's browser opens. */
+const AUTHORIZE_PATH = '/ui/v1/oauth/authorize';
+
+/**
+ * Back-channel endpoints, called by the CLI itself.
+ *
+ * The auth service also exposes `/auth/v1/oauth/introspect` and
+ * `/auth/v1/openid/userinfo`. Neither is used: the CLI does not need to
+ * introspect a token it just received, and identity comes from
+ * `/system/v1/whoami` rather than the OIDC userinfo endpoint.
+ */
+const TOKEN_PATH = '/auth/v1/oauth/token';
+const REVOKE_PATH = '/auth/v1/oauth/revoke';
+
 const DEFAULT_CLIENT_ID = 'mux-cli';
-const DEFAULT_AUTHORIZATION_URL = 'https://dashboard.mux.com/oauth/authorize';
-const DEFAULT_TOKEN_URL = 'https://api.mux.com/oauth/token';
-const DEFAULT_REVOCATION_URL = 'https://api.mux.com/oauth/revoke';
+
+/** The API host every OAuth endpoint is derived from. */
+function getApiBaseUrl(): string {
+  return (process.env.MUX_BASE_URL || DEFAULT_API_BASE_URL).replace(/\/+$/, '');
+}
+
+/**
+ * Scopes requested at authorization, and the source of truth for what this CLI
+ * asks a user to consent to. The server rejects a request with no `scope`.
+ *
+ * One login serves every command, so this is the union of what the CLI can do:
+ *
+ * - `video:*`   assets, live streams, uploads, playback IDs and restrictions,
+ *               DRM configurations, transcription vocabularies
+ * - `data:*`    metrics, monitoring, dimensions, errors, exports, video views,
+ *               incidents, annotations, delivery usage
+ * - `robots:*`  the robots commands
+ * - `system:*`  `whoami`, the webhook event stream, and signing key create and
+ *               delete (`mux.system.signingKeys`)
+ *
+ * `openid`, `profile`, and `email` are deliberately not requested: the CLI does
+ * not consume an `id_token`, and identity comes from `/system/v1/whoami`, which
+ * reports what the access token can actually do rather than who the subject is.
+ *
+ * Overridable with `MUX_OAUTH_SCOPES` for a narrower login.
+ */
+const DEFAULT_SCOPES = [
+  'video:read',
+  'video:write',
+  'data:read',
+  'data:write',
+  'robots:read',
+  'robots:write',
+  'system:read',
+  'system:write',
+];
 
 /**
  * Applied when a token response omits `expires_in`. A finite default is safer
@@ -101,13 +155,15 @@ export class OAuthError extends Error {
 export function getOAuthEndpoints(): OAuthEndpoints {
   const scopes = process.env.MUX_OAUTH_SCOPES?.trim();
 
+  const base = getApiBaseUrl();
+
   return {
     clientId: process.env.MUX_OAUTH_CLIENT_ID || DEFAULT_CLIENT_ID,
     authorizationUrl:
-      process.env.MUX_OAUTH_AUTHORIZE_URL || DEFAULT_AUTHORIZATION_URL,
-    tokenUrl: process.env.MUX_OAUTH_TOKEN_URL || DEFAULT_TOKEN_URL,
-    revocationUrl: process.env.MUX_OAUTH_REVOKE_URL || DEFAULT_REVOCATION_URL,
-    scopes: scopes ? scopes.split(/[\s,]+/).filter(Boolean) : [],
+      process.env.MUX_OAUTH_AUTHORIZE_URL || `${base}${AUTHORIZE_PATH}`,
+    tokenUrl: process.env.MUX_OAUTH_TOKEN_URL || `${base}${TOKEN_PATH}`,
+    revocationUrl: process.env.MUX_OAUTH_REVOKE_URL || `${base}${REVOKE_PATH}`,
+    scopes: scopes ? scopes.split(/[\s,]+/).filter(Boolean) : DEFAULT_SCOPES,
   };
 }
 
@@ -140,8 +196,7 @@ export async function resolveOAuthEndpoints(
   apiBaseUrl?: string,
 ): Promise<OAuthEndpoints> {
   const defaults = getOAuthEndpoints();
-  const baseUrl =
-    apiBaseUrl || process.env.MUX_BASE_URL || DEFAULT_API_BASE_URL;
+  const baseUrl = apiBaseUrl || getApiBaseUrl();
 
   const discovered = await discoverEndpoints(baseUrl);
   if (!discovered) {
@@ -210,8 +265,50 @@ interface TokenResponseBody {
   expires_in?: number;
   token_type?: string;
   scope?: string;
-  error?: string;
+  /**
+   * A string under RFC 6749, but the Mux API wraps errors in an object
+   * (`{ type, messages }`), and these endpoints can return either depending on
+   * which layer rejected the request.
+   */
+  error?: unknown;
   error_description?: string;
+}
+
+/** The Mux API's error envelope, as returned by non-OAuth-aware layers. */
+interface MuxErrorEnvelope {
+  type?: string;
+  messages?: string[];
+}
+
+/**
+ * Turn whatever the endpoint returned into a code and a human-readable detail.
+ *
+ * Three shapes show up in practice: the RFC 6749 flat form, the Mux API
+ * envelope, and something unrecognized (an HTML error page from a proxy, or a
+ * 404 from a path that is not the token endpoint at all). The last case still
+ * has to say something useful, or the failure is undiagnosable.
+ */
+function describeFailure(
+  body: TokenResponseBody,
+  raw: string,
+): { code?: string; detail?: string } {
+  if (typeof body.error === 'string') {
+    return { code: body.error, detail: body.error_description ?? body.error };
+  }
+
+  if (body.error && typeof body.error === 'object') {
+    const envelope = body.error as MuxErrorEnvelope;
+    const messages = Array.isArray(envelope.messages)
+      ? envelope.messages.filter((m) => typeof m === 'string').join('; ')
+      : undefined;
+    return {
+      ...(typeof envelope.type === 'string' && { code: envelope.type }),
+      detail: messages || envelope.type,
+    };
+  }
+
+  const snippet = raw.trim().replace(/\s+/g, ' ').slice(0, 200);
+  return { detail: snippet || undefined };
 }
 
 function nowSeconds(): number {
@@ -263,19 +360,22 @@ async function postForm(
 function failureFrom(
   status: number,
   body: TokenResponseBody,
+  raw: string,
+  url: string,
   fallbackContext: string,
 ): OAuthError {
-  const code = body.error;
-  const detail = body.error_description || body.error;
+  const { code, detail } = describeFailure(body, raw);
   // 5xx and 429 are transport-adjacent: the credential may still be good.
   const retryableStatus = status >= 500 || status === 429;
   const terminal = code
     ? TERMINAL_ERROR_CODES.has(code) && !retryableStatus
     : !retryableStatus;
 
+  // Naming the URL matters most for exactly the confusing case: a 404 from a
+  // misconfigured endpoint looks identical to a rejected credential otherwise.
   const message = detail
-    ? `${fallbackContext}: ${detail} (HTTP ${status})`
-    : `${fallbackContext}: HTTP ${status}`;
+    ? `${fallbackContext}: ${detail} (HTTP ${status} from ${url})`
+    : `${fallbackContext}: HTTP ${status} from ${url}`;
 
   return new OAuthError(message, { code, status, terminal });
 }
@@ -321,7 +421,7 @@ export async function exchangeCodeForTokens(params: {
 }): Promise<OAuthTokens> {
   const endpoints = params.endpoints ?? (await resolveOAuthEndpoints());
 
-  const { status, body } = await postForm(endpoints.tokenUrl, {
+  const { status, body, raw } = await postForm(endpoints.tokenUrl, {
     grant_type: 'authorization_code',
     code: params.code,
     code_verifier: params.codeVerifier,
@@ -330,7 +430,13 @@ export async function exchangeCodeForTokens(params: {
   });
 
   if (status < 200 || status >= 300) {
-    throw failureFrom(status, body, 'Could not complete the login');
+    throw failureFrom(
+      status,
+      body,
+      raw,
+      endpoints.tokenUrl,
+      'Could not complete the login',
+    );
   }
 
   return tokensFrom(body);
@@ -349,14 +455,20 @@ export async function refreshAccessToken(
   // after any endpoint compiled into this binary could have moved.
   const endpoints = endpointOverrides ?? (await resolveOAuthEndpoints());
 
-  const { status, body } = await postForm(endpoints.tokenUrl, {
+  const { status, body, raw } = await postForm(endpoints.tokenUrl, {
     grant_type: 'refresh_token',
     refresh_token: refreshToken,
     client_id: endpoints.clientId,
   });
 
   if (status < 200 || status >= 300) {
-    throw failureFrom(status, body, 'Could not refresh the access token');
+    throw failureFrom(
+      status,
+      body,
+      raw,
+      endpoints.tokenUrl,
+      'Could not refresh the access token',
+    );
   }
 
   return tokensFrom(body, refreshToken);
@@ -373,13 +485,19 @@ export async function revokeRefreshToken(
 ): Promise<void> {
   const endpoints = endpointOverrides ?? (await resolveOAuthEndpoints());
 
-  const { status, body } = await postForm(endpoints.revocationUrl, {
+  const { status, body, raw } = await postForm(endpoints.revocationUrl, {
     token: refreshToken,
     token_type_hint: 'refresh_token',
     client_id: endpoints.clientId,
   });
 
   if (status < 200 || status >= 300) {
-    throw failureFrom(status, body, 'Could not revoke the refresh token');
+    throw failureFrom(
+      status,
+      body,
+      raw,
+      endpoints.revocationUrl,
+      'Could not revoke the refresh token',
+    );
   }
 }

--- a/src/lib/oauth.ts
+++ b/src/lib/oauth.ts
@@ -38,7 +38,7 @@ const AUTHORIZE_PATH = '/ui/v1/oauth/authorize';
 const TOKEN_PATH = '/auth/v1/oauth/token';
 const REVOKE_PATH = '/auth/v1/oauth/revoke';
 
-const DEFAULT_CLIENT_ID = 'mux-cli';
+const DEFAULT_CLIENT_ID = '30b5a08e-1e48-4f70-a3fb-e4d64cf69566';
 
 /** The API host every OAuth endpoint is derived from. */
 function getApiBaseUrl(): string {

--- a/src/lib/oauth.ts
+++ b/src/lib/oauth.ts
@@ -1,0 +1,376 @@
+/**
+ * OAuth 2.0 authorization code + PKCE client for `mux login`.
+ *
+ * Endpoint values are centralized here so that confirming the authorization
+ * server contract is a one-file change. Each is overridable by environment
+ * variable, which is also how the test suite and staging environments point the
+ * CLI at a non-production authorization server.
+ */
+
+import { discoverEndpoints } from './oauth-discovery.ts';
+
+/**
+ * Fallbacks used when discovery is unavailable and nothing is overridden.
+ *
+ * TODO: confirm against the Mux authorization server before release. Tracked as
+ * the endpoint table in OAUTH_LOGIN_SPEC.md section 8. Once the discovery
+ * document is deployed these matter only offline, or if it ever stops resolving.
+ */
+const DEFAULT_API_BASE_URL = 'https://api.mux.com';
+const DEFAULT_CLIENT_ID = 'mux-cli';
+const DEFAULT_AUTHORIZATION_URL = 'https://dashboard.mux.com/oauth/authorize';
+const DEFAULT_TOKEN_URL = 'https://api.mux.com/oauth/token';
+const DEFAULT_REVOCATION_URL = 'https://api.mux.com/oauth/revoke';
+
+/**
+ * Applied when a token response omits `expires_in`. A finite default is safer
+ * than treating the token as immediately stale, which would refresh on every
+ * command.
+ */
+const DEFAULT_ACCESS_TOKEN_TTL_SECONDS = 3600;
+
+/**
+ * OAuth error codes that no amount of retrying will fix. Everything else —
+ * transport failures, 5xx, throttling — is reported as retryable so callers can
+ * distinguish "try again" from "log in again".
+ */
+const TERMINAL_ERROR_CODES = new Set([
+  'invalid_grant',
+  'invalid_client',
+  'invalid_request',
+  'invalid_scope',
+  'unauthorized_client',
+  'unsupported_grant_type',
+  'access_denied',
+]);
+
+export interface OAuthEndpoints {
+  clientId: string;
+  authorizationUrl: string;
+  tokenUrl: string;
+  revocationUrl: string;
+  scopes: string[];
+}
+
+export interface OAuthTokens {
+  accessToken: string;
+  refreshToken: string;
+  /** Absolute expiry in epoch seconds, computed from `expires_in` at receipt. */
+  expiresAt: number;
+  scope?: string;
+  tokenType: 'Bearer';
+}
+
+interface OAuthErrorOptions {
+  /** The OAuth `error` code, when the provider supplied one. */
+  code?: string;
+  /** HTTP status, when the failure came from a response rather than transport. */
+  status?: number;
+  /** False when retrying could plausibly succeed. */
+  terminal: boolean;
+}
+
+/**
+ * An OAuth failure. `terminal` separates "this credential is dead, log in
+ * again" from "the network or server had a bad moment, retry".
+ */
+export class OAuthError extends Error {
+  readonly code?: string;
+  readonly status?: number;
+  readonly terminal: boolean;
+
+  constructor(message: string, options: OAuthErrorOptions) {
+    super(message);
+    this.name = 'OAuthError';
+    this.code = options.code;
+    this.status = options.status;
+    this.terminal = options.terminal;
+  }
+}
+
+/**
+ * Resolve the authorization server configuration from environment overrides and
+ * built-in defaults only. This is the offline floor: no network, always works.
+ */
+export function getOAuthEndpoints(): OAuthEndpoints {
+  const scopes = process.env.MUX_OAUTH_SCOPES?.trim();
+
+  return {
+    clientId: process.env.MUX_OAUTH_CLIENT_ID || DEFAULT_CLIENT_ID,
+    authorizationUrl:
+      process.env.MUX_OAUTH_AUTHORIZE_URL || DEFAULT_AUTHORIZATION_URL,
+    tokenUrl: process.env.MUX_OAUTH_TOKEN_URL || DEFAULT_TOKEN_URL,
+    revocationUrl: process.env.MUX_OAUTH_REVOKE_URL || DEFAULT_REVOCATION_URL,
+    scopes: scopes ? scopes.split(/[\s,]+/).filter(Boolean) : [],
+  };
+}
+
+/** What the authorization server said it supports, when discovery succeeded. */
+export interface ServerCapabilities {
+  grantTypes?: string[];
+  codeChallengeMethods?: string[];
+  scopes?: string[];
+  discoveredFrom?: string;
+}
+
+let capabilities: ServerCapabilities = {};
+
+/**
+ * What the last endpoint resolution learned about the server. Empty when
+ * discovery has not run or was unavailable.
+ */
+export function getServerCapabilities(): ServerCapabilities {
+  return capabilities;
+}
+
+/**
+ * Resolve endpoints for use, preferring what the authorization server publishes.
+ *
+ * Order: explicit environment override > discovery document (cached up to a day)
+ * > built-in default, applied per field. An endpoint that moves server-side is
+ * picked up without a CLI release; a discovery outage changes nothing.
+ */
+export async function resolveOAuthEndpoints(
+  apiBaseUrl?: string,
+): Promise<OAuthEndpoints> {
+  const defaults = getOAuthEndpoints();
+  const baseUrl =
+    apiBaseUrl || process.env.MUX_BASE_URL || DEFAULT_API_BASE_URL;
+
+  const discovered = await discoverEndpoints(baseUrl);
+  if (!discovered) {
+    capabilities = {};
+    return defaults;
+  }
+
+  capabilities = {
+    ...(discovered.grantTypes && { grantTypes: discovered.grantTypes }),
+    ...(discovered.codeChallengeMethods && {
+      codeChallengeMethods: discovered.codeChallengeMethods,
+    }),
+    ...(discovered.scopes && { scopes: discovered.scopes }),
+    discoveredFrom: discovered.discoveredFrom,
+  };
+
+  // An explicit override always wins: it is how staging and tests pin a host,
+  // and a discovery document must not be able to override it.
+  return {
+    clientId: defaults.clientId,
+    authorizationUrl:
+      process.env.MUX_OAUTH_AUTHORIZE_URL ||
+      discovered.authorizationUrl ||
+      defaults.authorizationUrl,
+    tokenUrl:
+      process.env.MUX_OAUTH_TOKEN_URL ||
+      discovered.tokenUrl ||
+      defaults.tokenUrl,
+    revocationUrl:
+      process.env.MUX_OAUTH_REVOKE_URL ||
+      discovered.revocationUrl ||
+      defaults.revocationUrl,
+    scopes: defaults.scopes,
+  };
+}
+
+/**
+ * Build the URL the user opens in their browser. Organization and environment
+ * selection happens on that page, so no org/env parameters are sent.
+ */
+export function buildAuthorizationUrl(params: {
+  codeChallenge: string;
+  state: string;
+  redirectUri: string;
+  endpoints?: OAuthEndpoints;
+}): string {
+  const endpoints = params.endpoints ?? getOAuthEndpoints();
+  const url = new URL(endpoints.authorizationUrl);
+
+  url.searchParams.set('response_type', 'code');
+  url.searchParams.set('client_id', endpoints.clientId);
+  url.searchParams.set('redirect_uri', params.redirectUri);
+  url.searchParams.set('code_challenge', params.codeChallenge);
+  url.searchParams.set('code_challenge_method', 'S256');
+  url.searchParams.set('state', params.state);
+  if (endpoints.scopes.length > 0) {
+    url.searchParams.set('scope', endpoints.scopes.join(' '));
+  }
+
+  return url.toString();
+}
+
+interface TokenResponseBody {
+  access_token?: string;
+  refresh_token?: string;
+  expires_in?: number;
+  token_type?: string;
+  scope?: string;
+  error?: string;
+  error_description?: string;
+}
+
+function nowSeconds(): number {
+  return Math.floor(Date.now() / 1000);
+}
+
+/**
+ * POST a form-encoded grant request. Transport failures become retryable
+ * OAuthErrors; the caller decides how to report them.
+ */
+async function postForm(
+  url: string,
+  form: Record<string, string>,
+): Promise<{ status: number; body: TokenResponseBody; raw: string }> {
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Accept: 'application/json',
+      },
+      body: new URLSearchParams(form).toString(),
+    });
+  } catch (error) {
+    throw new OAuthError(
+      `Could not reach the Mux authorization server at ${url} (${
+        error instanceof Error ? error.message : String(error)
+      }). Check your network connection and try again.`,
+      { terminal: false },
+    );
+  }
+
+  const raw = await response.text();
+  let body: TokenResponseBody = {};
+  try {
+    body = raw ? (JSON.parse(raw) as TokenResponseBody) : {};
+  } catch {
+    // Non-JSON bodies (proxy error pages, for example) are reported by status.
+    body = {};
+  }
+
+  return { status: response.status, body, raw };
+}
+
+function failureFrom(
+  status: number,
+  body: TokenResponseBody,
+  fallbackContext: string,
+): OAuthError {
+  const code = body.error;
+  const detail = body.error_description || body.error;
+  // 5xx and 429 are transport-adjacent: the credential may still be good.
+  const retryableStatus = status >= 500 || status === 429;
+  const terminal = code
+    ? TERMINAL_ERROR_CODES.has(code) && !retryableStatus
+    : !retryableStatus;
+
+  const message = detail
+    ? `${fallbackContext}: ${detail} (HTTP ${status})`
+    : `${fallbackContext}: HTTP ${status}`;
+
+  return new OAuthError(message, { code, status, terminal });
+}
+
+function tokensFrom(
+  body: TokenResponseBody,
+  presentedRefreshToken?: string,
+): OAuthTokens {
+  if (!body.access_token) {
+    throw new OAuthError(
+      'The Mux authorization server did not return an access token.',
+      { terminal: true },
+    );
+  }
+
+  const refreshToken = body.refresh_token || presentedRefreshToken;
+  if (!refreshToken) {
+    throw new OAuthError(
+      'The Mux authorization server did not return a refresh token, so the CLI could not keep the login alive.',
+      { terminal: true },
+    );
+  }
+
+  return {
+    accessToken: body.access_token,
+    refreshToken,
+    expiresAt:
+      nowSeconds() + (body.expires_in ?? DEFAULT_ACCESS_TOKEN_TTL_SECONDS),
+    ...(body.scope && { scope: body.scope }),
+    tokenType: 'Bearer',
+  };
+}
+
+/**
+ * Exchange an authorization code for tokens. No client secret is sent — the
+ * PKCE verifier is what proves this is the process that started the flow.
+ */
+export async function exchangeCodeForTokens(params: {
+  code: string;
+  codeVerifier: string;
+  redirectUri: string;
+  endpoints?: OAuthEndpoints;
+}): Promise<OAuthTokens> {
+  const endpoints = params.endpoints ?? (await resolveOAuthEndpoints());
+
+  const { status, body } = await postForm(endpoints.tokenUrl, {
+    grant_type: 'authorization_code',
+    code: params.code,
+    code_verifier: params.codeVerifier,
+    client_id: endpoints.clientId,
+    redirect_uri: params.redirectUri,
+  });
+
+  if (status < 200 || status >= 300) {
+    throw failureFrom(status, body, 'Could not complete the login');
+  }
+
+  return tokensFrom(body);
+}
+
+/**
+ * Trade a refresh token for a new access token. When the server rotates refresh
+ * tokens the new one is returned; otherwise the presented one is carried
+ * forward so callers can persist a complete credential either way.
+ */
+export async function refreshAccessToken(
+  refreshToken: string,
+  endpointOverrides?: OAuthEndpoints,
+): Promise<OAuthTokens> {
+  // Discovery matters most here: refresh runs for months after a login, long
+  // after any endpoint compiled into this binary could have moved.
+  const endpoints = endpointOverrides ?? (await resolveOAuthEndpoints());
+
+  const { status, body } = await postForm(endpoints.tokenUrl, {
+    grant_type: 'refresh_token',
+    refresh_token: refreshToken,
+    client_id: endpoints.clientId,
+  });
+
+  if (status < 200 || status >= 300) {
+    throw failureFrom(status, body, 'Could not refresh the access token');
+  }
+
+  return tokensFrom(body, refreshToken);
+}
+
+/**
+ * Revoke a refresh token server-side. Callers treat failure as a warning: the
+ * user's intent on `mux logout` is to stop using the credential locally, which
+ * happens regardless.
+ */
+export async function revokeRefreshToken(
+  refreshToken: string,
+  endpointOverrides?: OAuthEndpoints,
+): Promise<void> {
+  const endpoints = endpointOverrides ?? (await resolveOAuthEndpoints());
+
+  const { status, body } = await postForm(endpoints.revocationUrl, {
+    token: refreshToken,
+    token_type_hint: 'refresh_token',
+    client_id: endpoints.clientId,
+  });
+
+  if (status < 200 || status >= 300) {
+    throw failureFrom(status, body, 'Could not revoke the refresh token');
+  }
+}

--- a/src/lib/pkce.test.ts
+++ b/src/lib/pkce.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  computeCodeChallenge,
+  generateCodeVerifier,
+  generateState,
+} from './pkce.ts';
+
+const BASE64URL = /^[A-Za-z0-9_-]+$/;
+
+describe('generateCodeVerifier', () => {
+  it('produces unpadded base64url within the RFC 7636 length bounds', () => {
+    const verifier = generateCodeVerifier();
+
+    expect(verifier).toMatch(BASE64URL);
+    expect(verifier.length).toBeGreaterThanOrEqual(43);
+    expect(verifier.length).toBeLessThanOrEqual(128);
+  });
+
+  it('produces a distinct value on every call', () => {
+    const verifiers = new Set(
+      Array.from({ length: 50 }, () => generateCodeVerifier()),
+    );
+
+    expect(verifiers.size).toBe(50);
+  });
+});
+
+describe('computeCodeChallenge', () => {
+  // RFC 7636 Appendix B test vector.
+  it('matches the RFC 7636 S256 test vector', () => {
+    expect(
+      computeCodeChallenge('dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk'),
+    ).toBe('E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM');
+  });
+
+  it('produces unpadded base64url', () => {
+    const challenge = computeCodeChallenge(generateCodeVerifier());
+
+    expect(challenge).toMatch(BASE64URL);
+    expect(challenge).not.toContain('=');
+  });
+
+  it('is deterministic for a given verifier', () => {
+    const verifier = generateCodeVerifier();
+
+    expect(computeCodeChallenge(verifier)).toBe(computeCodeChallenge(verifier));
+  });
+
+  it('differs for different verifiers', () => {
+    expect(computeCodeChallenge('verifier-one')).not.toBe(
+      computeCodeChallenge('verifier-two'),
+    );
+  });
+});
+
+describe('generateState', () => {
+  it('produces unpadded base64url of at least 32 bytes of entropy', () => {
+    const state = generateState();
+
+    expect(state).toMatch(BASE64URL);
+    expect(state.length).toBeGreaterThanOrEqual(43);
+  });
+
+  it('produces a distinct value on every call', () => {
+    const states = new Set(Array.from({ length: 50 }, () => generateState()));
+
+    expect(states.size).toBe(50);
+  });
+});

--- a/src/lib/pkce.ts
+++ b/src/lib/pkce.ts
@@ -1,0 +1,41 @@
+import { createHash, randomBytes } from 'node:crypto';
+
+/**
+ * PKCE (RFC 7636) helpers for the OAuth authorization code flow.
+ *
+ * The CLI is a public client — it ships no client secret — so PKCE is what
+ * binds an authorization code to the process that requested it. Only the S256
+ * method is implemented; `plain` offers no protection against an attacker who
+ * can observe the redirect.
+ */
+
+/** 32 bytes of entropy, base64url encoded: 43 characters, within RFC 7636 bounds. */
+const VERIFIER_BYTES = 32;
+const STATE_BYTES = 32;
+
+function base64url(bytes: Buffer): string {
+  return bytes.toString('base64url');
+}
+
+/**
+ * Generate a code verifier. Held only in process memory — never written to
+ * disk, and never logged.
+ */
+export function generateCodeVerifier(): string {
+  return base64url(randomBytes(VERIFIER_BYTES));
+}
+
+/**
+ * Derive the S256 code challenge sent on the authorization request.
+ */
+export function computeCodeChallenge(verifier: string): string {
+  return base64url(createHash('sha256').update(verifier, 'ascii').digest());
+}
+
+/**
+ * Generate the `state` value that binds the redirect back to this login
+ * attempt, guarding against a forged or replayed callback.
+ */
+export function generateState(): string {
+  return base64url(randomBytes(STATE_BYTES));
+}

--- a/src/lib/refresh-lock.test.ts
+++ b/src/lib/refresh-lock.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { existsSync } from 'node:fs';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { getRefreshLockPath, withRefreshLock } from './refresh-lock.ts';
+
+let testConfigDir: string;
+let originalXdgConfigHome: string | undefined;
+
+beforeEach(async () => {
+  testConfigDir = await mkdtemp(join(tmpdir(), 'mux-cli-lock-test-'));
+  originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
+  process.env.XDG_CONFIG_HOME = testConfigDir;
+});
+
+afterEach(async () => {
+  if (originalXdgConfigHome === undefined) {
+    delete process.env.XDG_CONFIG_HOME;
+  } else {
+    process.env.XDG_CONFIG_HOME = originalXdgConfigHome;
+  }
+  await rm(testConfigDir, { recursive: true, force: true });
+});
+
+describe('withRefreshLock', () => {
+  it('runs the critical section and returns its value', async () => {
+    expect(await withRefreshLock(async () => 'refreshed')).toBe('refreshed');
+  });
+
+  it('releases the lock after a successful run', async () => {
+    await withRefreshLock(async () => 'first');
+
+    expect(existsSync(getRefreshLockPath())).toBe(false);
+    expect(await withRefreshLock(async () => 'second')).toBe('second');
+  });
+
+  it('releases the lock when the critical section throws', async () => {
+    expect(
+      withRefreshLock(async () => {
+        throw new Error('refresh failed');
+      }),
+    ).rejects.toThrow('refresh failed');
+
+    // Give the rejection a turn to settle before asserting on the lock file.
+    await Bun.sleep(10);
+    expect(existsSync(getRefreshLockPath())).toBe(false);
+    expect(await withRefreshLock(async () => 'after')).toBe('after');
+  });
+
+  it('serializes concurrent critical sections', async () => {
+    let active = 0;
+    let maxActive = 0;
+    const order: number[] = [];
+
+    await Promise.all(
+      [1, 2, 3, 4].map((n) =>
+        withRefreshLock(async () => {
+          active += 1;
+          maxActive = Math.max(maxActive, active);
+          await Bun.sleep(15);
+          order.push(n);
+          active -= 1;
+        }),
+      ),
+    );
+
+    expect(maxActive).toBe(1);
+    expect(order.length).toBe(4);
+  });
+
+  it('records the owning pid so stale locks can be identified', async () => {
+    let contents = '';
+    await withRefreshLock(async () => {
+      contents = await readFile(getRefreshLockPath(), 'utf-8');
+    });
+
+    expect(JSON.parse(contents).pid).toBe(process.pid);
+  });
+
+  it('breaks a lock left behind by a dead process', async () => {
+    await Bun.write(
+      getRefreshLockPath(),
+      JSON.stringify({ pid: 2 ** 30, acquiredAt: Date.now() }),
+    );
+
+    expect(await withRefreshLock(async () => 'recovered')).toBe('recovered');
+  });
+
+  it('breaks a lock older than the stale threshold', async () => {
+    await Bun.write(
+      getRefreshLockPath(),
+      JSON.stringify({
+        pid: process.pid,
+        acquiredAt: Date.now() - 60_000,
+      }),
+    );
+
+    expect(await withRefreshLock(async () => 'recovered')).toBe('recovered');
+  });
+
+  it('breaks a lock whose contents are unreadable', async () => {
+    await Bun.write(getRefreshLockPath(), 'not json');
+
+    expect(await withRefreshLock(async () => 'recovered')).toBe('recovered');
+  });
+});

--- a/src/lib/refresh-lock.test.ts
+++ b/src/lib/refresh-lock.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import { existsSync } from 'node:fs';
-import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { mkdtemp, readFile, rm, unlink } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { getRefreshLockPath, withRefreshLock } from './refresh-lock.ts';
@@ -103,5 +103,68 @@ describe('withRefreshLock', () => {
     await Bun.write(getRefreshLockPath(), 'not json');
 
     expect(await withRefreshLock(async () => 'recovered')).toBe('recovered');
+  });
+
+  it('refuses to break the lock of a live holder', async () => {
+    // A young lock held by a running process cannot be abandoned. Deleting it
+    // would put two processes on the same rotating refresh token, so acquiring
+    // must fail instead — and it must fail rather than hang forever.
+    await Bun.write(
+      getRefreshLockPath(),
+      JSON.stringify({
+        pid: process.pid,
+        acquiredAt: Date.now(),
+        owner: 'someone-else',
+      }),
+    );
+
+    await expect(
+      withRefreshLock(async () => 'should not run', { timeoutMs: 150 }),
+    ).rejects.toThrow(/another mux process/i);
+
+    // The other holder's lock survives untouched.
+    const contents = JSON.parse(await readFile(getRefreshLockPath(), 'utf-8'));
+    expect(contents.owner).toBe('someone-else');
+  });
+
+  it('does not release a lock it no longer owns', async () => {
+    // Simulates this process's lock having been broken as stale and re-taken by
+    // another process while the critical section was still running: releasing
+    // must not delete the new holder's lock.
+    await withRefreshLock(async () => {
+      await Bun.write(
+        getRefreshLockPath(),
+        JSON.stringify({
+          pid: process.pid,
+          acquiredAt: Date.now(),
+          owner: 'new-holder',
+        }),
+      );
+    });
+
+    expect(existsSync(getRefreshLockPath())).toBe(true);
+    const contents = JSON.parse(await readFile(getRefreshLockPath(), 'utf-8'));
+    expect(contents.owner).toBe('new-holder');
+  });
+
+  it('waits for a live holder that finishes in time', async () => {
+    // The waiter polls rather than failing immediately: a holder doing normal
+    // work should be waited out, not interrupted.
+    const path = getRefreshLockPath();
+    await Bun.write(
+      path,
+      JSON.stringify({
+        pid: process.pid,
+        acquiredAt: Date.now(),
+        owner: 'brief-holder',
+      }),
+    );
+    setTimeout(() => {
+      void unlink(path).catch(() => {});
+    }, 60);
+
+    expect(
+      await withRefreshLock(async () => 'acquired', { timeoutMs: 5000 }),
+    ).toBe('acquired');
   });
 });

--- a/src/lib/refresh-lock.ts
+++ b/src/lib/refresh-lock.ts
@@ -1,0 +1,128 @@
+import { randomBytes } from 'node:crypto';
+import { link, mkdir, readFile, unlink, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { getConfigDir } from './xdg.ts';
+
+/**
+ * Cross-process mutual exclusion for token refresh.
+ *
+ * Several `mux` invocations can run at once — an ad-hoc command beside a
+ * long-lived `mux webhooks listen` — and an authorization server that rotates
+ * refresh tokens invalidates the old one on use. Without a lock, two processes
+ * refreshing together would spend the same refresh token twice and one would be
+ * left holding a dead credential.
+ */
+
+/** A lock older than this is assumed abandoned (crash, SIGKILL). */
+const STALE_AFTER_MS = 30_000;
+
+/** How long to wait for another process before breaking the lock. */
+const ACQUIRE_TIMEOUT_MS = 15_000;
+
+const POLL_INTERVAL_MS = 25;
+
+interface LockContents {
+  pid: number;
+  acquiredAt: number;
+}
+
+export function getRefreshLockPath(): string {
+  return join(getConfigDir(), 'refresh.lock');
+}
+
+/** Whether a pid is still running. EPERM means alive but not ours to signal. */
+function processAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
+
+/**
+ * Decide whether an existing lock can be broken. Unreadable or malformed lock
+ * files are treated as abandoned: leaving one in place would wedge refresh for
+ * every future invocation.
+ */
+async function isBreakable(path: string): Promise<boolean> {
+  let contents: LockContents;
+  try {
+    contents = JSON.parse(await readFile(path, 'utf-8')) as LockContents;
+  } catch {
+    return true;
+  }
+
+  if (
+    typeof contents.pid !== 'number' ||
+    typeof contents.acquiredAt !== 'number'
+  ) {
+    return true;
+  }
+  if (Date.now() - contents.acquiredAt > STALE_AFTER_MS) {
+    return true;
+  }
+
+  return !processAlive(contents.pid);
+}
+
+async function acquire(path: string): Promise<void> {
+  await mkdir(getConfigDir(), { recursive: true, mode: 0o700 });
+
+  const deadline = Date.now() + ACQUIRE_TIMEOUT_MS;
+  const stagingPath = `${path}.${process.pid}.${randomBytes(4).toString('hex')}`;
+
+  while (true) {
+    // Stage the full contents first, then link it into place. `link` fails when
+    // the target exists, which makes acquisition atomic, and the lock file is
+    // never observable in a half-written state — a competitor that read an
+    // empty lock file would mistake a live holder for a crashed one.
+    await writeFile(
+      stagingPath,
+      JSON.stringify({ pid: process.pid, acquiredAt: Date.now() }),
+      { mode: 0o600 },
+    );
+
+    try {
+      await link(stagingPath, path);
+      return;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'EEXIST') {
+        throw error;
+      }
+    } finally {
+      await unlink(stagingPath).catch(() => {});
+    }
+
+    if (await isBreakable(path)) {
+      await unlink(path).catch(() => {});
+      continue;
+    }
+
+    if (Date.now() > deadline) {
+      // The holder is alive but stuck. Breaking in is better than failing every
+      // command from here on; the holder's own write is atomic either way.
+      await unlink(path).catch(() => {});
+      continue;
+    }
+
+    await Bun.sleep(POLL_INTERVAL_MS);
+  }
+}
+
+/**
+ * Run `critical` while holding the refresh lock. The lock is always released,
+ * including when `critical` throws.
+ */
+export async function withRefreshLock<T>(
+  critical: () => Promise<T>,
+): Promise<T> {
+  const path = getRefreshLockPath();
+  await acquire(path);
+
+  try {
+    return await critical();
+  } finally {
+    await unlink(path).catch(() => {});
+  }
+}

--- a/src/lib/refresh-lock.ts
+++ b/src/lib/refresh-lock.ts
@@ -13,17 +13,30 @@ import { getConfigDir } from './xdg.ts';
  * left holding a dead credential.
  */
 
-/** A lock older than this is assumed abandoned (crash, SIGKILL). */
+/**
+ * A lock older than this is assumed abandoned (crash, SIGKILL).
+ *
+ * A holder's critical section is a config read, one token request bounded by the
+ * timeout in oauth.ts, and a config write — comfortably inside this window.
+ */
 const STALE_AFTER_MS = 30_000;
 
-/** How long to wait for another process before breaking the lock. */
-const ACQUIRE_TIMEOUT_MS = 15_000;
+/**
+ * How long to wait before giving up. Deliberately longer than STALE_AFTER_MS so
+ * that an abandoned lock is always broken by the staleness check first: a waiter
+ * must never delete the lock of a holder that is alive and making progress,
+ * because that would put two processes on the same rotating refresh token — the
+ * exact thing this lock exists to prevent.
+ */
+const ACQUIRE_TIMEOUT_MS = 60_000;
 
 const POLL_INTERVAL_MS = 25;
 
 interface LockContents {
   pid: number;
   acquiredAt: number;
+  /** Distinguishes this acquisition from any other, including same-pid retries. */
+  owner: string;
 }
 
 export function getRefreshLockPath(): string {
@@ -66,26 +79,34 @@ async function isBreakable(path: string): Promise<boolean> {
   return !processAlive(contents.pid);
 }
 
-async function acquire(path: string): Promise<void> {
+export interface RefreshLockOptions {
+  /** Override how long to wait for another holder. Intended for tests. */
+  timeoutMs?: number;
+}
+
+/** Acquire the lock, returning the owner token that proves this acquisition. */
+async function acquire(path: string, timeoutMs: number): Promise<string> {
   await mkdir(getConfigDir(), { recursive: true, mode: 0o700 });
 
-  const deadline = Date.now() + ACQUIRE_TIMEOUT_MS;
+  const deadline = Date.now() + timeoutMs;
   const stagingPath = `${path}.${process.pid}.${randomBytes(4).toString('hex')}`;
 
   while (true) {
+    const owner = randomBytes(8).toString('hex');
+
     // Stage the full contents first, then link it into place. `link` fails when
     // the target exists, which makes acquisition atomic, and the lock file is
     // never observable in a half-written state — a competitor that read an
     // empty lock file would mistake a live holder for a crashed one.
     await writeFile(
       stagingPath,
-      JSON.stringify({ pid: process.pid, acquiredAt: Date.now() }),
+      JSON.stringify({ pid: process.pid, acquiredAt: Date.now(), owner }),
       { mode: 0o600 },
     );
 
     try {
       await link(stagingPath, path);
-      return;
+      return owner;
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== 'EEXIST') {
         throw error;
@@ -100,14 +121,34 @@ async function acquire(path: string): Promise<void> {
     }
 
     if (Date.now() > deadline) {
-      // The holder is alive but stuck. Breaking in is better than failing every
-      // command from here on; the holder's own write is atomic either way.
-      await unlink(path).catch(() => {});
-      continue;
+      // The holder is alive and still working: a lock this young cannot be
+      // abandoned, since STALE_AFTER_MS would have broken it first. Failing is
+      // the safe outcome — deleting a live holder's lock would put two
+      // processes on the same rotating refresh token.
+      throw new Error(
+        `Timed out after ${Math.round(
+          timeoutMs / 1000,
+        )}s waiting for another mux process to finish refreshing credentials. If no other mux command is running, delete ${path} and try again.`,
+      );
     }
 
     await Bun.sleep(POLL_INTERVAL_MS);
   }
+}
+
+/** Release only if this acquisition still owns the lock. */
+async function release(path: string, owner: string): Promise<void> {
+  try {
+    const contents = JSON.parse(await readFile(path, 'utf-8')) as LockContents;
+    // Someone else's lock: ours was already broken as stale, and unlinking now
+    // would cascade the problem onto whoever holds it.
+    if (contents.owner !== owner) return;
+  } catch {
+    // Missing or unreadable: nothing of ours to release.
+    return;
+  }
+
+  await unlink(path).catch(() => {});
 }
 
 /**
@@ -116,13 +157,14 @@ async function acquire(path: string): Promise<void> {
  */
 export async function withRefreshLock<T>(
   critical: () => Promise<T>,
+  options: RefreshLockOptions = {},
 ): Promise<T> {
   const path = getRefreshLockPath();
-  await acquire(path);
+  const owner = await acquire(path, options.timeoutMs ?? ACQUIRE_TIMEOUT_MS);
 
   try {
     return await critical();
   } finally {
-    await unlink(path).catch(() => {});
+    await release(path, owner);
   }
 }

--- a/src/lib/signing.ts
+++ b/src/lib/signing.ts
@@ -24,7 +24,12 @@ export function hasSigningKeys(credentials: SigningCredentials): boolean {
 export async function signPlaybackId(
   playbackId: string,
   credentials: SigningCredentials,
-  apiCredentials: { tokenId: string; tokenSecret: string },
+  /**
+   * Optional. Signing is a local operation — the JWT is minted from the signing
+   * key pair without calling the API — so no API credential is required. OAuth
+   * logins have no token pair to pass.
+   */
+  apiCredentials: { tokenId?: string; tokenSecret?: string } | undefined,
   options: SigningOptions = {},
 ): Promise<string> {
   if (!hasSigningKeys(credentials)) {
@@ -35,9 +40,12 @@ export async function signPlaybackId(
     );
   }
 
+  // Explicit nulls rather than undefined: an undefined field lets the SDK read
+  // its own environment variables, and this client exists only to mint a JWT.
   const mux = new Mux({
-    tokenId: apiCredentials.tokenId,
-    tokenSecret: apiCredentials.tokenSecret,
+    tokenId: apiCredentials?.tokenId ?? null,
+    tokenSecret: apiCredentials?.tokenSecret ?? null,
+    authorizationToken: null,
   });
 
   // The SDK types params as Record<string, string> but the JWT serializer

--- a/src/lib/token-refresh.test.ts
+++ b/src/lib/token-refresh.test.ts
@@ -1,0 +1,331 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type Mock,
+  spyOn,
+} from 'bun:test';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  getEnvironment,
+  type OAuthCredentials,
+  setCredential,
+} from './config.ts';
+import { OAuthError } from './oauth.ts';
+import {
+  ensureFreshAccessToken,
+  isAccessTokenExpiring,
+  REFRESH_SKEW_SECONDS,
+  refreshEnvironmentTokens,
+} from './token-refresh.ts';
+
+let testConfigDir: string;
+let originalXdgConfigHome: string | undefined;
+let originalXdgCacheHome: string | undefined;
+let savedOAuthEnv: Record<string, string | undefined>;
+let fetchSpy: Mock<typeof fetch> | undefined;
+
+const OAUTH_ENV_KEYS = ['MUX_OAUTH_CLIENT_ID', 'MUX_OAUTH_TOKEN_URL'] as const;
+
+const NAME = 'acme-production';
+
+function nowSeconds(): number {
+  return Math.floor(Date.now() / 1000);
+}
+
+function credential(
+  overrides: Partial<OAuthCredentials> = {},
+): OAuthCredentials {
+  return {
+    accessToken: 'access_1',
+    refreshToken: 'refresh_1',
+    expiresAt: nowSeconds() + 3600,
+    tokenType: 'Bearer',
+    ...overrides,
+  };
+}
+
+/**
+ * Mock the token endpoint. Discovery requests 404 so endpoint resolution falls
+ * back to the configured defaults, leaving `tokenCalls()` measuring exactly the
+ * grant requests that refresh coalescing is about.
+ */
+function mockTokenEndpoint(body: unknown, status = 200) {
+  fetchSpy = spyOn(globalThis, 'fetch').mockImplementation((async (
+    input: string,
+  ) => {
+    if (String(input).includes('/.well-known/')) {
+      return new Response('not found', { status: 404 });
+    }
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as unknown as typeof fetch);
+  return fetchSpy;
+}
+
+/** How many token-endpoint requests were made (discovery excluded). */
+function tokenCalls(): number {
+  return (fetchSpy?.mock.calls ?? []).filter(
+    (call) => !String(call[0]).includes('/.well-known/'),
+  ).length;
+}
+
+beforeEach(async () => {
+  testConfigDir = await mkdtemp(join(tmpdir(), 'mux-cli-refresh-test-'));
+  originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
+  process.env.XDG_CONFIG_HOME = testConfigDir;
+  // Isolate the discovery cache too, or these tests would read and write the
+  // real one in ~/.cache/mux and leak state between runs.
+  originalXdgCacheHome = process.env.XDG_CACHE_HOME;
+  process.env.XDG_CACHE_HOME = testConfigDir;
+
+  savedOAuthEnv = {};
+  for (const key of OAUTH_ENV_KEYS) {
+    savedOAuthEnv[key] = process.env[key];
+  }
+  process.env.MUX_OAUTH_CLIENT_ID = 'test_client';
+  process.env.MUX_OAUTH_TOKEN_URL = 'https://api.test/oauth/token';
+});
+
+afterEach(async () => {
+  if (originalXdgConfigHome === undefined) {
+    delete process.env.XDG_CONFIG_HOME;
+  } else {
+    process.env.XDG_CONFIG_HOME = originalXdgConfigHome;
+  }
+  if (originalXdgCacheHome === undefined) {
+    delete process.env.XDG_CACHE_HOME;
+  } else {
+    process.env.XDG_CACHE_HOME = originalXdgCacheHome;
+  }
+  for (const key of OAUTH_ENV_KEYS) {
+    if (savedOAuthEnv[key] === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = savedOAuthEnv[key];
+    }
+  }
+  fetchSpy?.mockRestore();
+  fetchSpy = undefined;
+  await rm(testConfigDir, { recursive: true, force: true });
+});
+
+describe('isAccessTokenExpiring', () => {
+  it('is false for a token valid well beyond the skew window', () => {
+    expect(isAccessTokenExpiring(credential())).toBe(false);
+  });
+
+  it('is true inside the skew window, before actual expiry', () => {
+    expect(
+      isAccessTokenExpiring(
+        credential({ expiresAt: nowSeconds() + REFRESH_SKEW_SECONDS - 10 }),
+      ),
+    ).toBe(true);
+  });
+
+  it('is true for an already expired token', () => {
+    expect(
+      isAccessTokenExpiring(credential({ expiresAt: nowSeconds() - 60 })),
+    ).toBe(true);
+  });
+
+  it('is true when expiry is unknown', () => {
+    expect(
+      isAccessTokenExpiring(
+        credential({ expiresAt: undefined as unknown as number }),
+      ),
+    ).toBe(true);
+  });
+});
+
+describe('ensureFreshAccessToken', () => {
+  it('returns the stored credential untouched when the token is fresh', async () => {
+    const oauth = credential();
+    await setCredential(NAME, 'oauth', oauth);
+    const spy = mockTokenEndpoint({});
+
+    expect((await ensureFreshAccessToken(NAME, oauth)).accessToken).toBe(
+      'access_1',
+    );
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('refreshes and persists when the token is inside the skew window', async () => {
+    const oauth = credential({ expiresAt: nowSeconds() + 30 });
+    await setCredential(NAME, 'oauth', oauth);
+    mockTokenEndpoint({
+      access_token: 'access_2',
+      refresh_token: 'refresh_2',
+      expires_in: 3600,
+    });
+
+    const result = await ensureFreshAccessToken(NAME, oauth);
+
+    expect(result.accessToken).toBe('access_2');
+    expect(result.refreshToken).toBe('refresh_2');
+
+    const stored = await getEnvironment(NAME);
+    expect(stored?.oauth?.accessToken).toBe('access_2');
+    expect(stored?.oauth?.refreshToken).toBe('refresh_2');
+    expect(stored?.oauth?.expiresAt).toBeGreaterThan(nowSeconds() + 3000);
+  });
+
+  it('preserves environment-bound state and a token pair across a refresh', async () => {
+    const oauth = credential({ expiresAt: nowSeconds() + 10 });
+    await setCredential(
+      NAME,
+      'token',
+      { tokenId: 'id_1', tokenSecret: 'secret_1' },
+      {
+        environmentId: 'env_123',
+        organizationName: 'Acme Inc',
+        signingKeyId: 'key_1',
+        signingPrivateKey: 'private_1',
+        forwardUrl: 'http://localhost:3000/webhooks',
+        baseUrl: 'https://api.staging.test',
+      },
+    );
+    await setCredential(NAME, 'oauth', oauth);
+    mockTokenEndpoint({ access_token: 'access_2', expires_in: 3600 });
+
+    await ensureFreshAccessToken(NAME, oauth);
+
+    const stored = await getEnvironment(NAME);
+    expect(stored?.signingKeyId).toBe('key_1');
+    expect(stored?.signingPrivateKey).toBe('private_1');
+    expect(stored?.forwardUrl).toBe('http://localhost:3000/webhooks');
+    expect(stored?.baseUrl).toBe('https://api.staging.test');
+    expect(stored?.environmentId).toBe('env_123');
+    expect(stored?.organizationName).toBe('Acme Inc');
+    // A refresh must not disturb the other way into this environment.
+    expect(stored?.token).toEqual({ tokenId: 'id_1', tokenSecret: 'secret_1' });
+  });
+
+  it('performs a single refresh for concurrent callers', async () => {
+    const oauth = credential({ expiresAt: nowSeconds() + 30 });
+    await setCredential(NAME, 'oauth', oauth);
+    mockTokenEndpoint({
+      access_token: 'access_2',
+      refresh_token: 'refresh_2',
+      expires_in: 3600,
+    });
+
+    const results = await Promise.all([
+      ensureFreshAccessToken(NAME, oauth),
+      ensureFreshAccessToken(NAME, oauth),
+      ensureFreshAccessToken(NAME, oauth),
+    ]);
+
+    // The lock holder refreshes; the others re-read the config and find the
+    // fresh token, so the refresh token is never spent twice.
+    expect(tokenCalls()).toBe(1);
+    for (const result of results) {
+      expect(result.accessToken).toBe('access_2');
+    }
+  });
+
+  it('clears a previous failure flag after a successful refresh', async () => {
+    const oauth = credential({
+      expiresAt: nowSeconds() - 10,
+      lastError: { code: 'invalid_grant', at: 'earlier' },
+    });
+    await setCredential(NAME, 'oauth', oauth);
+    mockTokenEndpoint({ access_token: 'access_2', expires_in: 3600 });
+
+    await ensureFreshAccessToken(NAME, oauth);
+
+    expect((await getEnvironment(NAME))?.oauth?.lastError).toBeUndefined();
+  });
+
+  describe('terminal failure', () => {
+    beforeEach(async () => {
+      await setCredential(NAME, 'oauth', credential({ expiresAt: 1 }));
+      mockTokenEndpoint({ error: 'invalid_grant' }, 400);
+    });
+
+    it('reports the environment name and the recovery step', async () => {
+      const error = await ensureFreshAccessToken(
+        NAME,
+        credential({ expiresAt: 1 }),
+      )
+        .then(() => null)
+        .catch((e: Error) => e);
+
+      expect(error?.message).toContain(NAME);
+      expect(error?.message).toContain('mux login');
+    });
+
+    it('flags the credential without deleting it', async () => {
+      await ensureFreshAccessToken(NAME, credential({ expiresAt: 1 })).catch(
+        () => undefined,
+      );
+
+      const stored = await getEnvironment(NAME);
+      expect(stored?.oauth?.lastError?.code).toBe('invalid_grant');
+      expect(stored?.oauth?.lastError?.at).toBeTruthy();
+      // The credential stays put: removing it is the user's call.
+      expect(stored?.oauth?.refreshToken).toBe('refresh_1');
+    });
+
+    it('leaves an access token pair on the same environment usable', async () => {
+      await setCredential(NAME, 'token', {
+        tokenId: 'id_1',
+        tokenSecret: 'secret_1',
+      });
+
+      await ensureFreshAccessToken(NAME, credential({ expiresAt: 1 })).catch(
+        () => undefined,
+      );
+
+      const stored = await getEnvironment(NAME);
+      expect(stored?.token).toEqual({
+        tokenId: 'id_1',
+        tokenSecret: 'secret_1',
+      });
+      expect(stored?.token?.lastError).toBeUndefined();
+    });
+  });
+
+  it('does not flag or suggest re-login when refresh fails for network reasons', async () => {
+    const oauth = credential({ expiresAt: nowSeconds() - 10 });
+    await setCredential(NAME, 'oauth', oauth);
+    fetchSpy = spyOn(globalThis, 'fetch').mockImplementation((async () => {
+      throw new TypeError('fetch failed');
+    }) as unknown as typeof fetch);
+
+    const error = await ensureFreshAccessToken(NAME, oauth)
+      .then(() => null)
+      .catch((e: Error) => e);
+
+    expect(error?.message).not.toContain('mux login');
+    expect(error).toBeInstanceOf(OAuthError);
+    expect((error as OAuthError).terminal).toBe(false);
+    // A flaky connection is not evidence the credential is dead.
+    expect((await getEnvironment(NAME))?.oauth?.lastError).toBeUndefined();
+  });
+});
+
+describe('refreshEnvironmentTokens', () => {
+  it('refreshes regardless of expiry, for the post-401 retry path', async () => {
+    const oauth = credential({ expiresAt: nowSeconds() + 3600 });
+    await setCredential(NAME, 'oauth', oauth);
+    mockTokenEndpoint({
+      access_token: 'access_forced',
+      expires_in: 3600,
+    });
+
+    const result = await refreshEnvironmentTokens(NAME, oauth);
+
+    expect(tokenCalls()).toBe(1);
+    expect(result.accessToken).toBe('access_forced');
+    expect((await getEnvironment(NAME))?.oauth?.accessToken).toBe(
+      'access_forced',
+    );
+  });
+});

--- a/src/lib/token-refresh.test.ts
+++ b/src/lib/token-refresh.test.ts
@@ -312,6 +312,55 @@ describe('ensureFreshAccessToken', () => {
 });
 
 describe('refreshEnvironmentTokens', () => {
+  it('adopts a token another caller already refreshed instead of spending again', async () => {
+    // The 401 came from `stale`, but the config already holds a replacement:
+    // spending the refresh token again would rotate for nothing.
+    await setCredential(
+      NAME,
+      'oauth',
+      credential({ accessToken: 'access_new' }),
+    );
+    mockTokenEndpoint({ access_token: 'should_not_be_used', expires_in: 3600 });
+
+    const result = await refreshEnvironmentTokens(
+      NAME,
+      credential({ accessToken: 'stale' }),
+    );
+
+    expect(result.accessToken).toBe('access_new');
+    expect(tokenCalls()).toBe(0);
+  });
+
+  it('still refreshes when the stored token is the one that failed', async () => {
+    await setCredential(NAME, 'oauth', credential({ accessToken: 'same' }));
+    mockTokenEndpoint({ access_token: 'access_forced', expires_in: 3600 });
+
+    const result = await refreshEnvironmentTokens(
+      NAME,
+      credential({ accessToken: 'same' }),
+    );
+
+    expect(result.accessToken).toBe('access_forced');
+    expect(tokenCalls()).toBe(1);
+  });
+
+  it('refreshes when the stored replacement is itself expiring', async () => {
+    await setCredential(
+      NAME,
+      'oauth',
+      credential({ accessToken: 'access_new', expiresAt: 1 }),
+    );
+    mockTokenEndpoint({ access_token: 'access_forced', expires_in: 3600 });
+
+    const result = await refreshEnvironmentTokens(
+      NAME,
+      credential({ accessToken: 'stale' }),
+    );
+
+    expect(result.accessToken).toBe('access_forced');
+    expect(tokenCalls()).toBe(1);
+  });
+
   it('refreshes regardless of expiry, for the post-401 retry path', async () => {
     const oauth = credential({ expiresAt: nowSeconds() + 3600 });
     await setCredential(NAME, 'oauth', oauth);

--- a/src/lib/token-refresh.test.ts
+++ b/src/lib/token-refresh.test.ts
@@ -188,7 +188,7 @@ describe('ensureFreshAccessToken', () => {
         signingKeyId: 'key_1',
         signingPrivateKey: 'private_1',
         forwardUrl: 'http://localhost:3000/webhooks',
-        baseUrl: 'https://api.staging.test',
+        baseUrl: 'https://api.custom.test',
       },
     );
     await setCredential(NAME, 'oauth', oauth);
@@ -200,7 +200,7 @@ describe('ensureFreshAccessToken', () => {
     expect(stored?.signingKeyId).toBe('key_1');
     expect(stored?.signingPrivateKey).toBe('private_1');
     expect(stored?.forwardUrl).toBe('http://localhost:3000/webhooks');
-    expect(stored?.baseUrl).toBe('https://api.staging.test');
+    expect(stored?.baseUrl).toBe('https://api.custom.test');
     expect(stored?.environmentId).toBe('env_123');
     expect(stored?.organizationName).toBe('Acme Inc');
     // A refresh must not disturb the other way into this environment.

--- a/src/lib/token-refresh.ts
+++ b/src/lib/token-refresh.ts
@@ -100,6 +100,20 @@ export async function refreshEnvironmentTokens(
 ): Promise<OAuthCredentials> {
   return withRefreshLock(async () => {
     const stored = await readStoredOAuth(name);
+
+    // Another process (or another in-flight request) may have refreshed while
+    // this one waited for the lock. A stored token that differs from the one
+    // that just got a 401 is that replacement — use it rather than spending the
+    // refresh token again, which under a burst of 401s would rotate N times for
+    // no benefit.
+    if (
+      stored &&
+      stored.accessToken !== oauth.accessToken &&
+      !isAccessTokenExpiring(stored)
+    ) {
+      return stored;
+    }
+
     return refreshAndPersist(name, stored ?? oauth);
   });
 }

--- a/src/lib/token-refresh.ts
+++ b/src/lib/token-refresh.ts
@@ -1,0 +1,130 @@
+import {
+  flagCredential,
+  getEnvironment,
+  type OAuthCredentials,
+  setCredential,
+} from './config.ts';
+import { OAuthError, refreshAccessToken } from './oauth.ts';
+import { withRefreshLock } from './refresh-lock.ts';
+
+/**
+ * Access token refresh for stored OAuth logins.
+ *
+ * Refresh is invisible to commands: it happens inside credential resolution, so
+ * no command needs to know an access token has a lifetime.
+ */
+
+/**
+ * Refresh this far ahead of expiry. Covers clock drift between the CLI host and
+ * the authorization server, plus the round-trip of the request about to be made.
+ */
+export const REFRESH_SKEW_SECONDS = 120;
+
+function nowSeconds(): number {
+  return Math.floor(Date.now() / 1000);
+}
+
+/**
+ * Whether the stored access token should be refreshed before use. An unknown
+ * expiry counts as expiring: better one unnecessary refresh than a request that
+ * fails on a stale token.
+ */
+export function isAccessTokenExpiring(
+  oauth: OAuthCredentials,
+  skewSeconds = REFRESH_SKEW_SECONDS,
+): boolean {
+  if (!oauth.expiresAt) return true;
+  return oauth.expiresAt - nowSeconds() <= skewSeconds;
+}
+
+/**
+ * Refresh and persist, mapping a dead refresh token onto actionable guidance.
+ * Retryable failures (network, 5xx) propagate unchanged so callers do not tell
+ * the user to log in again over a flaky connection.
+ */
+async function refreshAndPersist(
+  name: string,
+  oauth: OAuthCredentials,
+): Promise<OAuthCredentials> {
+  let tokens: Awaited<ReturnType<typeof refreshAccessToken>>;
+  try {
+    tokens = await refreshAccessToken(oauth.refreshToken);
+  } catch (error) {
+    if (error instanceof OAuthError && error.terminal) {
+      // Flag rather than delete: the credential stays for the user to inspect,
+      // `mux auth status` can explain it, and an access token pair on the same
+      // environment becomes the preferred credential from here on.
+      await flagCredential(name, 'oauth', {
+        code: error.code ?? 'refresh_failed',
+        at: new Date().toISOString(),
+        message: error.message,
+      });
+      throw new Error(
+        `The stored login for environment "${name}" is no longer valid (${
+          error.code ?? 'refresh failed'
+        }). Run 'mux login' to sign in again, or 'mux env switch <name>' to use a different environment.`,
+      );
+    }
+    throw error;
+  }
+
+  const refreshed: OAuthCredentials = {
+    accessToken: tokens.accessToken,
+    refreshToken: tokens.refreshToken,
+    expiresAt: tokens.expiresAt,
+    tokenType: tokens.tokenType,
+    ...(tokens.scope && { scope: tokens.scope }),
+    // No lastError: a successful refresh clears any previous failure.
+  };
+
+  // Writes only the oauth block, so signing keys, forward URL, the token pair,
+  // and the org/environment identity all survive untouched.
+  await setCredential(name, 'oauth', refreshed);
+
+  return refreshed;
+}
+
+/** The stored OAuth block for an environment, or null if it has none. */
+async function readStoredOAuth(name: string): Promise<OAuthCredentials | null> {
+  const stored = await getEnvironment(name);
+  return stored?.oauth ?? null;
+}
+
+/**
+ * Force a refresh regardless of the stored expiry. Used after a 401, where the
+ * server has invalidated a token the CLI still considers fresh.
+ */
+export async function refreshEnvironmentTokens(
+  name: string,
+  oauth: OAuthCredentials,
+): Promise<OAuthCredentials> {
+  return withRefreshLock(async () => {
+    const stored = await readStoredOAuth(name);
+    return refreshAndPersist(name, stored ?? oauth);
+  });
+}
+
+/**
+ * Return credentials good for the request about to be made, refreshing first if
+ * the access token is at or near expiry.
+ */
+export async function ensureFreshAccessToken(
+  name: string,
+  oauth: OAuthCredentials,
+): Promise<OAuthCredentials> {
+  if (!isAccessTokenExpiring(oauth)) {
+    return oauth;
+  }
+
+  return withRefreshLock(async () => {
+    // Re-read under the lock: another process may have refreshed while this one
+    // waited, in which case its token is already on disk and spending our
+    // refresh token again would invalidate theirs.
+    const stored = await readStoredOAuth(name);
+    if (stored && !isAccessTokenExpiring(stored)) {
+      return stored;
+    }
+
+    return refreshAndPersist(name, stored ?? oauth);
+  });
+}


### PR DESCRIPTION
## Description

`mux login` now opens the browser by default to kick off the OAuth flow. You pick an organization and environment in the Mux Dashboard, the CLI catches the redirect on a loopback port, exchanges the code for tokens, and handles refresh from then on. Mux API access tokens keep working exactly as before.

The four ways to authenticate are now explicit and mutually exclusive: `--oauth` (default), `--interactive`, `--env-file`, `--from-env`.

## Breaking changes

Read these before approving. The first two are deliberate; the third is a consequence of the config format.

1. **`mux login` errors when `MUX_TOKEN_ID`/`MUX_TOKEN_SECRET` are set.** It used to save them silently. Since env vars always outrank the config, that produced an entry that did nothing until you unset them. It now prints the four explicit options and exits 1 without writing. CI that runs `mux login` with injected credentials needs `--from-env`.
3. **`mux login` with no flags opens a browser** instead of prompting for a Token ID and Secret. Anything scripted against those prompts needs `--interactive`.
5. **Configs written by 3.x can't be read by 2.x.** Credentials moved into nested `oauth` / `token` blocks. Reading old flat entries works fine and needs no migration, but not the reverse — and note that *any* write converts every entry, including ones the command didn't touch. A downgrade means re-running `mux login`. Nothing is lost: the credentials are still in `config.json`, just nested one level deeper. Worth saying explicitly in the release notes, since Mux only shows an access token secret once at creation and people may otherwise mint a replacement.
7. `--oauth` and `--interactive` require a TTY. They fail immediately under `--json`, in agent mode, or with piped stdin rather than hanging.
9. `mux env list` and `mux auth status` output changed shape, so text parsing of them breaks. Both have `--json`.
11. `mux logout` now makes a network call to revoke refresh tokens. Failure prints a warning and still removes the local credentials.
12. The env-var shadow notice on stderr now names the shadowed environment.

`mux login --json` output and its `source` values are unchanged.

## What's new

- `mux auth status` — every credential source, which is active, and why. No network calls, never prints token material.
- `mux logout --all`, and revocation on logout.
- `mux env switch` with no argument gives an interactive picker; `--json` on `env list`, `env switch`, and `logout`.
- An environment can hold **both** an OAuth login and an access token pair. OAuth is preferred when present — it goes stale unless exercised and refreshed, so the CLI won't quietly live on the token pair.
- Automatic refresh: proactively before expiry, and once on an unexpected 401. Concurrent `mux` processes coordinate through a lock file so a rotating refresh token is never spent twice. `webhooks listen` refreshes and reconnects instead of dying mid-stream.
- A terminally failed credential is **flagged, not deleted**: `mux auth status` explains it, and a token pair on the same environment silently takes over.


### Read these six, in this order

1. **`src/lib/credentials.ts`** (236) — start here. The credential model: what an environment holds, how the two historical config layouts are normalized on read, and `getPreferredCredential`, which decides OAuth-vs-token including the fallback when a credential is flagged as failing. Everything else assumes this.
2. **`src/lib/mux.ts`** (+264) — the choke point. `resolveCredentials()` returns a discriminated `ResolvedCredentials`, which is why `Bearer` vs `Basic` needed no changes in ~98 command files. Also where the SDK client is built, and where the pre-existing `MUX_AUTHORIZATION_TOKEN` footgun is defused.
3. **`src/lib/token-refresh.ts` + `src/lib/refresh-lock.ts`** (130 + 170) — the riskiest code in the PR. Proactive refresh, the re-read under lock that stops two processes spending one rotating refresh token, and flag-don't-delete on terminal failure. The lock deliberately fails rather than breaking a live holder's lock; that tradeoff is the thing to argue with.
4. **`src/lib/oauth-loopback.ts`** (299) — the security surface. Binds 127.0.0.1 only, one path, one accepted callback, constant-time `state` compare, forced close. If you're only going to scrutinize one file for safety, this is it.
5. **`src/lib/oauth.ts`** (503) — endpoint resolution (env override → discovery → built-in) the three grant calls, scope policy, and error normalization. The top ~90 lines are configuration and comments explaining *why* each default is what it is.
6. **`src/commands/login-mode.ts`** (88) — pure function, no I/O, and it encodes the breaking behavior: four mutually exclusive methods, and the error when shell credentials are set. Quickest way to review the UX contract.

## Worth a reviewer's attention

**The SDK already supported bearer auth.** `@mux/mux-node` has an `authorizationToken` option, so no custom client was needed. It also revealed a pre-existing bug: that option defaults to `process.env.MUX_AUTHORIZATION_TOKEN`, and the SDK builds the bearer header *after* the Basic one, so a stray variable in someone's shell would silently override Basic auth. We now pass `null` explicitly for whichever credential kind isn't in use.

**Endpoints derive from one base, and are discoverable.** All three live on the API host (`/ui/v1/oauth/authorize` for the browser leg, `/auth/v1/oauth/{token,revoke}` for the back channel), so `MUX_BASE_URL` moves the API calls, discovery, and the sign-in flow together — the token endpoint can't end up on a different host than the authorize endpoint. On top of that, RFC 8414 / OIDC discovery is consulted on login and refresh (cached a day) so Mux can move endpoints without stranding installed binaries. Discovery is never load-bearing: any failure falls back to the built-ins. Discovered endpoints are validated to be `https:` on a `.mux.com` host (dot-boundary matched, so `mux.com.evil.test` fails) or the document's own origin, because a document that can repoint `token_endpoint` could otherwise collect authorization codes.

**Scopes are hardcoded deliberately.** `video/data/robots/system` read+write — the union of what the commands need. Not taken from the server's `scopes_supported`, which would mean silently requesting any scope Mux adds later. No `openid`/`profile`/`email`: no `id_token` is requested or consumed, and identity comes from `/system/v1/whoami`, which reports what the access token can actually do. That also keeps JWKS out of the client.

**The 401 retry is one function, not 98 changes.** It's the SDK's `fetch` implementation, so every command inherits refresh-and-retry.

**Refresh is lock-guarded.** Acquisition uses `link()` of a fully-written temp file — an `open('wx')` lock is briefly empty, and a competitor reading that mistakes a live holder for a crashed one. A waiter never breaks a live holder's lock, and release is ownership-checked.

## Testing

1200 tests pass, up from 1014 on `main`. Beyond unit coverage, the flows were driven against real staging and a local fake authorization server, and verified on the wire:

- `Bearer` for OAuth vs `Basic` for token pairs on the same command
- a 401 producing refresh → retry → rotated token persisted, with the user seeing only normal output
- a flagged OAuth credential falling back to `Basic` on the same environment
- a server that moved its token endpoint being followed via discovery rather than the compiled-in default
- the callback page rendering from a compiled binary, which has no filesystem to read the HTML from

No secrets in the diff: scanned the commits, working tree, and untracked files for `sk-ant-`, `eyJ`, private key blocks, `client_secret`, and the staging client ID. The only high-entropy strings are the RFC 7636 Appendix B PKCE test vectors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication defaults, credential storage format, and token refresh/concurrency; includes breaking `mux login` behavior when env vars are set and config layout incompatible with 2.x after write.
> 
> **Overview**
> **Browser OAuth is now the default for `mux login`**, with loopback callback, token refresh (proactive + one 401 retry via SDK `fetch`), and agent/`--json` flows that emit the authorization URL on stderr. API access tokens remain via `--interactive`, `--env-file`, or new **`--from-env`**; when `MUX_TOKEN_ID`/`MUX_TOKEN_SECRET` are set, bare `mux login` **refuses to guess** and exits without writing config.
> 
> **Stored credentials move to nested `oauth` / `token` blocks** (legacy flat entries normalize on read). One environment can hold both kinds; **OAuth is preferred**, with flag-on-failure fallback to the token pair. Config writes are **atomic**; login **updates entries in place** so default environment and signing keys are not lost on re-login.
> 
> New **`mux auth status`** (and `mux auth login`/`logout` aliases) reports every source, shadowing by env vars, and credential health without printing secrets. **`mux env list` / `mux env switch`** gain richer output, `--json`, and an interactive switcher; **`mux logout`** adds **`--all`**, refresh-token revocation, and JSON. Long-running **`webhooks listen`** refreshes OAuth and reconnects on 401. **Asset signing** no longer requires API token pairs when only signing keys are needed.
> 
> README documents the full auth model, upgrade notes, and breaking CI/TTY/parsing behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddac170540db4b3753fe139f9e6c72390d8c5b90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->